### PR TITLE
Scale vmagent remote write queues based on worker count for better performance

### DIFF
--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -133,4 +133,8 @@ locals {
   }
 
   slurm_node_extra = "\\\"{ \\\\\\\"monitoring\\\\\\\": \\\\\\\"https://console.eu.nebius.com/${var.iam_project_id}/compute/instances/$INSTANCE_ID/monitoring\\\\\\\" }\\\""
+
+  # Calculate vmagent remote write queue count based on cluster size
+  # This sets metrics ingestion capacity for larger clusters properly
+  vm_agent_queue_count = 2 + floor(sum(var.node_count.worker) / 80)
 }

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -290,6 +290,8 @@ resource "helm_release" "soperator_fluxcd_cm" {
       dcgm_exporter       = local.resources.dcgm_exporter
     }
 
+    vm_agent_queue_count = local.vm_agent_queue_count
+
   })]
 }
 

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -106,7 +106,7 @@ resources:
                       memory: ${resources.vm_agent.memory}
                   %{~ if public_o11y_enabled ~}
                   remoteWriteSettings:
-                    queues: 2
+                    queues: ${vm_agent_queue_count}
                   %{~ endif ~}
               vmsingle:
                 spec:


### PR DESCRIPTION
## Summary

Implements dynamic scaling of vmagent remote write queues based on cluster worker count using formula `2 + floor(sum(worker_count) / 80)`.

## Changes

- Replace hardcoded `queues: 2` with dynamic calculation
- Small clusters (≤79 workers): 2 queues
- Large clusters (160+ workers): 4+ queues

This improves metrics ingestion performance for larger clusters.