### PR TITLE
Forbid clusters without jail submounts and other changes

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -4,7 +4,7 @@ locals {
     controller = module.resources.by_platform[var.slurm_nodeset_controller.resource.platform][var.slurm_nodeset_controller.resource.preset]
     workers    = [for worker in var.slurm_nodeset_workers : module.resources.by_platform[worker.resource.platform][worker.resource.preset]]
     login      = module.resources.by_platform[var.slurm_nodeset_login.resource.platform][var.slurm_nodeset_login.resource.preset]
-    accounting = var.slurm_nodeset_accounting != null ? module.resources.by_platform[var.slurm_nodeset_accounting.resource.platform][var.slurm_nodeset_accounting.resource.preset] : null
+    accounting = module.resources.by_platform[var.slurm_nodeset_accounting.resource.platform][var.slurm_nodeset_accounting.resource.preset]
   }
 
   slurm_cluster_name = "soperator"
@@ -18,7 +18,6 @@ locals {
 resource "terraform_data" "check_variables" {
   depends_on = [
     terraform_data.check_slurm_nodeset,
-    terraform_data.check_slurm_nodeset_accounting,
     terraform_data.check_nfs,
   ]
 }
@@ -45,7 +44,7 @@ module "filestore" {
     } : null
   }
 
-  accounting = var.accounting_enabled ? {
+  accounting = {
     spec = var.filestore_accounting.spec != null ? {
       disk_type            = "NETWORK_SSD"
       size_gibibytes       = var.filestore_accounting.spec.size_gibibytes
@@ -54,7 +53,7 @@ module "filestore" {
     existing = var.filestore_accounting.existing != null ? {
       id = var.filestore_accounting.existing.id
     } : null
-  } : null
+  }
 
   jail = {
     spec = var.filestore_jail.spec != null ? {
@@ -123,7 +122,6 @@ module "k8s" {
     module.filestore,
     module.nfs-server,
     module.cleanup,
-    terraform_data.check_slurm_nodeset_accounting,
     terraform_data.check_slurm_nodeset,
   ]
 
@@ -158,10 +156,7 @@ module "k8s" {
     ]
   ])
   node_group_login = var.slurm_nodeset_login
-  node_group_accounting = {
-    enabled = var.accounting_enabled
-    spec    = var.slurm_nodeset_accounting
-  }
+  node_group_accounting = var.slurm_nodeset_accounting
 
   filestores = {
     controller_spool = {
@@ -176,10 +171,10 @@ module "k8s" {
       id        = submount.id
       mount_tag = submount.mount_tag
     }]
-    accounting = var.accounting_enabled ? {
+    accounting = {
       id        = module.filestore.accounting.id
       mount_tag = module.filestore.accounting.mount_tag
-    } : null
+    }
   }
 
   node_ssh_access_users = var.k8s_cluster_node_ssh_access_users
@@ -344,14 +339,14 @@ module "slurm" {
         -module.resources.k8s_ephemeral_storage_reserve.gibibytes
       )
     }
-    accounting = var.accounting_enabled ? {
+    accounting = {
       cpu_cores        = local.resources.accounting.cpu_cores
       memory_gibibytes = floor(local.resources.accounting.memory_gibibytes)
       ephemeral_storage_gibibytes = floor(
         var.slurm_nodeset_accounting.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
         -module.resources.k8s_ephemeral_storage_reserve.gibibytes
       )
-    } : null
+    }
   }
 
   filestores = {
@@ -369,10 +364,10 @@ module "slurm" {
       device         = module.filestore.jail_submounts[submount.name].mount_tag
       mount_path     = submount.mount_path
     }]
