### PR TITLE
Soperator: Slurm controller to have node group of size 1

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -327,7 +327,9 @@ module "slurm" {
   operator_stable        = var.slurm_operator_stable
   operator_feature_gates = var.slurm_operator_feature_gates
 
-  maintenance                   = var.maintenance
+  maintenance                    = var.maintenance
+  maintenance_ignore_node_groups = var.maintenance_ignore_node_groups
+
   use_preinstalled_gpu_drivers  = var.use_preinstalled_gpu_drivers
   use_cuda13rc                  = var.slurm_nodeset_workers[0].resource.platform == "gpu-b300-sxm" ? true : false
   controller_state_on_filestore = var.controller_state_on_filestore

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -450,6 +450,12 @@ active_checks_scope = "prod"
 # ---
 slurm_shared_memory_size_gibibytes = 1024
 
+# Node groups that Soperator should ignore during maintenance events.
+# These ignored maintenance events will be handled by mk8s control plane instead.
+# Supported values: controller, nfs, system, login, accounting.
+# ---
+maintenance_ignore_node_groups = ["controller", "nfs"]
+
 # endregion Config
 #----------------------------------------------------------------------------------------------------------------------#
 #                                                                                                                      #

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1074,6 +1074,12 @@ variable "maintenance" {
   }
 }
 
+variable "maintenance_ignore_node_groups" {
+  description = "List of node groups that Soperator should ignore for maintenance events. Supported values: controller, nfs, system, login, accounting."
+  type        = list(string)
+  default     = ["controller", "nfs"]
+}
+
 # endregion Maintenance
 
 # endregion Slurm

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -79,6 +79,16 @@ locals {
     }
   }
 
+  maintenance_ignore_node_labels = flatten([
+    for group in var.maintenance_ignore_node_groups : [
+      for match_value in try(
+        [local.node_filters[group].match],
+        try(local.node_filters[group].matches, [])
+      ) :
+      format("%s=%s", local.node_filters.label.nodeset, match_value)
+    ]
+  ])
+
   resources = {
     munge = {
       cpu               = 0.1

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -134,7 +134,8 @@ resource "helm_release" "soperator_fluxcd_cm" {
       slurm_worker_features     = var.slurm_worker_features
       slurm_health_check_config = var.slurm_health_check_config
 
-      k8s_node_filters = local.node_filters
+      k8s_node_filters               = local.node_filters
+      maintenance_ignore_node_labels = local.maintenance_ignore_node_labels
 
       node_local_jail_submounts = var.node_local_jail_submounts
       node_local_image_storage  = var.node_local_image_storage

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -930,7 +930,7 @@ resources:
               checks:
                 manager:
                   env:
-                    maintenanceIgnoreNodeLabels: "${slurm_cluster.k8s_node_filters.label.nodeset}=${slurm_cluster.k8s_node_filters.controller.match},${slurm_cluster.k8s_node_filters.label.nodeset}=${slurm_cluster.k8s_node_filters.nfs.match}"
+                    maintenanceIgnoreNodeLabels: "${join(",", slurm_cluster.maintenance_ignore_node_labels)}"
                   resources:
                     requests:
                       memory: ${resources.slurm_operator.requests.memory}Gi

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -446,6 +446,20 @@ variable "maintenance" {
   }
 }
 
+variable "maintenance_ignore_node_groups" {
+  description = "List of node groups that Soperator should ignore for maintenance events. Supported values: controller, nfs, system, login, accounting."
+  type        = list(string)
+  default     = ["controller", "nfs"]
+
+  validation {
+    condition = alltrue([
+      for group in var.maintenance_ignore_node_groups :
+      contains(["system", "controller", "login", "accounting", "nfs"], group)
+    ])
+    error_message = "maintenance_ignore_node_groups must only contain: system, controller, login, accounting, nfs."
+  }
+}
+
 # endregion Maintenance
 
 # region NodeConfigurator


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Changing Slurm Controller node set and additional parameter setting to make use of new Soperator feature to skip maintenance handling for nodes based on their labels. The aim is to have the underlying platform (Managed K8S in this case) to handle the maintenance event instead of Soperator for some node groups.