### PR TITLE
Add soperator-release branch support for automated releases

### DIFF
--- a/.github/workflows/soperator.yml
+++ b/.github/workflows/soperator.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
+      - soperator-release-*
     paths:
-      - "soperator/**"
-      - ".github/workflows/soperator.yml"
+      - "soperator/VERSION"
+      - "soperator/SUBVERSION"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The soperator GitHub workflow now triggers automated releases on both `main` and `soperator-release-*` branches when VERSION or SUBVERSION files are modified.

Previously, releases were only triggered on merges to `main` with any changes in the `soperator/` directory. This change enables release automation for version bumps on soperator release branches.

## Changes

- Added `soperator-release-*` branch pattern to workflow triggers
- Simplified path filtering to only trigger on VERSION/SUBVERSION file changes
- Both `main` and release branches now have consistent behavior for version-based triggering