### PR TITLE
add nfs-system to the allowed namespaces for cleanup

### DIFF
--- a/soperator/modules/cleanup/scripts/disk_cleanup.sh
+++ b/soperator/modules/cleanup/scripts/disk_cleanup.sh
@@ -4,7 +4,7 @@ parent_id=$PARENT_ID
 page_size=100
 page_token=""
 result_ids=()
-allowed_cleanup_namespaces=("logs-system" "monitoring-system" "soperator")
+allowed_cleanup_namespaces=("logs-system" "monitoring-system" "soperator" "nfs-system")
 
 is_allowed_namespace() {
   local ns="$1"


### PR DESCRIPTION
## Release Notes (Mandatory Description)
Add `nfs-system` to the allowed namespaces, so any disk that has label `kubernetes.io/created-for/pvc/namespace: nfs-system` and is not attached to any instance will be deleted during the `terraform destroy`