### PR TITLE
Disable nccl benchmark by default

### DIFF
--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -377,9 +377,9 @@ default_epilog_enabled = true
 
 # Whether to enable NCCL benchmark CronJob to benchmark GPU performance.
 # It won't take effect in case of 1-GPU hosts.
-# By default, true.
+# By default, false.
 # ---
-nccl_benchmark_enable = true
+nccl_benchmark_enable = false
 
 # NCCL benchmark's CronJob schedule.
 # By default, `0 */3 * * *` - every 3 hour.

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -789,7 +789,7 @@ variable "default_epilog_enabled" {
 variable "nccl_benchmark_enable" {
   description = "Whether to enable NCCL benchmark CronJob to benchmark GPU performance. It won't take effect in case of 1-GPU hosts."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "nccl_benchmark_schedule" {

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -315,7 +315,7 @@ variable "nccl_topology_type" {
 variable "nccl_benchmark_enable" {
   description = "Whether to enable NCCL benchmark CronJob to benchmark GPU performance. It won't take effect in case of 1-GPU hosts."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "nccl_benchmark_schedule" {


### PR DESCRIPTION
Disabling by default since introduction of ActiveChecks