### PR TITLE
[FIX] Add buckets cleanup

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -187,6 +187,26 @@ jobs:
           --public-key-id ${{ secrets.TERRAFORM_SA_PUBLIC_KEY_ID }} \
           --parent-id ${{ env.TF_VAR_parent_id }} \
           --private-key-file /tmp/sa.pem
+    
+    - name: Setup s3cmd
+      run: |
+        pip3 install s3cmd --no-cache --quiet
+        s3cmd --configure --dump-config \
+        --access_key="${{ secrets.SA_ACCESS_KEY_ID }}" \
+        --secret_key="${{ secrets.SA_SECRET_KEY }}" \
+        --host="storage.eu-north1.nebius.cloud:443" \
+        --host-bucket="%(bucket)s.storage.eu-north1.nebius.cloud" \
+        > ~/.s3cfg
+    
+    - name: Cleanup buckets
+      run: |
+        for resource in \
+          "storage bucket" \
+        ; do
+        echo Cleaning up buckets $resource 
+        eval nebius --format json $resource list \
+          | jq -r 'try .items[] | .metadata.id' \
+          | eval xargs -r -n 1 s3cmd del --recursive s3://{}
 
     - name: Perform forced cleanup
       run: |


### PR DESCRIPTION
Due to the some leftovers in the buckets after tests or failed tests, we need to cleanup buckets first

```
Deleting all storage bucket
Error: rpc error: code = InvalidArgument desc = BucketNotEmpty: The bucket is not empty
request = 9b43f813-8dd9-4624-abc1-ab0329d3d3c6
caused by service error:
  Service storage error BucketNotEmpty
```