### PR TITLE
add more aws variables for proper cleanup

### DIFF
--- a/soperator/installations/example/.envrc
+++ b/soperator/installations/example/.envrc
@@ -126,6 +126,12 @@ AWS_SECRET_ACCESS_KEY="$(nebius iam v2 access-key get \
   | jq -r '.status.secret')"
 export AWS_SECRET_ACCESS_KEY
 
+AWS_REGION=$NEBIUS_REGION
+export AWS_REGION
+
+AWS_ENDPOINT_URL="https://storage.$AWS_REGION.nebius.cloud:443"
+export AWS_ENDPOINT_URL
+
 # endregion AWS access key
 
 # region Bucket


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Added `AWS_REGION` and `AWS_ENDPOINT_URL` to cleanup backup buckets on destroy in different regions