### PR TITLE
Soperator/snccld Ensure NCCL debug log directory

### DIFF
--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -693,7 +693,7 @@ variable "slurm_nodeset_accounting" {
       block_size_kibibytes = number
     })
   })
-  default  = {
+  default = {
     resource = {
       platform = "cpu-d3"
       preset   = "8vcpu-32gb"

--- a/soperator/modules/k8s/variables.tf
+++ b/soperator/modules/k8s/variables.tf
@@ -92,7 +92,7 @@ variable "node_group_workers" {
     gpu_cluster = optional(object({
       infiniband_fabric = string
     }))
-    preemptible = optional(object({}))
+    preemptible   = optional(object({}))
     nodeset_index = number
     subset_index  = number
   }))

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -5,7 +5,7 @@ resource "terraform_data" "wait_for_slurm_cluster_hr" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = templatefile("${path.module}/scripts/wait_for_flux_hr.sh.tmpl", {
+    command = templatefile("${path.module}/scripts/wait_for_flux_hr.sh.tmpl", {
       k8s_cluster_context = var.k8s_cluster_context
       helmrelease_name    = "flux-system-soperator-fluxcd-slurm-cluster"
     })
@@ -19,7 +19,7 @@ resource "terraform_data" "wait_for_soperator_activechecks_hr" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command     = templatefile("${path.module}/scripts/wait_for_flux_hr.sh.tmpl", {
+    command = templatefile("${path.module}/scripts/wait_for_flux_hr.sh.tmpl", {
       k8s_cluster_context = var.k8s_cluster_context
       helmrelease_name    = "flux-system-soperator-fluxcd-soperator-activechecks"
     })
@@ -295,6 +295,20 @@ resource "helm_release" "soperator_fluxcd_ad_hoc_cm" {
   namespace  = var.flux_namespace
 
   values = [templatefile("${path.module}/templates/helm_values/soperator_fluxcd.yaml.tftpl", {})]
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "helm_release" "cm_terraform_soperator_activechecks" {
+  name       = "terraform-soperator-activechecks"
+  repository = local.helm.repository.raw
+  chart      = local.helm.chart.raw
+  version    = local.helm.version.raw
+  namespace  = var.flux_namespace
+
+  values = [templatefile("${path.module}/templates/helm_values/cm_terraform_soperator_activechecks.yaml.tftpl", {})]
 
   lifecycle {
     ignore_changes = all

--- a/soperator/modules/slurm/templates/helm_values/cm_terraform_soperator_activechecks.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/cm_terraform_soperator_activechecks.yaml.tftpl
@@ -1,0 +1,9 @@
+resources:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: terraform-soperator-activechecks
+    data:
+      values.yaml: |
+        ensureDirSnccldLogs:
+          enabled: true


### PR DESCRIPTION
This PR introduces a ConfigMap with overrode values for `soperator_activechecks` Helm chart to enable [`ensureDirSnccldLogs`](https://github.com/nebius/soperator/pull/1541) active check.