### PR TITLE
SOperator installation example should use no expiring tokens

### DIFF
--- a/soperator/README.md
+++ b/soperator/README.md
@@ -65,7 +65,7 @@ This command loads environment variables and performs several important setup ta
 - Configures Object Storage access for the Terraform state
 - Exports environment variables with resource IDs 
 
-Check that NEBIUS_IAM_TOKEN is valid:
+Check that nebius CLI is authenticated:
 ```bash
 nebius iam whoami
 ```

--- a/soperator/installations/example/.envrc
+++ b/soperator/installations/example/.envrc
@@ -16,27 +16,6 @@ if [ -z "${NEBIUS_PROJECT_ID}" ]; then
   return 1
 fi
 
-# region IAM token
-
-unset NEBIUS_IAM_TOKEN
-nebius iam whoami > /dev/null
-nebius iam get-access-token > /dev/null
-NEBIUS_IAM_TOKEN=$(nebius iam get-access-token)
-export NEBIUS_IAM_TOKEN
-
-if [ -f "$HOME/.nebius/credentials.yaml" ]; then
-  IAM_TOKEN_EXPIRES_AT=$(yq '.tokens[].expires_at' "$HOME/.nebius/credentials.yaml" 2>/dev/null)
-  if [ -n "$IAM_TOKEN_EXPIRES_AT" ]; then
-    if [[ "$(uname)" == "Darwin" ]]; then
-      echo "IAM token expires at: $(date -r "$IAM_TOKEN_EXPIRES_AT")"
-    else
-      echo "IAM token expires at: $(date -d @"$IAM_TOKEN_EXPIRES_AT")"
-    fi
-  fi
-fi
-
-# endregion IAM token
-
 # region VPC subnet
 
 NEBIUS_VPC_SUBNET_ID=$(nebius vpc subnet list \
@@ -209,7 +188,6 @@ EOF
 # region TF variables
 
 export TF_VAR_region="${NEBIUS_REGION}"
-export TF_VAR_iam_token="${NEBIUS_IAM_TOKEN}"
 export TF_VAR_iam_tenant_id="${NEBIUS_TENANT_ID}"
 export TF_VAR_iam_project_id="${NEBIUS_PROJECT_ID}"
 export TF_VAR_o11y_iam_tenant_id="${NEBIUS_OLLY_TENANT_ID}"

--- a/soperator/installations/example/terraform.tf
+++ b/soperator/installations/example/terraform.tf
@@ -34,7 +34,16 @@ terraform {
 }
 
 provider "nebius" {
-  domain = "api.eu.nebius.cloud:443"
+  domain  = "api.eu.nebius.cloud:443"
+  profile = {}
+}
+
+locals {
+  kubernetes_exec = {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "nebius"
+    args        = ["mk8s", "v1", "cluster", "get-token", "--format", "json"]
+  }
 }
 
 provider "units" {}
@@ -44,14 +53,18 @@ provider "string-functions" {}
 provider "kubernetes" {
   host                   = module.k8s.control_plane.public_endpoint
   cluster_ca_certificate = module.k8s.control_plane.cluster_ca_certificate
-  token                  = var.iam_token
+  exec {
+    api_version = local.kubernetes_exec.api_version
+    command     = local.kubernetes_exec.command
+    args        = local.kubernetes_exec.args
+  }
 }
 
 provider "flux" {
   kubernetes = {
     host                   = module.k8s.control_plane.public_endpoint
     cluster_ca_certificate = module.k8s.control_plane.cluster_ca_certificate
-    token                  = var.iam_token
+    exec                   = local.kubernetes_exec
   }
 }
 
@@ -59,7 +72,11 @@ provider "helm" {
   kubernetes {
     host                   = module.k8s.control_plane.public_endpoint
     cluster_ca_certificate = module.k8s.control_plane.cluster_ca_certificate
-    token                  = var.iam_token
+    exec {
+      api_version = local.kubernetes_exec.api_version
+      command     = local.kubernetes_exec.command
+      args        = local.kubernetes_exec.args
+    }
   }
 }
 

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -14,13 +14,6 @@ resource "terraform_data" "check_region" {
   }
 }
 
-variable "iam_token" {
-  description = "IAM token used for communicating with Nebius services."
-  type        = string
-  nullable    = false
-  sensitive   = true
-}
-
 variable "iam_project_id" {
   description = "ID of the IAM project."
   type        = string


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Now there is no need to rerun `.envrc` just to refresh tokens.