### PR TITLE
SCHED-542: Do not cleanup s3 bucket if it doesn't exist

### DIFF
--- a/soperator/modules/backups_store/main.tf
+++ b/soperator/modules/backups_store/main.tf
@@ -25,6 +25,11 @@ if [ $? != 0 ]; then
   exit 0
 fi
 
+if ! aws s3api head-bucket --bucket ${self.triggers_replace.bucket_name} 2>/dev/null; then
+  echo "Bucket ${self.triggers_replace.bucket_name} doesn't exist, skipping cleanup"
+  exit 0
+fi
+
 aws s3 rm s3://${self.triggers_replace.bucket_name}/ --recursive
 EOT
   }


### PR DESCRIPTION
## Problem

If s3 bucket doesn't exist, e.g. was deleted by previous terraform destroy call, but terraform state wasn't saved properly, next terraform destroy fails.

## Solution

Check for existence first