### PR TITLE
Overwrite Enroot's custom dirs if image disks are used

### DIFF
--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -588,7 +588,7 @@ resources:
                       volumeSourceName: sys-host
                     %{~ if slurm_cluster.node_local_image_storage.enabled ~}
                     - name: enroot-on-image-storage
-                      mountPath: /etc/enroot/enroot.conf.d/image-storage.conf
+                      mountPath: /etc/enroot/enroot.conf.d/custom-dirs.conf
                       subPath: enroot.conf
                       readOnly: true
                       volumeSourceName: image-storage


### PR DESCRIPTION
Otherwise, default value for `ENROOT_DATA_PATH` is used