### PR TITLE
Improve Slurm monitoring dashboards

### DIFF
--- a/soperator/modules/monitoring/templates/dashboards/cluster_health.json
+++ b/soperator/modules/monitoring/templates/dashboards/cluster_health.json
@@ -31,6 +31,1244 @@
       },
       "id": 12,
       "panels": [],
+      "title": "Quick Stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 14,
+      "maxPerRow": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "group(\n    label_replace(\n        container_processes{\n            image=~\".*slurm-operator:.*\",\n            container=\"manager\"\n        }\n    , \"version\", \"$1\", \"image\", \".*:(.+)\"\n    )\n) by(version)\n",
+          "instant": true,
+          "legendFormat": "{{version}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Soperator Version",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 20,
+      "maxPerRow": 6,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": false
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(\n  tlast_change_over_time(\n    (\n      group(\n        label_replace(\n          container_processes{\n            image=~\".*slurm-operator:.*\",\n            container=\"manager\"\n          },\n          \"version\",\n          \"$1\",\n          \"image\",\n          \".*:(.+)\"\n        )\n      ) by(version)\n    )[30d]\n  )\n    *\n  1000\n)\n  and on(version)\ngroup(\n  label_replace(\n    container_processes{\n      image=~\".*slurm-operator:.*\",\n      container=\"manager\"\n    },\n    \"version\",\n    \"$1\",\n    \"image\",\n    \".*:(.+)\"\n  )\n) by(version)",
+          "instant": true,
+          "legendFormat": "{{version}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Last Soperator upgrade",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 21,
+      "maxPerRow": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^H100 80GB HBM3$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "group(\n    label_transform(\n        DCGM_FI_DEV_COUNT,\n        \"modelName\", \"NVIDIA (.*)\", \"$1\"\n    )\n) by (modelName)",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU model",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "GPU Nodes",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(\n    count(\n        DCGM_FI_DEV_COUNT\n    ) by (Hostname)\n)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-purple",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(\n  DCGM_FI_DEV_GPU_UTIL\n)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "GPUs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "time() - kube_pod_created{\n  namespace=~\"soperator\",\n  pod=~\"controller-[0-9]+\"\n}",
+          "instant": true,
+          "legendFormat": "{{pod}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "SlurmCtld Pod Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-orange",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum_over_time(\n    count(\n    DCGM_FI_DEV_GPU_UTIL\n        >=\n    10\n)[1d:10m])\n/\nsum_over_time(\n    count(\n    DCGM_FI_DEV_GPU_UTIL\n)[1d:10m])\n* 100",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Utilization 1d",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-orange",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 4
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum_over_time(\n    count(\n    DCGM_FI_DEV_GPU_UTIL\n        >=\n    10\n)[7d:1h])\n/\nsum_over_time(\n    count(\n    DCGM_FI_DEV_GPU_UTIL\n)[7d:1h])\n* 100",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Utilization 7d",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-orange",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 4
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum_over_time(\n    count(\n    DCGM_FI_DEV_GPU_UTIL\n        >=\n    10\n)[30d:6h])\n/\nsum_over_time(\n    count(\n    DCGM_FI_DEV_GPU_UTIL\n)[30d:6h])\n* 100",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Utilization 30d",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 4
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(\n    slurm_node_info{\n        state_base=~\"IDLE|MIXED|ALLOCATED\",\n        state_is_drain=\"false\"\n    }\n)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Healthy Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "In selected time window",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-red",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 4
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "legend": {
+          "displayMode": "list"
+        },
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(max by(node_name, reason, state_base, state_is_drain, state_is_maintenance, state_is_reserved) (slurm_node_fails_total{state_is_maintenance=\"false\"})[$__range]))",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Node Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Time nodes spent in `unavailable` state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "super-light-purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "No Unavailable Node",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "legend": {
+          "displayMode": "list"
+        },
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  slurm_node_unavailability_duration_seconds_sum\n) by()\n  /\nsum(\n  slurm_node_unavailability_duration_seconds_count\n) by()",
+          "hide": false,
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Avg Unavailable Time",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Based on number of nodes per job\n\nOver the selected time window",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 7
+      },
+      "id": 27,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(\n  sum_over_time(\n    (\n      slurm_job_info{\n        user_name!=\"soperatorchecks\",\n        job_state=\"RUNNING\"\n      }\n    )[1d:1m]\n  )\n    *\n  60\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Avg Job Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Based on number of nodes per job (nodes > 1)\n\nOver the selected time window",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 7
+      },
+      "id": 28,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(\n  (\n    count(\n      slurm_node_job\n    ) by(job_id)\n      * on(job_id)\n    slurm_job_info{\n      user_name!=\"soperatorchecks\"\n    }\n  )\n    >\n  1\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Avg Job Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Over the selected time window",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 7
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(\n  DCGM_FI_DEV_POWER_USAGE\n    and on(exported_pod,gpu)\n  count(\n    DCGM_FI_DEV_GPU_UTIL\n      >=\n    10\n  ) by(exported_pod,gpu)\n)",
+          "hide": false,
+          "instant": false,
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Avg Power Usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "None",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "light-red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 7
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(\n    slurm_node_info{\n        state_base=~\"DOWN|ERROR\",\n        state_is_drain=\"true\"\n    }\n)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Unhealthy Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "GPUh"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 7
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "legend": {
+          "displayMode": "list"
+        },
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "(\n  sum (\n    increase(\n      sum by (node_name, state_base, state_is_drain, state_is_maintenance, state_is_reserved) (\n        slurm_node_gpu_seconds_total{\n          state_is_maintenance=\"false\",\n          state_base=~\".*\"\n        }\n      )[7d]\n    )\n  )\n  /\n  (\n    sum (\n      increase(\n        max by (node_name, reason, state_base, state_is_drain, state_is_maintenance, state_is_reserved) (\n          slurm_node_fails_total{\n            state_is_maintenance=\"false\"\n          }\n        )[7d]\n      )\n    )\n    or\n    (\n      sum (\n        increase(\n          slurm_node_gpu_seconds_total{\n            state_is_maintenance=\"false\",\n            state_base=~\".*\"\n          }[7d]\n        )\n      ) * 0\n    )\n  )\n) / 3600",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Overall MTBF (7d)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Time nodes spent in `draining` state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "super-light-orange",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "No Draining Node",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 7
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "legend": {
+          "displayMode": "list"
+        },
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(\n  slurm_node_draining_duration_seconds_sum\n) by()\n  /\nsum(\n  slurm_node_draining_duration_seconds_count\n) by()",
+          "hide": false,
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Avg Drain Time",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 13,
+      "panels": [],
       "title": "Slurm Nodes",
       "type": "row"
     },
@@ -39,6 +1277,7 @@
         "type": "prometheus",
         "uid": "VictoriaMetrics"
       },
+      "description": "Node states breakdown:\n- **Down**: Nodes not operational (DOWN or ERROR states)\n- **Drained**: IDLE nodes with DRAIN flag\n- **Draining**: Nodes with DRAIN flag running jobs\n- **Busy**: Nodes running jobs normally (ALLOCATED or MIXED)\n- **Idle**: Nodes ready and available to accept new jobs\n- **Maintenance**: Nodes temporarily unavailable for administrative tasks",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -98,22 +1337,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "UNKNOWN"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "rgba(128, 128, 128, 1)",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "DOWN"
+              "options": "Down"
             },
             "properties": [
               {
@@ -128,13 +1352,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "IDLE"
+              "options": "Drained"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "rgba(51, 162, 73, 1)",
+                  "fixedColor": "rgba(255, 152, 48, 1)",
                   "mode": "fixed"
                 }
               }
@@ -143,22 +1367,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "ALLOCATED"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "rgba(31, 120, 193, 1)",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "ERROR"
+              "options": "Draining"
             },
             "properties": [
               {
@@ -173,13 +1382,58 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "MIXED"
+              "options": "Busy"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "rgba(102, 166, 204, 1)",
+                  "fixedColor": "rgba(31, 120, 193, 1)",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(51, 162, 73, 1)",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Maintenance"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(128, 128, 128, 1)",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(163, 74, 163, 1)",
                   "mode": "fixed"
                 }
               }
@@ -188,10 +1442,10 @@
         ]
       },
       "gridPos": {
-        "h": 11,
-        "w": 12,
+        "h": 13,
+        "w": 24,
         "x": 0,
-        "y": 1
+        "y": 11
       },
       "id": 1,
       "options": {
@@ -219,11 +1473,77 @@
             "type": "prometheus",
             "uid": "VictoriaMetrics"
           },
-          "expr": "count by (state_base) (slurm_node_info)",
+          "expr": "count(slurm_node_info{state_base=~\"DOWN|ERROR\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"})",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{state_base}}",
+          "legendFormat": "Down",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "expr": "count(slurm_node_info{state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain=\"true\", node_name=~\"$node_name\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Drained",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "expr": "count(slurm_node_info{state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain=\"true\", node_name=~\"$node_name\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Draining",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "expr": "count(slurm_node_info{state_base=~\"ALLOCATED|MIXED\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", node_name=~\"$node_name\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Busy",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "expr": "count(slurm_node_info{state_base=\"IDLE\", state_is_maintenance!=\"true\", state_is_drain!=\"true\", node_name=~\"$node_name\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Idle",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "expr": "count(slurm_node_info{state_is_maintenance=\"true\", node_name=~\"$node_name\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Maintenance",
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "expr": "count(slurm_node_info{state_base=\"UNKNOWN\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Unknown",
+          "refId": "G"
         }
       ],
       "title": "Nodes by State",
@@ -234,343 +1554,7 @@
         "type": "prometheus",
         "uid": "VictoriaMetrics"
       },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "orange",
-            "mode": "shades"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*DOWN.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "rgba(242, 73, 92, 1)",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": ".*drain.*"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 12,
-        "x": 12,
-        "y": 1
-      },
-      "id": 5,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "editorMode": "code",
-          "expr": "sum by (node_name, state_base) (slurm_node_info{state_base=~\"DOWN|ERROR\", state_is_drain=\"false\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{node_name}}, {{state_base}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "editorMode": "code",
-          "expr": "sum by (node_name, state_base) (slurm_node_info{state_is_drain=\"true\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{node_name}}, {{state_base}}+DRAIN",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Node Problems",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "VictoriaMetrics"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": false,
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "node_name"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 200
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "instance_id"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 250
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "reason"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 150
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 12
-      },
-      "id": 52,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "enablePagination": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "frameIndex": 0,
-        "showHeader": true
-      },
-      "pluginVersion": "11.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "VictoriaMetrics"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(slurm_node_info{state_base=~\"DOWN|ERROR\", state_is_drain=\"false\"} or slurm_node_info{state_is_drain=\"true\"}) * on(node_name) group_left(reason) (slurm_node_fails_total or on(node_name) (slurm_node_info * 0))",
-          "format": "table",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Node Problems Table",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "keepLabels": [
-              "node_name",
-              "instance_id",
-              "state_base",
-              "state_is_drain",
-              "reason",
-              "__name__"
-            ],
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "groupToNestedTable",
-          "options": {
-            "fields": {
-              "Time": {
-                "aggregations": [
-                  "first",
-                  "last"
-                ],
-                "operation": "aggregate"
-              },
-              "state_base": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "instance_id": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "state_is_drain": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "node_name": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "reason": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "slurm_node_info": {
-                "aggregations": [
-                  "last"
-                ],
-                "operation": "aggregate"
-              }
-            },
-            "showSubframeHeaders": false
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Time (first)"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "VictoriaMetrics"
-      },
+      "description": "Timeline of node problems showing Down (DOWN/ERROR states), Drained (IDLE with drain), and Draining (ALLOCATED/MIXED with drain) states. Maintenance nodes are filtered out.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -591,19 +1575,19 @@
             {
               "options": {
                 "1": {
-                  "color": "rgba(255, 193, 7, 0.6)",
+                  "color": "rgba(242, 73, 92, 0.8)",
                   "index": 0,
-                  "text": "DRAIN"
+                  "text": "Down"
                 },
                 "2": {
-                  "color": "rgba(242, 73, 92, 0.6)",
+                  "color": "rgba(255, 152, 48, 0.8)",
                   "index": 1,
-                  "text": "DOWN"
+                  "text": "Drained"
                 },
                 "3": {
-                  "color": "rgba(176, 41, 54, 0.6)",
+                  "color": "rgba(255, 193, 7, 0.8)",
                   "index": 2,
-                  "text": "DOWN+DRAIN"
+                  "text": "Draining"
                 }
               },
               "type": "value"
@@ -623,10 +1607,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 12
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 24
       },
       "id": 51,
       "options": {
@@ -653,7 +1637,7 @@
             "uid": "VictoriaMetrics"
           },
           "editorMode": "code",
-          "expr": "sum by (node_name) (\n  count by (node_name) (slurm_node_info{state_is_drain=\"true\", state_base!=\"DOWN\"}) * 1 or\n  count by (node_name) (slurm_node_info{state_is_drain=\"false\", state_base=\"DOWN\"}) * 2 or\n  count by (node_name) (slurm_node_info{state_is_drain=\"true\", state_base=\"DOWN\"}) * 3\n)\n",
+          "expr": "sum by (node_name) (\n  # Down: Nodes in DOWN or ERROR state (not in maintenance)\n  count by (node_name) (slurm_node_info{state_base=~\"DOWN|ERROR\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"}) * 1 or\n  # Drained: IDLE nodes with drain flag (not in maintenance)\n  count by (node_name) (slurm_node_info{state_base=\"IDLE\", state_is_drain=\"true\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"}) * 2 or\n  # Draining: ALLOCATED/MIXED nodes with drain flag (not in maintenance)\n  count by (node_name) (slurm_node_info{state_base=~\"ALLOCATED|MIXED\", state_is_drain=\"true\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"}) * 3\n)\n",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "__auto",
@@ -665,14 +1649,266 @@
       "type": "state-timeline"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Lists nodes that are DOWN, in ERROR state, or have DRAIN flag set (maintenance nodes excluded).\n\n**Columns:**\n- Fail Reason: From failure counter metrics\n- State Reason: From node info (Soperator 1.22+)\n\n**Note:** Rows group events by state - same node may appear multiple times with overlapping time ranges.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Instance ID"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Is Drain"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 70
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "First Time Seen"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 170
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Time Seen"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 170
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 52,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(\n  # Get nodes with problems: DOWN/ERROR states or drain flag\n  slurm_node_info{state_base=~\"DOWN|ERROR\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"} or\n  slurm_node_info{state_is_drain=\"true\", state_is_maintenance!=\"true\", node_name=~\"$node_name\"}\n) * on(node_name) group_left(fail_reason) (\n  # Join with failure reasons from counter metric\n  label_replace(\n    topk by (node_name) (1,\n      rate(slurm_node_fails_total{state_is_maintenance!=\"true\", node_name=~\"$node_name\"}[$__rate_interval])\n    ),\n    \"fail_reason\", \"$1\", \"reason\", \"(.*)\"\n  ) or on(node_name) (\n    # Fallback for nodes without failure counter data\n    slurm_node_info{node_name=~\"$node_name\"} * 0\n  )\n)",
+          "format": "table",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node Problems Breakdown",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "keepLabels": [
+              "node_name",
+              "instance_id",
+              "state_base",
+              "state_is_drain",
+              "reason",
+              "fail_reason",
+              "__name__"
+            ],
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "groupToNestedTable",
+          "options": {
+            "fields": {
+              "Time": {
+                "aggregations": [
+                  "first",
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "fail_reason": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "instance_id": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "node_name": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "reason": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "slurm_node_info": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "state_base": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "state_is_drain": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            },
+            "showSubframeHeaders": false
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Time (first)"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Nested frames": true
+            },
+            "indexByName": {
+              "Time (first)": 0,
+              "Time (last)": 1,
+              "fail_reason (first)": 6,
+              "instance_id": 3,
+              "node_name": 2,
+              "reason": 7,
+              "state_base": 4,
+              "state_is_drain": 5
+            },
+            "renameByName": {
+              "Time (first)": "First Time Seen",
+              "Time (last)": "Last Time Seen",
+              "fail_reason (first)": "Fail Reason",
+              "instance_id": "Instance ID",
+              "node_name": "Name",
+              "reason": "State Reason",
+              "state_base": "State",
+              "state_is_drain": "Is Drain"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 53
       },
-      "id": 13,
+      "id": 56,
       "panels": [],
       "title": "Slurm Jobs",
       "type": "row"
@@ -704,8 +1940,8 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -714,7 +1950,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -726,8 +1962,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -743,9 +1978,9 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 54
       },
-      "id": 2,
+      "id": 54,
       "options": {
         "legend": {
           "calcs": [
@@ -772,16 +2007,120 @@
             "uid": "VictoriaMetrics"
           },
           "editorMode": "code",
-          "expr": "count by (job_state, job_id, job_name) (slurm_job_info{job_state=~\".*ING|POWER_UP_NODE|REQUEUE.*|RESV_DEL_HOLD|STAGE_OUT|STOPPED|SUSPENDED|UPDATE_DB\", user_name=~\"$user_name\"})",
+          "expr": "count by (user_name) (slurm_job_info{job_state=\"RUNNING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}})",
           "format": "time_series",
-          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{job_id}}: {{job_state}}, {{job_name}}",
+          "legendFormat": "{{user_name}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Non-Terminal Job States",
+      "title": "Running Jobs by User",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "count by (slurm_partition) (slurm_job_info{job_state=\"RUNNING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{slurm_partition}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Running Jobs by Partition",
       "type": "timeseries"
     },
     {
@@ -809,7 +2148,7 @@
             {
               "options": {
                 "1": {
-                  "color": "light-blue",
+                  "color": "gray",
                   "index": 0,
                   "text": "PENDING"
                 },
@@ -819,7 +2158,7 @@
                   "text": "CONFIGURING"
                 },
                 "3": {
-                  "color": "green",
+                  "color": "blue",
                   "index": 2,
                   "text": "RUNNING"
                 },
@@ -921,8 +2260,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -931,10 +2269,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
-        "w": 12,
-        "x": 12,
-        "y": 22
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 65
       },
       "id": 53,
       "options": {
@@ -945,6 +2283,7 @@
           "showLegend": true
         },
         "mergeValues": true,
+        "perPage": 30,
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {
@@ -961,7 +2300,7 @@
             "uid": "VictoriaMetrics"
           },
           "editorMode": "code",
-          "expr": "label_join(\n  sum by (job_id, job_name)(\n    count by (job_id, job_name) (slurm_job_info{job_state=\"PENDING\", user_name=~\"$user_name\"}) * 1 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"CONFIGURING\", user_name=~\"$user_name\"}) * 2 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"RUNNING\", user_name=~\"$user_name\"}) * 3 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"COMPLETING\", user_name=~\"$user_name\"}) * 4 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"COMPLETED\", user_name=~\"$user_name\"}) * 5 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"CANCELLED\", user_name=~\"$user_name\"}) * 6 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"FAILED\", user_name=~\"$user_name\"}) * 7 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"TIMEOUT\", user_name=~\"$user_name\"}) * 8 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"PREEMPTED\", user_name=~\"$user_name\"}) * 9 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"NODE_FAIL\", user_name=~\"$user_name\"}) * 10 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"BOOT_FAIL\", user_name=~\"$user_name\"}) * 11 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"DEADLINE\", user_name=~\"$user_name\"}) * 12 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"OUT_OF_MEMORY\", user_name=~\"$user_name\"}) * 13 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"REQUEUED\", user_name=~\"$user_name\"}) * 14 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"RESIZING\", user_name=~\"$user_name\"}) * 15 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"SUSPENDED\", user_name=~\"$user_name\"}) * 16 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"STOPPED\", user_name=~\"$user_name\"}) * 17 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"POWER_UP_NODE\", user_name=~\"$user_name\"}) * 18 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"SIGNALING\", user_name=~\"$user_name\"}) * 19 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"STAGE_OUT\", user_name=~\"$user_name\"}) * 20 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"UPDATE_DB\", user_name=~\"$user_name\"}) * 21\n  ),\n  \"job_display\", \": \", \"job_id\", \"job_name\"\n)",
+          "expr": "label_join(\n  sum by (job_id, job_name)(\n    count by (job_id, job_name) (slurm_job_info{job_state=\"PENDING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 1 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"CONFIGURING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 2 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"RUNNING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 3 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"COMPLETING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 4 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"COMPLETED\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 5 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"CANCELLED\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 6 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"FAILED\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 7 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"TIMEOUT\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 8 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"PREEMPTED\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 9 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"NODE_FAIL\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 10 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"BOOT_FAIL\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 11 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"DEADLINE\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 12 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"OUT_OF_MEMORY\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 13 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"REQUEUED\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 14 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"RESIZING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 15 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"SUSPENDED\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 16 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"STOPPED\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 17 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"POWER_UP_NODE\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 18 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"SIGNALING\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 19 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"STAGE_OUT\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 20 or\n    count by (job_id, job_name) (slurm_job_info{job_state=\"UPDATE_DB\", user_name=~\"$user_name\", slurm_partition${partition_match_exp}}) * 21\n  ),\n  \"job_display\", \": \", \"job_id\", \"job_name\"\n)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{job_display}}",
@@ -971,14 +2310,466 @@
       ],
       "title": "Job State Timeline",
       "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "description": "Shows jobs in terminal states (COMPLETED, CANCELLED, FAILED, TIMEOUT). All times are displayed in the current Grafana timezone.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Submit Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 160
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Start Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 160
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Finished Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 160
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Job ID"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Job Name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 460
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 105
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "State Reason"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 135
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "User"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Partition"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Submit Time"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsLocal"
+              },
+              {
+                "id": "custom.width",
+                "value": 190
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Start Time"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsLocal"
+              },
+              {
+                "id": "custom.width",
+                "value": 190
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Finished Time"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsLocal"
+              },
+              {
+                "id": "custom.width",
+                "value": 190
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 81
+      },
+      "id": 57,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "slurm_job_info{\n  job_state=~\"COMPLETED|CANCELLED|FAILED|TIMEOUT\",\n  user_name=~\"$user_name\", slurm_partition${partition_match_exp}\n}",
+          "format": "table",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Finished Jobs",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "keepLabels": [
+              "job_id",
+              "job_name",
+              "job_state",
+              "job_state_reason",
+              "user_name",
+              "slurm_partition",
+              "submit_time",
+              "start_time",
+              "finished_time",
+              "__name__"
+            ],
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "groupToNestedTable",
+          "options": {
+            "fields": {
+              "Time": {
+                "aggregations": [
+                  "first",
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "finished_time": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "job_id": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "job_name": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "job_state": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "job_state_reason": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "slurm_job_info": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "slurm_partition": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "start_time": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "submit_time": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              },
+              "user_name": {
+                "aggregations": [
+                  "first"
+                ],
+                "operation": "aggregate"
+              }
+            },
+            "showSubframeHeaders": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "start_time_ms",
+            "binary": {
+              "left": "start_time (first)",
+              "operator": "*",
+              "right": "1000"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "submit_time_ms",
+            "binary": {
+              "left": "submit_time (first)",
+              "operator": "*",
+              "right": "1000"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "finished_time_ms",
+            "binary": {
+              "left": "finished_time (first)",
+              "operator": "*",
+              "right": "1000"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "finished_time_ms"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Nested frames": true,
+              "Time (first)": true,
+              "Time (last)": true,
+              "finished_time (first)": true,
+              "slurm_job_info (last)": true,
+              "start_time (first)": true,
+              "submit_time (first)": true
+            },
+            "indexByName": {
+              "finished_time_ms": 8,
+              "job_id": 0,
+              "job_name (first)": 1,
+              "job_state (first)": 2,
+              "job_state_reason (first)": 3,
+              "slurm_partition (first)": 5,
+              "start_time_ms": 7,
+              "submit_time_ms": 6,
+              "user_name (first)": 4
+            },
+            "renameByName": {
+              "finished_time_ms": "Finished Time",
+              "job_id": "Job ID",
+              "job_name (first)": "Job Name",
+              "job_state (first)": "State",
+              "job_state_reason (first)": "State Reason",
+              "slurm_partition (first)": "Partition",
+              "start_time_ms": "Start Time",
+              "submit_time_ms": "Submit Time",
+              "user_name (first)": "User"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "preload": false,
-  "refresh": "30s",
+  "refresh": "",
   "schemaVersion": 40,
   "tags": [],
   "templating": {
     "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "VictoriaMetrics"
+        },
+        "definition": "label_values(slurm_node_info, node_name)",
+        "includeAll": true,
+        "label": "Worker Node",
+        "multi": true,
+        "name": "node_name",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(slurm_node_info, node_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
       {
         "current": {
           "text": "All",
@@ -990,7 +2781,7 @@
           "type": "prometheus",
           "uid": "VictoriaMetrics"
         },
-        "definition": "label_values(slurm_job_info{user_name!=\"soperatorchecks\"},user_name)",
+        "definition": "label_values(slurm_job_info,user_name)",
         "includeAll": true,
         "label": "Job User Name",
         "multi": true,
@@ -998,13 +2789,37 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(slurm_job_info{user_name!=\"soperatorchecks\"},user_name)",
+          "query": "label_values(slurm_job_info,user_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "text": "!~\"^(hidden|background)$\"",
+          "value": "!~\"^(hidden|background)$\""
+        },
+        "description": "Filter system jobs from hidden and background partitions",
+        "includeAll": false,
+        "label": "System Jobs",
+        "name": "partition_match_exp",
+        "options": [
+          {
+            "selected": false,
+            "text": "Show",
+            "value": "=~\"^.*$\""
+          },
+          {
+            "selected": true,
+            "text": "Hide",
+            "value": "!~\"^(hidden|background)$\""
+          }
+        ],
+        "query": "Show : =~\"^.*$\",Hide : !~\"^(hidden|background)$\"",
+        "type": "custom"
       }
     ]
   },

--- a/soperator/modules/monitoring/templates/dashboards/jobs_overview.json
+++ b/soperator/modules/monitoring/templates/dashboards/jobs_overview.json
@@ -2816,7 +2816,7 @@
           "type": "prometheus",
           "uid": "VictoriaMetrics"
         },
-        "definition": "label_values(node_uname_info{job=\"node-exporter\", nodename=~\"$hostname\"},instance)",
+        "definition": "label_values(node_uname_info{container=\"node-exporter\", nodename=~\"$hostname\"},instance)",
         "hide": 2,
         "includeAll": true,
         "label": "ip",
@@ -2825,7 +2825,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(node_uname_info{job=\"node-exporter\", nodename=~\"$hostname\"},instance)",
+          "query": "label_values(node_uname_info{container=\"node-exporter\", nodename=~\"$hostname\"},instance)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,

--- a/soperator/modules/monitoring/templates/dashboards/update-dashboards.sh
+++ b/soperator/modules/monitoring/templates/dashboards/update-dashboards.sh
@@ -68,5 +68,10 @@ if [ $updated_count -eq 0 ]; then
     echo "✅ All dashboards are up to date!"
 else
     echo "✅ Updated $updated_count dashboard(s), skipped $skipped_count unchanged"
-    echo "⏳ Wait 30s for Grafana to reload dashboards automatically"
+    echo "⏳ Waiting for Grafana to reload dashboards automatically..."
+    for i in {30..1}; do
+        printf "\r⏳ Wait for %2d seconds..." "$i"
+        sleep 1
+    done
+    printf "\r✅ Done waiting! Dashboards should be reloaded.\n"
 fi

--- a/soperator/modules/monitoring/templates/dashboards/workers_overview.json
+++ b/soperator/modules/monitoring/templates/dashboards/workers_overview.json
@@ -4280,7 +4280,7 @@
           "type": "prometheus",
           "uid": "VictoriaMetrics"
         },
-        "definition": "label_values(node_uname_info{job=\"node-exporter\", nodename=~\"$hostname\"},instance)",
+        "definition": "label_values(node_uname_info{container=\"node-exporter\", nodename=~\"$hostname\"},instance)",
         "hide": 2,
         "includeAll": true,
         "label": "ip",
@@ -4289,7 +4289,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(node_uname_info{job=\"node-exporter\", nodename=~\"$hostname\"},instance)",
+          "query": "label_values(node_uname_info{container=\"node-exporter\", nodename=~\"$hostname\"},instance)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
- Added 20-panel Quick Stats section with key cluster metrics (utilization, health, MTBF/MTTR)
- Implemented granular node state visualization (7 quasi-states: Down, Drained, Draining, Busy, Idle, Maintenance, Unknown)
- Enhanced Node Problems table with combined State/Fail Reason columns and improved layout
- Added Finished Jobs table with proper timestamp formatting for terminal job states
- Introduced Worker Node and System Jobs filtering variables with improved query handling
- Updated node-exporter labels from job="node-exporter" to container="node-exporter" across dashboards
- Improved panel descriptions, column widths, and overall dashboard organization
- Added deployment script improvements with countdown timer for Grafana reload
