### PR TITLE
[cherry-pick] increased iam API version to v2 in soperator

### DIFF
--- a/soperator/installations/example/.envrc
+++ b/soperator/installations/example/.envrc
@@ -100,30 +100,30 @@ else
 fi
 
 echo 'Creating new access key for Object Storage'
-NEBIUS_SA_ACCESS_KEY_ID=$(nebius iam access-key create \
+NEBIUS_SA_ACCESS_KEY_ID=$(nebius iam v2 access-key create \
   --parent-id "${NEBIUS_PROJECT_ID}" \
   --name "slurm-tf-ak-$(date +%s)" \
   --account-service-account-id "${NEBIUS_SA_TERRAFORM_ID}" \
   --description 'Temporary S3 Access' \
   --expires-at "${EXPIRATION_DATE}" \
   --format json \
-  | jq -r '.resource_id')
+  | jq -r '.metadata.id')
 echo "Created new access key: ${NEBIUS_SA_ACCESS_KEY_ID}"
 
 # endregion Access key
 
 # region AWS access key
 
-AWS_ACCESS_KEY_ID=$(nebius iam access-key get-by-id \
+AWS_ACCESS_KEY_ID=$(nebius iam v2 access-key get \
   --id "${NEBIUS_SA_ACCESS_KEY_ID}" \
   --format json | jq -r '.status.aws_access_key_id')
 export AWS_ACCESS_KEY_ID
 
 echo "Generating new AWS_SECRET_ACCESS_KEY"
-AWS_SECRET_ACCESS_KEY="$(nebius iam access-key get-secret-once \
+AWS_SECRET_ACCESS_KEY="$(nebius iam v2 access-key get \
   --id "${NEBIUS_SA_ACCESS_KEY_ID}" \
   --format json \
-  | jq -r '.secret')"
+  | jq -r '.status.secret')"
 export AWS_SECRET_ACCESS_KEY
 
 # endregion AWS access key

--- a/soperator/modules/backups/main.tf
+++ b/soperator/modules/backups/main.tf
@@ -31,10 +31,10 @@ resource "terraform_data" "k8s_backups_bucket_access_secret" {
     command = join(
       "",
       [
-        "for AKID in $(nebius iam access-key list-by-account ",
-        "--account-service-account-id ${self.triggers_replace.service_account_id} | yq e -o=j -I=0 '.items[]'); ",
+        "for AKID in $(nebius iam v2 access-key list-by-account ",
+        "--account-service-account-id ${self.triggers_replace.service_account_id} | yq '.items[].metadata.id' ); ",
         "do ",
-        "nebius iam access-key delete --id-id $(echo $AKID | yq .metadata.id); ",
+        "nebius iam v2 access-key delete --id $(echo $AKID); ",
         "done; ",
         "kubectl get --context ${self.triggers_replace.k8s_cluster_context} ",
         "-n ${self.triggers_replace.namespace} secret ${self.triggers_replace.secret_name} -oyaml ",
@@ -52,8 +52,8 @@ set -e
 
 kubectl create namespace ${var.soperator_namespace} --context ${var.k8s_cluster_context} || true
 
-AKID=$(nebius iam access-key create --parent-id ${var.iam_project_id} \
-  --account-service-account-id ${self.triggers_replace.service_account_id} | yq .resource_id)
+AKID=$(nebius iam v2 access-key create --parent-id ${var.iam_project_id} \
+  --account-service-account-id ${self.triggers_replace.service_account_id} | yq .metadata.id)
 
 kubectl apply --server-side --context ${var.k8s_cluster_context} -f -  <<EOF
 apiVersion: v1
@@ -67,8 +67,8 @@ metadata:
   annotations:
     slurm.nebius.ai/service-account: ${self.triggers_replace.service_account_id}
 data:
-  aws-access-key-id: $(nebius iam access-key get-by-id --id $AKID | yq .status.aws_access_key_id | tr -d '\n' | base64)
-  aws-access-secret-key: $(nebius iam access-key get-secret-once --id $AKID | yq .secret | tr -d '\n' | base64)
+  aws-access-key-id: $(nebius iam v2 access-key get --id $AKID | yq .status.aws_access_key_id | tr -d '\n' | base64)
+  aws-access-secret-key: $(nebius iam v2 access-key get --id $AKID | yq .status.secret | tr -d '\n' | base64)
   backup-password: $(echo -n ${var.backups_password} | base64)
 EOF
 EOT


### PR DESCRIPTION
Cherry-picked from #447

In the current version we use nebius iam access-key [flags] rather than nebius iam v2 access-key  [flags] which results in the following warning:
```
Warning: command 'access-key' is deprecated and will be removed on 2025-09-01. Access keys API v1 is deprecated, use the v2 version instead. Keys produced by API v1 are available using v2.
```

This PR updates it to V2