### PR TITLE
[Merge to main] logs-cleaner runAfterCreation: true

### DIFF
--- a/soperator/modules/active_checks/templates/soperator_outputs_logs_cleaner.tftpl
+++ b/soperator/modules/active_checks/templates/soperator_outputs_logs_cleaner.tftpl
@@ -28,5 +28,5 @@ resources:
             mountPath: /mnt/jail
       name: soperator-outputs-logs-cleaner
       schedule: "0 */2 * * *" # every 2 hours
-      runAfterCreation: false
+      runAfterCreation: true
       slurmClusterRefName: ${slurm_cluster_name}


### PR DESCRIPTION
Merge back PR
https://github.com/nebius/nebius-solutions-library/pull/497

## Original description

`wait-for-checks` will keep waiting forever because logs-cleaner doesn't run after creation. This PR changes it to `runAfterCreation: true`