### PR TITLE
Change soperator release workflow to manual triggering only

### DIFF
--- a/.github/workflows/soperator.yml
+++ b/.github/workflows/soperator.yml
@@ -1,12 +1,7 @@
 name: "Build soperator terraform release"
 
 on:
-  push:
-    branches:
-      - soperator-release-*
-    paths:
-      - soperator/VERSION
-      - soperator/SUBVERSION
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Change to manual triggering, so when we test 1.22.0, it will no longer be called 1.21.14: we can rename it first, and then make a release.

Same was already done in soperator itself: https://github.com/nebius/soperator/pull/1609/files