### PR TITLE
[SCHED-541] disk_cleanup.sh hides errors

### DIFF
--- a/soperator/modules/cleanup/scripts/disk_cleanup.sh
+++ b/soperator/modules/cleanup/scripts/disk_cleanup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 parent_id=$PARENT_ID
 page_size=100


### PR DESCRIPTION
## Problem

Errors in disk_cleanup.sh are ignored, it takes long time to investigate issues.

## Solution

Use proper bash flags.