### PR TITLE
[SCHED-540] E2E broken: wrong helmrelease name

### DIFF
--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -7,7 +7,7 @@ resource "terraform_data" "wait_for_slurm_cluster_hr" {
     interpreter = ["/bin/bash", "-c"]
     command = templatefile("${path.module}/scripts/wait_for_flux_hr.sh.tmpl", {
       k8s_cluster_context = var.k8s_cluster_context
-      helmrelease_name    = "flux-system-soperator-fluxcd-slurm-cluster"
+      helmrelease_name    = "soperator-fluxcd-slurm-cluster"
       timeout_minutes     = 60
     })
   }
@@ -22,7 +22,7 @@ resource "terraform_data" "wait_for_soperator_activechecks_hr" {
     interpreter = ["/bin/bash", "-c"]
     command = templatefile("${path.module}/scripts/wait_for_flux_hr.sh.tmpl", {
       k8s_cluster_context = var.k8s_cluster_context
-      helmrelease_name    = "flux-system-soperator-fluxcd-soperator-activechecks"
+      helmrelease_name    = "soperator-fluxcd-soperator-activechecks"
       timeout_minutes     = 120
     })
   }


### PR DESCRIPTION
## Problem

Cluster provisioning is broken because the script waits for wrong helm release.
Because helm releases lost "flux-system-" prefix in this PR: https://github.com/nebius/soperator/pull/1854/files

## Solution

Remove prefix

## Testing

https://github.com/nebius/soperator/actions/runs/19857515028