### PR TITLE
Reserve more RAM for system usage by default

### DIFF
--- a/soperator/modules/available_resources/reserve.tf
+++ b/soperator/modules/available_resources/reserve.tf
@@ -9,7 +9,7 @@ locals {
       count       = 1
     }
     ram = {
-      coefficient = 0.95
+      coefficient = 0.9
       count       = 2
     }
     ephemeral_storage = {


### PR DESCRIPTION
## Release Notes (Mandatory Description)
On Soperator worker nodes 10% of all RAM is reserved for system usage instead of 5%.