### PR TITLE
Fix soperator release workflow to tag correct commit instead of main branch

### DIFF
--- a/.github/workflows/soperator.yml
+++ b/.github/workflows/soperator.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           tag_name: soperator-${{ env.TAG_VERSION }}
           name: Soperator Terraform recipe ${{ env.TAG_VERSION }}
+          target_commitish: ${{ github.sha }}
           draft: false
           prerelease: false
           files: |


### PR DESCRIPTION
## Summary

This PR fixes the soperator release workflow to ensure GitHub releases are created with tags pointing to the actual commit that triggered the workflow, rather than defaulting to the main branch.

## Changes

- Added `target_commitish: ${{ github.sha }}` parameter to the GitHub release action in `.github/workflows/soperator.yml`

This prevents issues where releases appear to be created from the wrong commit, ensuring the release tag accurately reflects the source code that was built and released.