### PR TITLE
fix apt related checks

### DIFF
--- a/soperator/modules/active_checks/templates/install_package.yaml.tftpl
+++ b/soperator/modules/active_checks/templates/install_package.yaml.tftpl
@@ -18,7 +18,8 @@ resources:
               echo "Installing libcudnn8"
               ssh -i /mnt/jail/opt/soperatorchecks/.ssh/soperatorchecks_id_ecdsa \
                   -o StrictHostKeyChecking=no \
-                  soperatorchecks@login-0.soperator-login-svc.soperator.svc 'sudo apt -o DPkg::Lock::Timeout=-1 update && sudo apt install -o DPkg::Lock::Timeout=-1 -y libcudnn8'
+                  soperatorchecks@login-0.soperator-login-svc.soperator.svc \
+                  "flock /var/lock/apt.lock bash -c 'sudo apt update && sudo apt install -y libcudnn8'"
           image: cr.eu-north1.nebius.cloud/soperator/k8s_check_job:1.20.0-jammy-slurm24.05.7
           volumes:
           - name: jail

--- a/soperator/modules/active_checks/templates/upgrade_cuda.yaml.tftpl
+++ b/soperator/modules/active_checks/templates/upgrade_cuda.yaml.tftpl
@@ -18,7 +18,7 @@ resources:
               echo "Upgrading cuda"
               ssh -i /mnt/jail/opt/soperatorchecks/.ssh/soperatorchecks_id_ecdsa \
                   -o StrictHostKeyChecking=no \
-                  soperatorchecks@login-0.soperator-login-svc.soperator.svc << 'EOF'
+                  soperatorchecks@login-0.soperator-login-svc.soperator.svc "flock /var/lock/apt.lock bash -s" << 'EOF'
 
               # Patterns of packages to process
               TARGET_PATTERNS=(
@@ -33,17 +33,17 @@ resources:
                 for pkg in $pkgs; do
                   if apt-mark showhold | grep -q "^$pkg$"; then
                     echo "Unholding $pkg"
-                    sudo apt-mark unhold -o DPkg::Lock::Timeout=-1 "$pkg"
+                    sudo apt-mark unhold "$pkg"
                   fi
                 done
               done
 
               echo "Removing existing CUDA installation..."
-              sudo apt remove -o DPkg::Lock::Timeout=-1 -y cuda || true
+              sudo apt remove -y cuda || true
 
               echo "Installing CUDA version ${cuda_version}..."
-              sudo apt -o DPkg::Lock::Timeout=-1 update
-              sudo apt install -o DPkg::Lock::Timeout=-1 -y "cuda=${cuda_version}"
+              sudo apt update
+              sudo apt install -y "cuda=${cuda_version}"
 
               sudo apt clean
               sudo apt autoremove -y
@@ -54,7 +54,7 @@ resources:
                 for pkg in $pkgs; do
                   if dpkg -s "$pkg" &>/dev/null; then
                     echo "Holding $pkg"
-                    sudo apt-mark hold -o DPkg::Lock::Timeout=-1 "$pkg"
+                    sudo apt-mark hold "$pkg"
                   fi
                 done
               done

--- a/soperator/modules/active_checks/variables.tf
+++ b/soperator/modules/active_checks/variables.tf
@@ -43,27 +43,7 @@ variable "checks" {
 
     ssh_check_enabled = true
     install_package_check_enabled = true
-    upgrade_cuda_enabled = true
+    upgrade_cuda_enabled = false
     cuda_version = "12.4.1-1"
-  }
-
-  validation {
-    condition = !var.checks.create_soperatorchecks_user || var.checks.create_nebius_user
-    error_message = "Create nebius user check could not be performed without soperatorchecks user creation."
-  }
-
-  validation {
-    condition = !var.checks.create_soperatorchecks_user || var.checks.ssh_check_enabled
-    error_message = "SSH check could not be performed without soperatorchecks user creation."
-  }
-
-  validation {
-    condition = !var.checks.create_soperatorchecks_user || var.checks.install_package_check_enabled
-    error_message = "Install package check could not be performed without soperatorchecks user creation."
-  }
-
-    validation {
-    condition = !var.checks.create_soperatorchecks_user || var.checks.upgrade_cuda_enabled
-    error_message = "Upgrade CUDA check could not be performed without soperatorchecks user creation."
   }
 }


### PR DESCRIPTION
Sometimes concurrent apt (even with dpkg lock) could lead to the issue:
```
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/Packages.gz  File has unexpected size (3254637 != 3254639). Mirror sync in progress? [IP: 91.189.91.83 80]
   Hashes of expected file:
    - Filesize:3254639 [weak]
    - SHA256:b0e2bfbe840e5e217cdb1d5cff270042f6a58671ac277a17d87f8a37c391a7e2
    - SHA1:6f5d1ef815142cd9f95fcb65e6a8c8fc48b8d4a8 [weak]
    - MD5Sum:ff6d049480375647837ecf8b8fbd3304 [weak]
   Release file created at: Thu, 22 May 2025 14:16:00 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
```