### PR TITLE
SCHED-300: Complete `wait_for_flux_hr` when Helm release status reason is `UpgradeSucceeded`

### DIFF
--- a/soperator/modules/slurm/scripts/wait_for_flux_hr.sh.tmpl
+++ b/soperator/modules/slurm/scripts/wait_for_flux_hr.sh.tmpl
@@ -48,7 +48,7 @@ for i in $(seq 1 $MAX_RETRIES); do
     RELEASE_STATUS_REASON=$(echo "$RELEASE_STATUS" | jq -r '.reason')
     RELEASE_STATUS_STATUS=$(echo "$RELEASE_STATUS" | jq -r '.status')
     
-    if [ "$RELEASE_STATUS_REASON" == "InstallSucceeded" ] && [ "$RELEASE_STATUS_STATUS" == "True" ]; then
+    if [[ "$RELEASE_STATUS_REASON" == "InstallSucceeded" || "$RELEASE_STATUS_REASON" == "UpgradeSucceeded" ]] && [ "$RELEASE_STATUS_STATUS" == "True" ]; then
       echo "HelmRelease $HELMRELEASE_NAME has been successfully installed."
       echo "Details:"
       echo "$RELEASE_STATUS" | jq .


### PR DESCRIPTION
## Release Notes (Mandatory Description)
Nothing