### PR TITLE
reference module path for helm chart

### DIFF
--- a/k8s-training/helm.tf
+++ b/k8s-training/helm.tf
@@ -68,7 +68,7 @@ resource "helm_release" "nebius_gpu_health_checker" {
   ]
 
   name      = "nebius-gpu-health-checker"
-  chart     = "./npd-helm/nebius-npd-0.2.0.tgz"
+  chart     = "${path.module}/npd-helm/nebius-npd-0.2.0.tgz"
   namespace = "default"
 
   set {


### PR DESCRIPTION
Path to helm chart with `./...` does not work when using `k8s-training` as a module and calling `terraform -chdir=...` in Anyscale solution

## Release Notes (Mandatory Description)