### PR TITLE
Fixed small changes 

### DIFF
--- a/vm-instance/.envrc.sh
+++ b/vm-instance/.envrc.sh
@@ -165,7 +165,7 @@ fi
 
 
 #region
-NEBIUS_REGION=$(nebius iam project get --id "$project_id" | awk '/region:/ {print $2}')
+NEBIUS_REGION=$(nebius iam project get --id "$project_id" --format json | jq -r '.spec.region')
 
 #end region
 
@@ -311,6 +311,7 @@ else
   echo "Using existing bucket: ${NEBIUS_BUCKET_NAME}"
 fi
 
+export AWS_CONFIG_FILE="./.aws/config"
 aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
 aws configure set region $NEBIUS_REGION

--- a/vm-instance/.envrc.zsh
+++ b/vm-instance/.envrc.zsh
@@ -175,7 +175,7 @@ if [[ "$1" == "destroy" ]]; then
 fi
 
 # Region setup
-NEBIUS_REGION=$(nebius iam project get --id "$project_id" | awk '/region:/ {print $2}')
+NEBIUS_REGION=$(nebius iam project get --id "$project_id" --format json | jq -r '.spec.region')
 export NEBIUS_REGION
 
 # VPC subnet
@@ -312,6 +312,7 @@ else
   echo "Using existing bucket: ${NEBIUS_BUCKET_NAME}"
 fi
 
+export AWS_CONFIG_FILE="./.aws/config"
 aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
 aws configure set region $NEBIUS_REGION

--- a/vm-instance/terraform.tfvars
+++ b/vm-instance/terraform.tfvars
@@ -1,5 +1,5 @@
 #parent_id      = "" # The project-id in this context
-#subnet_id      = "" # Use the command "nebius vpc v1alpha1 network list" to see the subnet id
+#subnet_id      = "" # Use the command "nebius vpc v1alpha1 network list --parent-id <your_parent_id>" to see the subnet id
 
 
 #preset = "16vcpu-64gb"


### PR DESCRIPTION
--- [in `vm-instance/.envrc.sh/zsh`] ---

In line 178 the `NEBIUS_REGION` is set by `nebius iam project get --id "$project_id" | awk '/region:/ {print $2}'`. This will result in setting the region to:

```
<region>
<region>
```

rather than the intended 

```
<region>
```

This happens since the output of `nebius iam project get --id "$project_id"` has `region:` twice (in `spec:` and `status:`). This is resolved by changing it to `NEBIUS_REGION=$(nebius iam project get --id "$project_id" --format json | jq -r '.spec.region')` - taking the region only from the spec

--- [in `vm-instance/.envrc.sh/zsh`] ---

Configurations for the awscli are written to `./.aws/config`. By default the awscli expects this in `~/.aws/config` so the configuration will only be found when the code is executed from the $HOME dir, other locations will give the message: `Unable to parse config file: $HOME/.aws/config`. This is fixed by setting the configuration location with `export AWS_CONFIG_FILE="./.aws/config”`

--- [in `vm-instance/terraform.tfvars`] ---

Line 2 states: 
`# Use the command "nebius vpc v1alpha1 network list" to see the subnet id`

this will result in the following error:
```
 Bad Request BadRequest: service VPC API, violations:
    parent_id: value is required
```

Which is resolved by changing it to `#subnet_id      = "" # Use the command "nebius vpc v1alpha1 network list --parent-id <your_parent_id>" to see the subnet id`

--- [in `bastion/README.md`] ---

renames JQuery to jq for the jq tool