### PR TITLE
Add mk8s cluster_id as label to metrics

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -293,6 +293,7 @@ module "slurm" {
   cluster_name        = var.company_name
   name                = local.slurm_cluster_name
   k8s_cluster_context = module.k8s.cluster_context
+  k8s_cluster_id      = module.k8s.cluster_id
 
   operator_version = var.slurm_operator_version
   operator_stable  = var.slurm_operator_stable

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -63,6 +63,7 @@ resource "helm_release" "soperator_fluxcd_cm" {
     accounting_enabled = var.accounting_enabled
     iam_tenant_id      = var.iam_tenant_id
     iam_project_id     = var.iam_project_id
+    k8s_cluster_id     = var.k8s_cluster_id
 
     backups_enabled = var.backups_enabled
     backups_config  = var.backups_enabled ? var.backups_config : null

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -129,6 +129,7 @@ resources:
                   externalLabels:
                     iam_tenant_id: ${iam_tenant_id}
                     iam_project_id: ${iam_project_id}
+                    mk8s_cluster_id: ${k8s_cluster_id}
                   resources:
                     requests:
                       memory: ${resources.vm_agent.memory}

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -30,6 +30,11 @@ variable "k8s_cluster_context" {
   nullable    = false
 }
 
+variable "k8s_cluster_id" {
+  description = "ID of the mk8s cluster."
+  type        = string
+}
+
 # region PartitionConfiguration
 
 variable "slurm_partition_config_type" {


### PR DESCRIPTION
## Release Notes (Mandatory Description)

It is useful to have `mk8s_cluster_id` attached to all metrics being forwarded to o11y:

- we can show it on dashboards
- we can join metrics and logs from other sources based on `mk8s_cluster_id` and make usable tables and graphs