-    accounting = var.accounting_enabled ? {
+    accounting = {
       size_gibibytes = module.filestore.accounting.size_gibibytes
       device         = module.filestore.accounting.mount_tag
-    } : null
+    }
   }
   node_local_jail_submounts = [for sm in var.node_local_jail_submounts : {
     name               = sm.name
@@ -400,7 +395,6 @@ module "slurm" {
 
   exporter_enabled    = var.slurm_exporter_enabled
   rest_enabled        = var.slurm_rest_enabled
-  accounting_enabled  = var.accounting_enabled
   backups_enabled     = local.backups_enabled
   telemetry_enabled   = var.telemetry_enabled
   public_o11y_enabled = var.public_o11y_enabled

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -59,7 +59,7 @@ filestore_jail = {
   }
 }
 
-# Additional (Optional) shared filesystems to be mounted inside jail.
+# Additional shared filesystems to be mounted inside jail.
 # If a big filesystem is needed it's better to deploy this additional storage because jails bigger than 12 TiB
 # ARE NOT BACKED UP by default.
 # ---

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -25,7 +25,12 @@ company_name = ""
 #----------------------------------------------------------------------------------------------------------------------#
 # region Storage
 
+# Whether to store the controller state on filestore or network SSD.
+controller_state_on_filestore = false
+
 # Shared filesystem to be used on controller nodes.
+# Deprecated: Starting with version 1.22, this variable isn't used, as controller state is stored on network SSD disks.
+# Remains for the backward compatibility.
 # ---
 filestore_controller_spool = {
   spec = {
@@ -262,7 +267,6 @@ slurm_nodeset_controller = {
     block_size_kibibytes = 4
   }
 }
-controller_state_on_filestore = false
 
 # Configuration of Slurm Worker node sets.
 # There can be only one Worker node set for a while.

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -120,8 +120,6 @@ node_local_image_disk = {
 }
 
 # Shared filesystem to be used for accounting DB.
-# By default, null.
-# Required if accounting_enabled is true.
 # ---
 filestore_accounting = {
   spec = {
@@ -398,20 +396,6 @@ soperator_notifier = {
 public_o11y_enabled = true
 
 # endregion Telemetry
-
-#----------------------------------------------------------------------------------------------------------------------#
-#                                                                                                                      #
-#                                                       Accounting                                                     #
-#                                                                                                                      #
-#----------------------------------------------------------------------------------------------------------------------#
-# region Accounting
-
-# Whether to enable Accounting.
-# By default, true.
-# ---
-accounting_enabled = true
-
-# endregion Accounting
 
 # endregion Slurm
 

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -177,6 +177,12 @@ locals {
   var.filestore_jail.spec.size_gibibytes)
 }
 
+variable "allow_empty_jail_submounts" {
+  description = "Flag for disabling validation for non-empty jail submounts."
+  type        = bool
+  default     = false
+}
+
 variable "filestore_jail_submounts" {
   description = "Shared filesystems to be mounted inside jail."
   type = list(object({
@@ -199,6 +205,11 @@ variable "filestore_jail_submounts" {
       (sm.existing == null && sm.spec != null)
     ]) == length(var.filestore_jail_submounts)
     error_message = "All submounts must have one of `existing` or `spec` provided."
+  }
+
+  validation {
+    condition     = var.allow_empty_jail_submounts || length(var.filestore_jail_submounts) >= 1
+    error_message = "Creating clusters without jail submounts is not allowed."
   }
 }
 

--- a/soperator/modules/available_resources/preset.tf
+++ b/soperator/modules/available_resources/preset.tf
@@ -9,8 +9,8 @@ locals {
         (module.labels.name_nodeset_system)     = false
         (module.labels.name_nodeset_controller) = true
         (module.labels.name_nodeset_worker)     = false
-        (module.labels.name_nodeset_login)      = true
-        (module.labels.name_nodeset_accounting) = true
+        (module.labels.name_nodeset_login)      = false
+        (module.labels.name_nodeset_accounting) = false
       }
     }
     c-4vcpu-16gb = {
@@ -19,10 +19,10 @@ locals {
       gpus                   = 0
       gpu_cluster_compatible = false
       sufficient = {
-        (module.labels.name_nodeset_system)     = true
+        (module.labels.name_nodeset_system)     = false
         (module.labels.name_nodeset_controller) = true
         (module.labels.name_nodeset_worker)     = false
-        (module.labels.name_nodeset_login)      = true
+        (module.labels.name_nodeset_login)      = false
         (module.labels.name_nodeset_accounting) = true
       }
     }
@@ -32,10 +32,10 @@ locals {
       gpus                   = 0
       gpu_cluster_compatible = false
       sufficient = {
-        (module.labels.name_nodeset_system)     = true
+        (module.labels.name_nodeset_system)     = false
         (module.labels.name_nodeset_controller) = true
         (module.labels.name_nodeset_worker)     = true
-        (module.labels.name_nodeset_login)      = true
+        (module.labels.name_nodeset_login)      = false
         (module.labels.name_nodeset_accounting) = true
       }
     }

--- a/soperator/modules/k8s/variables.tf
+++ b/soperator/modules/k8s/variables.tf
@@ -116,7 +116,6 @@ variable "node_group_login" {
 variable "node_group_accounting" {
   description = "System node group specification."
   type = object({
-    enabled = bool
     spec = optional(object({
       resource = object({
         platform = string
@@ -129,14 +128,6 @@ variable "node_group_accounting" {
       })
     }))
   })
-
-  validation {
-    condition = (var.node_group_accounting.enabled
-      ? var.node_group_accounting.spec != null
-      : true
-    )
-    error_message = "Specification must be provided when accounting is enabled."
-  }
 }
 
 #---

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -109,7 +109,7 @@ resource "helm_release" "soperator_fluxcd_cm" {
   values = [templatefile("${path.module}/templates/helm_values/terraform_fluxcd_values.yaml.tftpl", {
     backups_enabled    = var.backups_enabled
     telemetry_enabled  = var.telemetry_enabled
-    accounting_enabled = var.accounting_enabled
+    accounting_enabled = true
     iam_tenant_id      = var.iam_tenant_id
     iam_project_id     = var.iam_project_id
 
@@ -155,11 +155,11 @@ resource "helm_release" "soperator_fluxcd_cm" {
           size   = "${submount.size_gibibytes}Gi"
           device = submount.device
         }]
-        accounting = var.accounting_enabled ? {
+        accounting = {
           enabled = true
           size    = "${var.filestores.accounting.size_gibibytes}Gi"
           device  = var.filestores.accounting.device
-        } : { enabled = false }
+        }
       }
     }
 
@@ -192,21 +192,21 @@ resource "helm_release" "soperator_fluxcd_cm" {
 
       nodes = {
         accounting = {
-          enabled              = var.accounting_enabled
+          enabled              = true
           use_protected_secret = var.use_protected_secret
-          mariadb_operator = var.accounting_enabled ? {
-            enabled         = var.accounting_enabled
-            storage_size    = var.accounting_enabled ? var.filestores.accounting.size_gibibytes : 0
+          mariadb_operator = {
+            enabled         = true
+            storage_size    = var.filestores.accounting.size_gibibytes
             metrics_enabled = var.telemetry_enabled
             resources       = local.resources.mariadb
-          } : null
+          }
           slurmdbd_config = var.slurmdbd_config
           slurm_config    = var.slurm_accounting_config
-          resources = var.accounting_enabled ? {
+          resources = {
             cpu               = var.resources.accounting.cpu_cores - local.resources.munge.cpu - local.resources.mariadb.cpu
             memory            = var.resources.accounting.memory_gibibytes - local.resources.munge.memory - local.resources.mariadb.memory
             ephemeral_storage = var.resources.accounting.ephemeral_storage_gibibytes - local.resources.munge.ephemeral_storage - local.resources.mariadb.ephemeral_storage
-          } : null
+          }
         }
 
         controller = {

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -366,7 +366,8 @@ resources:
               k8sNodeFilterName: ${slurm_cluster.k8s_node_filters.system.name}
 
             slurmConfig:
-              defMemPerNode: ${floor(slurm_cluster.nodes.worker.resources.memory * 1024)}
+              # Allocate half of the available memory by default
+              defMemPerNode: ${floor(slurm_cluster.nodes.worker.resources.memory * 1024 / 2)}
 
             periodicChecks:
               ncclBenchmark:

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -131,7 +131,7 @@ variable "resources" {
   # TODO: remove when node sets are supported
   validation {
     condition     = length(var.resources.worker) == 1
-    error_message = "Only one worker node is supported."
+    error_message = "Only one worker nodeset is supported."
   }
 }
 
@@ -321,18 +321,6 @@ variable "dcgm_job_map_dir" {
 # endregion Telemetry
 
 # region Accounting
-
-variable "mariadb_operator_namespace" {
-  description = "Namespace for MariaDB operator."
-  type        = string
-  default     = "mariadb-operator-system"
-}
-
-variable "accounting_enabled" {
-  description = "Whether to enable accounting."
-  type        = bool
-  default     = true
-}
 
 variable "use_protected_secret" {
   description = "If true, protected user secret MariaDB will not be deleted after the MariaDB CR is deleted."


### PR DESCRIPTION
## Release Notes (Mandatory Description)
- Allocate only half of the total memory in jobs by default
- Forbid creating clusters without jail submounts by default
- Deprecate the use of filestore for storing controller state
- Add min sizes for K8s node boot disks
- Make Slurm accounting required