### PR TITLE
SCHED-547: Don't set GPU drivers preset on CPU-only nodes

### DIFF
--- a/soperator/modules/k8s/k8s_ng_workers_v2.tf
+++ b/soperator/modules/k8s/k8s_ng_workers_v2.tf
@@ -90,8 +90,8 @@ resource "nebius_mk8s_v1_node_group" "worker_v2" {
 
     preemptible = var.node_group_workers_v2[count.index].preemptible
 
-    gpu_settings = var.use_preinstalled_gpu_drivers ? {
-      drivers_preset = "cuda12.8"
+    gpu_settings = (var.use_preinstalled_gpu_drivers && local.node_group_gpu_present_v2.worker[count.index]) ? {
+      drivers_preset = module.resources.driver_preset_by_platform[var.node_group_workers_v2[count.index].resource.platform]
     } : null
 
     boot_disk = {


### PR DESCRIPTION
## Release Notes (Mandatory Description)