### PR TITLE
Add reusable Tailscale and External Secrets modules

### DIFF
--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -242,7 +242,7 @@ variable "mig_parted_config" {
   default     = null
 
   validation {
-    condition = var.mig_parted_config == null || contains(
+    condition = var.mig_parted_config == null ? true : contains(
       lookup(local.valid_mig_parted_configs, local.gpu_nodes_platform, []),
       var.mig_parted_config,
     )

--- a/modules/external-secret-mysterybox/README.md
+++ b/modules/external-secret-mysterybox/README.md
@@ -1,0 +1,229 @@
+#####################################################################
+# NOTE: This is a module and should not be run manually or standalone
+#####################################################################
+
+Creates an External Secrets `SecretStore` or `ClusterSecretStore` for Nebius
+MysteryBox and an `ExternalSecret` that syncs one MysteryBox secret into a
+Kubernetes Secret.
+
+Use this module when Terraform-managed workloads need a Kubernetes Secret
+reference but should not read the underlying secret value into Terraform
+variables or state.
+
+What this module manages:
+
+- An optional namespace for the ExternalSecret target Secret
+- An optional `SecretStore` or `ClusterSecretStore` for the Nebius MysteryBox
+  provider
+- One `ExternalSecret` that extracts all key/value pairs from one MysteryBox
+  secret into one Kubernetes Secret
+
+What this module does not manage:
+
+- Nebius service account creation
+- Nebius MysteryBox secret creation
+- External Secrets Operator installation
+- Any consumer-specific wiring beyond exposing the resulting Secret name
+- The bootstrap Kubernetes Secret that holds the Nebius Subject Credentials JSON
+  used by the External Secrets provider
+
+Creation boundary:
+
+- Created outside Terraform:
+  - The Nebius MysteryBox secret identified by `mysterybox_secret_id`
+  - The Nebius service account used by External Secrets
+  - The permissions that allow that service account to read MysteryBox payloads
+  - The Subject Credentials JSON for that service account
+  - The bootstrap Kubernetes Secret that stores that JSON
+- Created by this module in Terraform:
+  - The target namespace when `create_namespace = true`
+  - The `SecretStore` or `ClusterSecretStore` when `create_secret_store = true`
+  - The `ExternalSecret`
+  - The synced target Kubernetes Secret
+
+Inputs:
+
+- `namespace`
+- `create_namespace`
+- `secret_store_kind`
+- `secret_store_name`
+- `create_secret_store`
+- `api_domain`
+- `service_account_credentials_secret_name`
+- `service_account_credentials_secret_key`
+- `ca_provider_secret_name`
+- `ca_provider_secret_key`
+- `external_secret_name`
+- `target_secret_name`
+- `mysterybox_secret_id`
+- `mysterybox_secret_version`
+- `refresh_interval`
+- `creation_policy`
+- `deletion_policy`
+
+Outputs:
+
+- `namespace`
+- `secret_store_name`
+- `secret_store_kind`
+- `external_secret_name`
+- `secret_name`
+- `mysterybox_secret_id`
+
+Example usage:
+
+```hcl
+module "app_secret" {
+  source = "../../modules/external-secret-mysterybox"
+
+  namespace                               = "my-app"
+  create_namespace                        = true
+  secret_store_name                       = "nebius-mysterybox"
+  service_account_credentials_secret_name = "nebius-mysterybox-sa-credentials"
+  service_account_credentials_secret_key  = "subject-credentials.json"
+  target_secret_name                      = "my-app-secret"
+  mysterybox_secret_id                    = var.mysterybox_secret_id
+
+  providers = {
+    kubernetes = kubernetes
+    kubectl    = kubectl
+  }
+}
+```
+
+- If `create_namespace = false`, the target namespace must already exist.
+
+Recommended secret flow:
+
+1. Keep the real secret value in Nebius MysteryBox.
+2. Use External Secrets to sync that value into Kubernetes.
+3. Pass only the resulting Kubernetes Secret name to downstream modules that
+   consume Kubernetes Secrets.
+
+This is better than reading the secret value into Terraform variables because it
+keeps the secret material out of Terraform plan output, provider configuration,
+and most state paths.
+
+Only roots that actually choose this MysteryBox + External Secrets composition
+need a `mysterybox_secret_id` variable. Consumers that use inline credentials
+or an already-existing Kubernetes Secret do not need this module at all.
+
+Version behavior:
+
+- If `mysterybox_secret_version` is unset, External Secrets follows the
+  MysteryBox primary version and updates the Kubernetes Secret on the next
+  refresh after the primary version changes.
+- If `mysterybox_secret_version` is set, the sync is pinned to that exact
+  MysteryBox version until Terraform is updated to point at a different one.
+
+Expected MysteryBox and Kubernetes Secret structure:
+
+- Store the source secret in MysteryBox as a structured secret whose keys
+  already match the contract expected by the consuming chart, operator, or
+  application.
+- This module uses `dataFrom.extract`, so every key/value pair from the
+  MysteryBox secret is copied into the target Kubernetes Secret.
+- That means the target Kubernetes Secret schema is determined by the source
+  MysteryBox secret schema and by the expectations of the downstream consumer.
+
+Consumer-specific guidance:
+
+- Keep application- or chart-specific key naming requirements in the
+  downstream consumer documentation, not here.
+- For example, if a consumer expects keys such as `username` / `password` or
+  `client_id` / `client_secret`, shape the MysteryBox secret accordingly and
+  document that requirement with that consumer module.
+
+Authentication notes:
+
+- The Nebius MysteryBox External Secrets provider currently supports service
+  account credentials authentication through
+  `serviceAccountCredsSecretRef`, and the API spec also exposes
+  `tokenSecretRef`.
+- The referenced Kubernetes Secret must hold the Nebius Subject Credentials JSON
+  document under the key you pass in
+  `service_account_credentials_secret_key`.
+- Treat that referenced Kubernetes Secret as bootstrap infrastructure and create
+  it out of band. If Terraform creates it, the credential JSON lands in
+  Terraform state.
+
+Bootstrap sequence:
+
+Out of band before Terraform:
+
+1. Create a Nebius service account for External Secrets.
+2. Grant that service account permission to read MysteryBox payloads for the
+   secrets you want to sync.
+3. Generate Nebius Subject Credentials JSON for that service account.
+4. Create the bootstrap Kubernetes Secret that External Secrets will use for
+   authentication.
+
+Created by Terraform after those steps:
+
+5. Run Terraform for `external-secret-mysterybox` and any downstream consumer
+   modules.
+
+Example bootstrap Secret creation:
+
+```bash
+kubectl create secret generic nebius-mysterybox-sa-credentials \
+  -n my-app \
+  --from-file=subject-credentials.json=/path/to/subject-credentials.json
+```
+
+With that Secret in place, set:
+
+```hcl
+service_account_credentials_secret_name = "nebius-mysterybox-sa-credentials"
+service_account_credentials_secret_key  = "subject-credentials.json"
+```
+
+Process timing:
+
+- The bootstrap Secret must exist before External Secrets can successfully
+  reconcile the `SecretStore` and `ExternalSecret`.
+- In practice, that means the target namespace must exist first, then the
+  bootstrap Secret must be created, and only then can the secret-sync modules
+  complete successfully.
+- If this module is also creating the target namespace, apply once to create
+  the namespace, create the bootstrap Secret out of band, and then apply again
+  so the `SecretStore` and `ExternalSecret` can reconcile successfully.
+
+Current limitation:
+
+- This bootstrap step exists because the Nebius MysteryBox provider in External
+  Secrets
+  (<https://external-secrets.io/main/provider/nebius-mysterybox/>) currently
+  documents only secret-backed auth methods for Nebius.
+- If the provider later adds alternatives such as workload identity, pod
+  identity, metadata-based auth, or direct Kubernetes service-account
+  references, this bootstrap Secret requirement could go away.
+
+Design notes:
+
+- `secret_store_kind` defaults to `SecretStore` because namespace-scoped stores
+  are usually easier to reason about and safer for tenant isolation.
+- Set `create_secret_store = false` when your cluster already has a shared
+  `SecretStore` or `ClusterSecretStore` and you only need a new `ExternalSecret`
+  plus target Secret.
+- This module intentionally outputs only secret references and IDs, never the
+  secret value itself.
+
+Best practices:
+
+- Prefer passing `module.<name>.secret_name` into downstream modules instead of
+  copying or re-exporting the underlying secret value.
+- Keep the External Secrets Operator lifecycle separate from the consuming app
+  modules.
+- Keep the bootstrap Nebius Subject Credentials JSON out of Terraform and create
+  the corresponding Kubernetes Secret with `kubectl` or another out-of-band
+  secret delivery path.
+- Use MysteryBox version pinning through `mysterybox_secret_version` when you
+  need a controlled rollout instead of following the primary version.
+
+References:
+
+- External Secrets Nebius MysteryBox provider:
+  <https://external-secrets.io/main/provider/nebius-mysterybox/>
+- External Secrets API specification:
+  <https://external-secrets.io/main/api/spec/>

--- a/modules/external-secret-mysterybox/main.tf
+++ b/modules/external-secret-mysterybox/main.tf
@@ -1,0 +1,123 @@
+locals {
+  external_secret_name = (
+    var.external_secret_name != null && trimspace(var.external_secret_name) != ""
+    ? trimspace(var.external_secret_name)
+    : var.target_secret_name
+  )
+
+  secret_store_manifest = {
+    apiVersion = "external-secrets.io/v1"
+    kind       = var.secret_store_kind
+    metadata = merge(
+      {
+        name = var.secret_store_name
+      },
+      var.secret_store_kind == "SecretStore" ? {
+        namespace = var.namespace
+      } : {}
+    )
+    spec = {
+      provider = {
+        nebiusmysterybox = merge(
+          {
+            apiDomain = var.api_domain
+            auth = {
+              serviceAccountCredsSecretRef = {
+                name = var.service_account_credentials_secret_name != null ? trimspace(var.service_account_credentials_secret_name) : ""
+                key  = var.service_account_credentials_secret_key != null ? trimspace(var.service_account_credentials_secret_key) : ""
+              }
+            }
+          },
+          var.ca_provider_secret_name != null && trimspace(var.ca_provider_secret_name) != "" ? {
+            caProvider = {
+              certSecretRef = {
+                name = trimspace(var.ca_provider_secret_name)
+                key  = trimspace(var.ca_provider_secret_key)
+              }
+            }
+          } : {}
+        )
+      }
+    }
+  }
+
+  external_secret_manifest = {
+    apiVersion = "external-secrets.io/v1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = local.external_secret_name
+      namespace = var.namespace
+    }
+    spec = merge(
+      {
+        refreshInterval = var.refresh_interval
+        secretStoreRef = {
+          kind = var.secret_store_kind
+          name = var.secret_store_name
+        }
+        target = merge(
+          {
+            name           = var.target_secret_name
+            creationPolicy = var.creation_policy
+          },
+          var.deletion_policy != null && trimspace(var.deletion_policy) != "" ? {
+            deletionPolicy = var.deletion_policy
+          } : {}
+        )
+      },
+      var.mysterybox_secret_version != null && trimspace(var.mysterybox_secret_version) != "" ? {
+        dataFrom = [{
+          extract = {
+            key     = var.mysterybox_secret_id
+            version = var.mysterybox_secret_version
+          }
+        }]
+        } : {
+        dataFrom = [{
+          extract = {
+            key = var.mysterybox_secret_id
+          }
+        }]
+      }
+    )
+  }
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "kubectl_manifest" "secret_store" {
+  count = var.create_secret_store ? 1 : 0
+
+  yaml_body = yamlencode(local.secret_store_manifest)
+
+  lifecycle {
+    precondition {
+      condition = (
+        var.service_account_credentials_secret_name != null &&
+        trimspace(var.service_account_credentials_secret_name) != "" &&
+        var.service_account_credentials_secret_key != null &&
+        trimspace(var.service_account_credentials_secret_key) != ""
+      )
+      error_message = "service_account_credentials_secret_name and service_account_credentials_secret_key must be set when create_secret_store is true."
+    }
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.this,
+  ]
+}
+
+resource "kubectl_manifest" "external_secret" {
+  yaml_body = yamlencode(local.external_secret_manifest)
+
+  depends_on = [
+    kubernetes_namespace_v1.this,
+    kubectl_manifest.secret_store,
+  ]
+}

--- a/modules/external-secret-mysterybox/outputs.tf
+++ b/modules/external-secret-mysterybox/outputs.tf
@@ -1,0 +1,33 @@
+output "namespace" {
+  description = "Namespace where the ExternalSecret and target Secret are managed."
+  value       = var.namespace
+}
+
+output "secret_store_name" {
+  description = "Name of the SecretStore or ClusterSecretStore referenced by the ExternalSecret."
+  value       = var.secret_store_name
+}
+
+output "secret_store_kind" {
+  description = "Kind of store referenced by the ExternalSecret."
+  value       = var.secret_store_kind
+}
+
+output "external_secret_name" {
+  description = "Name of the ExternalSecret resource."
+  value = (
+    var.external_secret_name != null && trimspace(var.external_secret_name) != ""
+    ? trimspace(var.external_secret_name)
+    : var.target_secret_name
+  )
+}
+
+output "secret_name" {
+  description = "Name of the target Kubernetes Secret populated from MysteryBox."
+  value       = var.target_secret_name
+}
+
+output "mysterybox_secret_id" {
+  description = "Nebius MysteryBox secret ID that backs the target Kubernetes Secret."
+  value       = var.mysterybox_secret_id
+}

--- a/modules/external-secret-mysterybox/variables.tf
+++ b/modules/external-secret-mysterybox/variables.tf
@@ -1,0 +1,121 @@
+variable "namespace" {
+  description = "Namespace where the ExternalSecret target Secret will be created."
+  type        = string
+}
+
+variable "create_namespace" {
+  description = "Whether to create the namespace used by the ExternalSecret and, when applicable, the SecretStore."
+  type        = bool
+  default     = false
+}
+
+variable "secret_store_kind" {
+  description = "Kind of External Secrets store reference to use."
+  type        = string
+  default     = "SecretStore"
+
+  validation {
+    condition     = contains(["SecretStore", "ClusterSecretStore"], var.secret_store_kind)
+    error_message = "secret_store_kind must be SecretStore or ClusterSecretStore."
+  }
+}
+
+variable "secret_store_name" {
+  description = "Name of the SecretStore or ClusterSecretStore used by the ExternalSecret."
+  type        = string
+}
+
+variable "create_secret_store" {
+  description = "Whether to create the referenced SecretStore or ClusterSecretStore."
+  type        = bool
+  default     = true
+}
+
+variable "api_domain" {
+  description = "Nebius API domain used by the External Secrets MysteryBox provider."
+  type        = string
+  default     = "api.nebius.cloud:443"
+}
+
+variable "service_account_credentials_secret_name" {
+  description = "Name of the Kubernetes Secret that stores Nebius service account credentials in Subject Credentials JSON format. Required when create_secret_store is true."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "service_account_credentials_secret_key" {
+  description = "Key inside the Kubernetes Secret that stores the Nebius service account credentials JSON. Required when create_secret_store is true."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "ca_provider_secret_name" {
+  description = "Optional Secret name that holds a custom CA certificate for the MysteryBox API endpoint."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "ca_provider_secret_key" {
+  description = "Key inside the custom CA Secret that contains the certificate. Required when ca_provider_secret_name is set."
+  type        = string
+  default     = "ca.crt"
+}
+
+variable "external_secret_name" {
+  description = "Optional name for the ExternalSecret resource. Defaults to target_secret_name."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "target_secret_name" {
+  description = "Name of the Kubernetes Secret that External Secrets should keep reconciled from MysteryBox."
+  type        = string
+}
+
+variable "mysterybox_secret_id" {
+  description = "Nebius MysteryBox secret ID to extract into the target Kubernetes Secret."
+  type        = string
+}
+
+variable "mysterybox_secret_version" {
+  description = "Optional MysteryBox secret version. If unset, External Secrets uses the primary version."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "refresh_interval" {
+  description = "How often External Secrets should refresh the target Secret from MysteryBox."
+  type        = string
+  default     = "1h"
+}
+
+variable "creation_policy" {
+  description = "External Secrets target creation policy."
+  type        = string
+  default     = "Owner"
+
+  validation {
+    condition     = contains(["Owner", "Orphan", "Merge", "None"], var.creation_policy)
+    error_message = "creation_policy must be Owner, Orphan, Merge, or None."
+  }
+}
+
+variable "deletion_policy" {
+  description = "Optional External Secrets target deletion policy."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition = (
+      var.deletion_policy == null ||
+      contains(["Delete", "Merge", "Retain"], var.deletion_policy)
+    )
+    error_message = "deletion_policy must be null, Delete, Merge, or Retain."
+  }
+}

--- a/modules/external-secret-mysterybox/versions.tf
+++ b/modules/external-secret-mysterybox/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.0.1"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.19.0"
+    }
+  }
+}

--- a/modules/external-secrets-operator/README.md
+++ b/modules/external-secrets-operator/README.md
@@ -1,0 +1,139 @@
+#####################################################################
+# NOTE: This is a module and should not be run manually or standalone
+#####################################################################
+
+Installs the External Secrets Operator into a Kubernetes cluster with Helm.
+
+Use this module when workloads in the cluster need to consume Kubernetes
+Secrets that are synced from an external system such as Nebius MysteryBox.
+
+What this module manages:
+
+- An optional namespace for the External Secrets Operator
+- A Helm release for the External Secrets Operator
+- External Secrets CRD installation when enabled
+
+What this module does not manage:
+
+- Any `SecretStore`, `ClusterSecretStore`, or `ExternalSecret` resources
+- Nebius service account creation
+- Nebius MysteryBox secret creation
+- Consumer-specific secret wiring
+
+Creation boundary:
+
+- Created outside Terraform:
+  - The Nebius service account used by the MysteryBox provider
+  - The permissions that allow that service account to read MysteryBox payloads
+  - The Subject Credentials JSON for that service account
+  - The bootstrap Kubernetes Secret that stores that JSON
+- Created by this module in Terraform:
+  - The External Secrets namespace when `create_namespace = true`
+  - The External Secrets Operator Helm release and CRDs
+
+Inputs:
+
+- `namespace`
+- `create_namespace`
+- `release_name`
+- `repository_url`
+- `chart_name`
+- `chart_version`
+- `install_crds`
+- `atomic`
+- `wait`
+- `timeout_seconds`
+- `values`
+
+Outputs:
+
+- `namespace`
+- `helm_release_name`
+- `chart_version`
+
+Example usage:
+
+```hcl
+module "external_secrets_operator" {
+  source = "../../modules/external-secrets-operator"
+
+  providers = {
+    kubernetes = kubernetes
+    helm       = helm
+  }
+}
+
+module "app_secret" {
+  source = "../../modules/external-secret-mysterybox"
+
+  namespace                               = "my-app"
+  create_namespace                        = true
+  secret_store_name                       = "nebius-mysterybox"
+  service_account_credentials_secret_name = "nebius-mysterybox-sa-credentials"
+  service_account_credentials_secret_key  = "subject-credentials.json"
+  target_secret_name                      = "my-app-secret"
+  mysterybox_secret_id                    = var.mysterybox_secret_id
+
+  depends_on = [module.external_secrets_operator]
+
+  providers = {
+    kubernetes = kubernetes
+    kubectl    = kubectl
+  }
+}
+```
+
+- If the target namespace already exists, you can leave
+  `create_namespace = false` in the downstream secret-sync module.
+
+
+Recommended layering:
+
+1. Install `external-secrets-operator`
+2. Sync provider-backed secrets with `external-secret-mysterybox`
+3. Pass only the resulting Kubernetes Secret name into consumer modules
+
+Only the roots that opt into this provider-backed secret flow need to carry a
+MysteryBox secret ID variable. This module itself stays generic and does not
+assume any specific consumer.
+
+Bootstrap note:
+
+- External Secrets still needs one bootstrap credential so it can talk to the
+  upstream secret backend.
+- For the Nebius MysteryBox provider, that bootstrap credential is a
+  Kubernetes Secret containing Nebius Subject Credentials JSON for a service
+  account with MysteryBox read access.
+- Create that bootstrap Secret out of band instead of through Terraform. If
+  Terraform creates it, the service-account credential material ends up in
+  Terraform state, which defeats the point of this pattern.
+- The current Nebius provider docs for External Secrets
+  (<https://external-secrets.io/main/provider/nebius-mysterybox/>) describe
+  only secret-backed auth for MysteryBox. That is why this bootstrap Secret
+  still exists in the process today.
+
+Recommended order of operations for the Nebius MysteryBox path:
+
+Out of band before Terraform:
+
+1. Create the Nebius service account and grant it MysteryBox read access.
+2. Generate the Subject Credentials JSON for that service account.
+3. Create the bootstrap Kubernetes Secret containing that JSON in the target
+   namespace.
+
+Created by Terraform:
+
+4. Install `external-secrets-operator`.
+5. Ensure the target namespace exists. If Terraform will create it through
+   `external-secret-mysterybox`, apply once to create the namespace, then
+   create the bootstrap Secret out of band, and then apply again.
+6. Apply `external-secret-mysterybox` to create the `SecretStore`,
+   `ExternalSecret`, and synced target Secret.
+7. Apply the downstream consumer that references the synced Kubernetes Secret.
+
+References:
+
+- External Secrets Operator getting started:
+  <https://external-secrets.io/latest/introduction/getting-started/>
+- External Secrets Nebius MysteryBox provider:
+  <https://external-secrets.io/main/provider/nebius-mysterybox/>

--- a/modules/external-secrets-operator/main.tf
+++ b/modules/external-secrets-operator/main.tf
@@ -1,0 +1,27 @@
+resource "kubernetes_namespace_v1" "this" {
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "helm_release" "this" {
+  depends_on = [kubernetes_namespace_v1.this]
+
+  name             = var.release_name
+  repository       = var.repository_url
+  chart            = var.chart_name
+  version          = var.chart_version
+  namespace        = var.namespace
+  create_namespace = false
+  atomic           = var.atomic
+  wait             = var.wait
+  timeout          = var.timeout_seconds
+
+  values = concat([
+    yamlencode({
+      installCRDs = var.install_crds
+    })
+  ], var.values)
+}

--- a/modules/external-secrets-operator/outputs.tf
+++ b/modules/external-secrets-operator/outputs.tf
@@ -1,0 +1,14 @@
+output "namespace" {
+  description = "Namespace where the External Secrets Operator is installed."
+  value       = var.namespace
+}
+
+output "helm_release_name" {
+  description = "Name of the External Secrets Operator Helm release."
+  value       = helm_release.this.name
+}
+
+output "chart_version" {
+  description = "Pinned Helm chart version for the External Secrets Operator release."
+  value       = helm_release.this.version
+}

--- a/modules/external-secrets-operator/variables.tf
+++ b/modules/external-secrets-operator/variables.tf
@@ -1,0 +1,70 @@
+variable "namespace" {
+  description = "Namespace where the External Secrets Operator will be installed."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "create_namespace" {
+  description = "Whether to create the namespace used by the External Secrets Operator."
+  type        = bool
+  default     = true
+}
+
+variable "release_name" {
+  description = "Helm release name for the External Secrets Operator."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "repository_url" {
+  description = "Helm repository URL for the External Secrets Operator chart."
+  type        = string
+  default     = "https://charts.external-secrets.io"
+}
+
+variable "chart_name" {
+  description = "Chart name for the External Secrets Operator release."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "chart_version" {
+  description = "External Secrets Operator Helm chart version."
+  type        = string
+  default     = "2.2.0"
+}
+
+variable "install_crds" {
+  description = "Whether the Helm release should install and manage the External Secrets CRDs."
+  type        = bool
+  default     = true
+}
+
+variable "atomic" {
+  description = "Whether Helm should perform the release as an atomic operation."
+  type        = bool
+  default     = true
+}
+
+variable "wait" {
+  description = "Whether Helm should wait until the External Secrets release is ready."
+  type        = bool
+  default     = true
+}
+
+variable "timeout_seconds" {
+  description = "Timeout, in seconds, for the Helm release install or upgrade."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.timeout_seconds > 0
+    error_message = "timeout_seconds must be greater than zero."
+  }
+}
+
+variable "values" {
+  description = "Additional Helm values documents to pass through to the External Secrets Operator chart."
+  type        = list(string)
+  default     = []
+}

--- a/modules/external-secrets-operator/versions.tf
+++ b/modules/external-secrets-operator/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.0.1"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.17.0, < 4.0.0"
+    }
+  }
+}

--- a/modules/tailscale-operator/README.md
+++ b/modules/tailscale-operator/README.md
@@ -1,0 +1,397 @@
+#####################################################################
+
+# NOTE: This is a module and should not be run manually or standalone
+
+#####################################################################
+
+Installs the Tailscale Kubernetes operator into a cluster and, when needed,
+applies the documented Cilium compatibility workaround for clusters that run
+with kube-proxy replacement.
+
+Call this module once per cluster. After the operator is installed, use
+`modules/tailscale-service` to expose individual Kubernetes services to the
+tailnet.
+
+What this module manages:
+
+- A dedicated namespace for the operator, by default `tailscale`
+- The Tailscale Kubernetes operator Helm release
+- Optional cluster-wide Cilium compatibility configuration for clusters that
+need `bpf-lb-sock-hostns-only=true`
+
+What this module does not manage:
+
+- Tailnet ACL policy
+- Tailscale OAuth client creation
+- Any deployment-specific service exposure
+- Per-service Kubernetes `Service` resources
+
+Creation boundary:
+
+- Created outside Terraform:
+  - The Tailscale OAuth client in the target tailnet
+  - Optional precreated Kubernetes Secrets used with `oauth_secret_name`
+  - Optional MysteryBox secrets, Nebius service-account credentials, and
+    bootstrap Kubernetes Secrets when you choose the External Secrets path
+- Created by this module in Terraform:
+  - The operator namespace when `create_namespace = true`
+  - The Tailscale operator Helm release
+  - Optional Cilium compatibility configuration and restart trigger
+
+Inputs:
+
+- `oauth_client_id`
+- `oauth_client_secret`
+- `oauth_secret_name`
+- `namespace`
+- `create_namespace`
+- `operator_name`
+- `operator_version`
+- `operator_hostname`
+- `default_tags`
+- `enable_cilium_bpf_lb_sock_hostns_only`
+- `restart_cilium_after_config_change`
+- `cilium_namespace`
+- `cilium_config_map_name`
+- `cilium_daemonset_name`
+
+Outputs:
+
+- `namespace`
+- `helm_release_name`
+- `cilium_bpf_lb_sock_hostns_only_enabled`
+
+Example usage:
+
+```hcl
+module "tailscale_operator" {
+  source = "../../modules/tailscale-operator"
+
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
+  operator_hostname   = "ts-operator-${var.cluster_name}"
+  enable_cilium_bpf_lb_sock_hostns_only = true
+
+  providers = {
+    kubernetes = kubernetes
+    helm       = helm
+  }
+}
+```
+
+Secret handling:
+
+- Do not commit the OAuth client ID or secret in `terraform.tfvars`.
+- Inline Terraform variables are still supported, but they should be treated as
+the fallback path:
+
+```bash
+export TF_VAR_tailscale_oauth_client_id="tskey-client-..."
+export TF_VAR_tailscale_oauth_client_secret="tskey-client-secret-..."
+```
+
+- The recommended pattern is to sync the OAuth credentials into a Kubernetes
+Secret and set `oauth_secret_name` explicitly.
+- `oauth_secret_name` must refer to a Secret in the operator namespace, and
+that Secret must contain `client_id` and `client_secret` keys.
+- If the Secret is named `operator-oauth`, that happens to match the Tailscale
+chart's built-in default Secret name, but that is only a convenience. The
+primary contract for this module is the explicit `oauth_secret_name` input.
+- If you use a different Secret name, the module wires it into the chart
+through `oauthSecretVolume`.
+- If you use Nebius MysteryBox plus External Secrets to create that Kubernetes
+Secret, the MysteryBox secret ID belongs to the root-module composition that
+calls `external-secret-mysterybox`; it is not an input to
+`tailscale-operator` itself.
+- Keep real values in local environment files only when you are using the
+inline-variable path. If an example installation needs documentation, use
+comments or empty placeholders rather than real values.
+- See `Deployment recipes` below for the full precreated-Secret and
+MysteryBox-plus-External-Secrets flows.
+
+Deployment recipes:
+
+Choose exactly one of these patterns for supplying the operator's OAuth
+credentials.
+
+Recipe 1: Inline Terraform variables
+
+Use this when you want the shortest path and accept that the OAuth values are
+being supplied directly to Terraform at apply time.
+
+Prerequisites:
+
+1. Create a Tailscale OAuth client in the target tailnet.
+2. Have a working Kubernetes cluster plus Terraform `kubernetes` and `helm`
+  providers.
+
+Created outside Terraform:
+
+- The Tailscale OAuth client
+- The local environment variables that supply the OAuth values
+
+Created by Terraform:
+
+- The Tailscale operator namespace and Helm release
+- Optional Cilium compatibility configuration
+
+Steps:
+
+1. Export the OAuth values locally:
+
+```bash
+export TF_VAR_tailscale_oauth_client_id="tskey-client-..."
+export TF_VAR_tailscale_oauth_client_secret="tskey-client-secret-..."
+```
+
+1. Call `tailscale-operator` with inline credentials:
+
+```hcl
+module "tailscale_operator" {
+  source = "../../modules/tailscale-operator"
+
+  oauth_client_id     = var.tailscale_oauth_client_id
+  oauth_client_secret = var.tailscale_oauth_client_secret
+  operator_hostname   = "ts-operator-${var.cluster_name}"
+
+  providers = {
+    kubernetes = kubernetes
+    helm       = helm
+  }
+}
+```
+
+Recipe 2: Precreated Kubernetes Secret
+
+Use this when another system already creates Kubernetes Secrets for you, or
+when you want to keep OAuth values out of Terraform inputs without adopting
+External Secrets.
+
+Prerequisites:
+
+1. Create a Tailscale OAuth client in the target tailnet.
+2. Have a working Kubernetes cluster plus Terraform `kubernetes` and `helm`
+  providers.
+3. Create a Kubernetes Secret in the operator namespace containing:
+  - `client_id`
+  - `client_secret`
+
+Created outside Terraform:
+
+- The Tailscale OAuth client
+- The Kubernetes Secret referenced by `oauth_secret_name`
+
+Created by Terraform:
+
+- The Tailscale operator namespace and Helm release
+- Optional Cilium compatibility configuration
+
+Example Secret creation:
+
+```bash
+kubectl create secret generic operator-oauth \
+  -n tailscale \
+  --from-literal=client_id='tskey-client-...' \
+  --from-literal=client_secret='tskey-client-secret-...'
+```
+
+Steps:
+
+1. Create the Kubernetes Secret before running Terraform for this module.
+2. Reference it explicitly:
+
+```hcl
+module "tailscale_operator" {
+  source = "../../modules/tailscale-operator"
+
+  oauth_secret_name = "operator-oauth"
+  operator_hostname = "ts-operator-${var.cluster_name}"
+
+  providers = {
+    kubernetes = kubernetes
+    helm       = helm
+  }
+}
+```
+
+Recipe 3: Nebius MysteryBox plus External Secrets
+
+Use this when you want the OAuth values stored in MysteryBox and synced into
+Kubernetes without Terraform ever reading the actual secret payload.
+
+Prerequisites:
+
+1. Create a Tailscale OAuth client in the target tailnet.
+2. Create a MysteryBox secret containing:
+  - `client_id`
+  - `client_secret`
+3. Have a working Kubernetes cluster plus Terraform `kubernetes`, `helm`, and
+  `kubectl` providers.
+4. Create a Nebius service account for External Secrets.
+5. Grant that service account permission to read MysteryBox payloads.
+6. Generate Nebius Subject Credentials JSON for that service account.
+7. Create the bootstrap Kubernetes Secret that External Secrets will use for
+  authentication.
+
+Created outside Terraform:
+
+- The Tailscale OAuth client
+- The MysteryBox secret containing `client_id` and `client_secret`
+- The Nebius service account used by External Secrets
+- The service account's Nebius permissions
+- The Subject Credentials JSON for that service account
+- The bootstrap Kubernetes Secret that stores that JSON
+
+Created by Terraform:
+
+- The External Secrets Operator release
+- The `SecretStore` and `ExternalSecret` that sync the MysteryBox secret
+- The synced Kubernetes Secret consumed by `tailscale-operator`
+- The Tailscale operator namespace and Helm release
+- Optional Cilium compatibility configuration
+
+Bootstrap Secret example:
+
+```bash
+kubectl create secret generic nebius-mysterybox-sa-credentials \
+  -n tailscale \
+  --from-file=subject-credentials.json=/path/to/subject-credentials.json
+```
+
+Recommended order:
+
+1. Install `external-secrets-operator`.
+2. Ensure the operator namespace exists.
+   If you want Terraform to create that namespace, apply once to create it,
+   then create the bootstrap Secret out of band, and then apply again for the
+   secret-sync and operator modules.
+3. Create the bootstrap Secret in that namespace.
+4. Apply `external-secret-mysterybox` to sync the OAuth secret into Kubernetes.
+5. Apply `tailscale-operator` with `oauth_secret_name` pointing at the synced
+  Secret.
+
+Example composition:
+
+```hcl
+module "external_secrets_operator" {
+  source = "../../modules/external-secrets-operator"
+
+  providers = {
+    kubernetes = kubernetes
+    helm       = helm
+  }
+}
+
+module "tailscale_oauth_secret" {
+  source = "../../modules/external-secret-mysterybox"
+
+  namespace                               = "tailscale"
+  create_namespace                        = false
+  secret_store_name                       = "nebius-mysterybox"
+  service_account_credentials_secret_name = "nebius-mysterybox-sa-credentials"
+  service_account_credentials_secret_key  = "subject-credentials.json"
+  target_secret_name                      = "tailscale-operator-oauth"
+  mysterybox_secret_id                    = var.mysterybox_secret_id
+
+  providers = {
+    kubernetes = kubernetes
+    kubectl    = kubectl
+  }
+
+  depends_on = [module.external_secrets_operator]
+}
+
+module "tailscale_operator" {
+  source = "../../modules/tailscale-operator"
+
+  oauth_secret_name = module.tailscale_oauth_secret.secret_name
+  operator_hostname = "ts-operator-${var.cluster_name}"
+
+  providers = {
+    kubernetes = kubernetes
+    helm       = helm
+  }
+}
+```
+
+Important limitation:
+
+- This bootstrap Secret exists because the current Nebius MysteryBox provider
+in External Secrets
+([https://external-secrets.io/main/provider/nebius-mysterybox/](https://external-secrets.io/main/provider/nebius-mysterybox/)) documents
+only secret-backed auth methods for Nebius.
+- If the provider later adds workload identity, pod identity,
+metadata/default-credential-chain auth, or direct Kubernetes service-account
+references, this bootstrap step could become unnecessary.
+
+Safe OAuth rotation with External Secrets:
+
+- This path was validated with the Nebius MysteryBox plus External Secrets
+  flow by promoting a new MysteryBox version to primary and then creating
+  brand-new Tailscale-backed services on both `k8s-training` and `soperator`.
+- Fresh service creation worked after the new secret version synced into the
+  Kubernetes Secret consumed by `oauth_secret_name`.
+- Cleanup of older operator-managed proxy services is a different path. After
+  revoking the old Tailscale OAuth credential, deleting an older existing
+  proxy-backed Service on `k8s-training` failed cleanup with operator logs
+  showing `401 Unauthorized` and `API token invalid` while deleting the
+  corresponding device.
+- This matches Tailscale's documented trust-credential behavior, where
+  revoking a trust credential immediately revokes API access created from it:
+  [https://tailscale.com/docs/reference/trust-credentials](https://tailscale.com/docs/reference/trust-credentials)
+- The operator's credential usage is documented here:
+  [https://tailscale.com/docs/features/kubernetes-operator](https://tailscale.com/docs/features/kubernetes-operator)
+
+Recommended rotation order:
+
+1. Create the new OAuth credential and store it in a new MysteryBox secret
+   version.
+2. Promote that version to primary.
+3. Wait for External Secrets to refresh the Kubernetes Secret referenced by
+   `oauth_secret_name`.
+4. Create a brand-new Tailscale-backed Service and confirm it boots and serves
+   traffic.
+5. Delete any older operator-managed Tailscale Services you still want cleaned
+   up while the old credential is still valid.
+6. Revoke the old OAuth credential only after the fresh-create test succeeds
+   and old-service cleanup is complete.
+
+Operational note:
+
+- If you revoke the old credential first, fresh service creation can still
+  succeed with the new credential, but cleanup of older proxy-backed Services
+  may fail until you intervene manually.
+- A cleaner long-term direction is Tailscale operator workload identity
+  federation, which Tailscale documents as beta in the Kubernetes operator
+  docs, because it avoids long-lived OAuth client secret rotation entirely.
+
+Testing workflow:
+
+1. Create the OAuth client in the target tailnet.
+2. If you are using the External Secrets path, create the MysteryBox secret that
+  stores the Tailscale OAuth `client_id` and `client_secret`.
+3. Choose one credential path:
+  - export the OAuth values locally through `.envrc` or equivalent for the
+   inline-variable path
+  - reference a precreated Kubernetes Secret with `oauth_secret_name`
+  - or sync the OAuth values into a Kubernetes Secret with External Secrets and
+  then pass `oauth_secret_name`
+4. If you use the External Secrets path, first install External Secrets
+   Operator, ensure the target namespace exists, create the Nebius Subject
+   Credentials bootstrap Secret in that namespace, and then apply the
+   secret-sync module.
+5. Run `terraform init` and `terraform validate` in the calling root module.
+6. Apply the operator module once per cluster.
+7. Apply one or more `tailscale-service` modules for the workloads you want to
+  expose.
+8. Confirm the resulting MagicDNS name appears in the tailnet admin console and
+  test connectivity from an authorized device.
+
+Notes:
+
+- This module expects working `kubernetes` and `helm` providers.
+- `enable_cilium_bpf_lb_sock_hostns_only` defaults to `true` because Nebius MK8s  
+clusters use Cilium in a mode that breaks Tailscale proxy return traffic  
+unless `bpf-lb-sock-hostns-only=true` is set. Override it to `false` only if  
+you have confirmed your target cluster does not need the workaround.
+- Manage Tailscale ACLs separately in the tailnet admin console.

--- a/modules/tailscale-operator/main.tf
+++ b/modules/tailscale-operator/main.tf
@@ -1,0 +1,112 @@
+locals {
+  oauth_secret_name_normalized   = var.oauth_secret_name != null ? trimspace(var.oauth_secret_name) : ""
+  oauth_client_id_normalized     = var.oauth_client_id != null ? trimspace(var.oauth_client_id) : ""
+  oauth_client_secret_normalized = var.oauth_client_secret != null ? trimspace(var.oauth_client_secret) : ""
+  use_oauth_secret               = local.oauth_secret_name_normalized != ""
+
+  operator_config = merge(
+    {
+      defaultTags = var.default_tags
+    },
+    var.operator_hostname == null ? {} : {
+      hostname = var.operator_hostname
+    }
+  )
+
+  helm_values = merge(
+    local.use_oauth_secret ? {} : {
+      oauth = {
+        clientId     = local.oauth_client_id_normalized
+        clientSecret = local.oauth_client_secret_normalized
+      }
+    },
+    local.use_oauth_secret && local.oauth_secret_name_normalized != "operator-oauth" ? {
+      oauthSecretVolume = {
+        secret = {
+          secretName = local.oauth_secret_name_normalized
+        }
+      }
+    } : {},
+    {
+      operatorConfig = local.operator_config
+    }
+  )
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "helm_release" "this" {
+  depends_on = [kubernetes_namespace_v1.this]
+
+  name             = var.operator_name
+  repository       = "https://pkgs.tailscale.com/helmcharts"
+  chart            = "tailscale-operator"
+  version          = var.operator_version
+  namespace        = var.namespace
+  create_namespace = false
+  values           = [yamlencode(local.helm_values)]
+
+  lifecycle {
+    precondition {
+      condition = !(
+        local.use_oauth_secret &&
+        (
+          local.oauth_client_id_normalized != "" ||
+          local.oauth_client_secret_normalized != ""
+        )
+      )
+      error_message = "Set either oauth_secret_name or inline oauth_client_id/oauth_client_secret, not both."
+    }
+
+    precondition {
+      condition = local.use_oauth_secret || (
+        local.oauth_client_id_normalized != "" &&
+        local.oauth_client_secret_normalized != ""
+      )
+      error_message = "When oauth_secret_name is not set, both oauth_client_id and oauth_client_secret must be provided."
+    }
+  }
+}
+
+# Some Cilium deployments require this setting so Tailscale proxy traffic returns
+# through tailscale0 instead of being short-circuited by socket-level load balancing.
+resource "kubernetes_config_map_v1_data" "cilium_hostns_only" {
+  count = var.enable_cilium_bpf_lb_sock_hostns_only ? 1 : 0
+
+  metadata {
+    name      = var.cilium_config_map_name
+    namespace = var.cilium_namespace
+  }
+
+  data = {
+    "bpf-lb-sock-hostns-only" = "true"
+  }
+
+  force = true
+}
+
+resource "kubernetes_annotations" "restart_cilium_agent" {
+  count = var.enable_cilium_bpf_lb_sock_hostns_only && var.restart_cilium_after_config_change ? 1 : 0
+
+  api_version = "apps/v1"
+  kind        = "DaemonSet"
+
+  metadata {
+    name      = var.cilium_daemonset_name
+    namespace = var.cilium_namespace
+  }
+
+  template_annotations = {
+    "tailscale.nebius.ai/cilium-config-restarted-for" = md5(jsonencode(kubernetes_config_map_v1_data.cilium_hostns_only[0].data))
+  }
+
+  depends_on = [
+    kubernetes_config_map_v1_data.cilium_hostns_only
+  ]
+}

--- a/modules/tailscale-operator/outputs.tf
+++ b/modules/tailscale-operator/outputs.tf
@@ -1,0 +1,14 @@
+output "namespace" {
+  description = "Namespace where the Tailscale operator is installed."
+  value       = var.namespace
+}
+
+output "helm_release_name" {
+  description = "Name of the Tailscale operator Helm release."
+  value       = helm_release.this.name
+}
+
+output "cilium_bpf_lb_sock_hostns_only_enabled" {
+  description = "Whether the Cilium bpf-lb-sock-hostns-only feature flag is enabled."
+  value       = var.enable_cilium_bpf_lb_sock_hostns_only
+}

--- a/modules/tailscale-operator/variables.tf
+++ b/modules/tailscale-operator/variables.tf
@@ -1,0 +1,88 @@
+variable "namespace" {
+  description = "Namespace where the Tailscale operator will be installed."
+  type        = string
+  default     = "tailscale"
+}
+
+variable "create_namespace" {
+  description = "Whether to create the namespace used by the Tailscale operator."
+  type        = bool
+  default     = true
+}
+
+variable "operator_name" {
+  description = "Helm release name for the Tailscale operator."
+  type        = string
+  default     = "tailscale-operator"
+}
+
+variable "operator_version" {
+  description = "Tailscale Kubernetes operator Helm chart version."
+  type        = string
+  default     = "1.94.2"
+}
+
+variable "operator_hostname" {
+  description = "Optional hostname for the operator node on the tailnet. Set to null to let Tailscale assign one."
+  type        = string
+  default     = null
+}
+
+variable "default_tags" {
+  description = "Default Tailscale tags applied by the operator to exposed resources."
+  type        = list(string)
+  default     = ["tag:k8s"]
+}
+
+variable "oauth_client_id" {
+  description = "Tailscale OAuth client ID for the Kubernetes operator. Set this only when you are not using oauth_secret_name."
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "oauth_client_secret" {
+  description = "Tailscale OAuth client secret for the Kubernetes operator. Set this only when you are not using oauth_secret_name."
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "oauth_secret_name" {
+  description = "Name of an existing Kubernetes Secret in the operator namespace that contains client_id and client_secret keys for the operator OAuth credentials."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "enable_cilium_bpf_lb_sock_hostns_only" {
+  description = "Whether to set the Cilium bpf-lb-sock-hostns-only feature flag to true."
+  type        = bool
+  default     = true
+}
+
+variable "restart_cilium_after_config_change" {
+  description = "Whether to restart the Cilium DaemonSet after applying the compatibility workaround."
+  type        = bool
+  default     = true
+}
+
+variable "cilium_namespace" {
+  description = "Namespace where the Cilium DaemonSet and ConfigMap are deployed."
+  type        = string
+  default     = "kube-system"
+}
+
+variable "cilium_config_map_name" {
+  description = "Name of the ConfigMap that stores Cilium agent configuration."
+  type        = string
+  default     = "cilium-config"
+}
+
+variable "cilium_daemonset_name" {
+  description = "Name of the Cilium DaemonSet to restart when the workaround is enabled."
+  type        = string
+  default     = "cilium"
+}

--- a/modules/tailscale-operator/versions.tf
+++ b/modules/tailscale-operator/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.0.1"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.17.0, < 4.0.0"
+    }
+  }
+}

--- a/modules/tailscale-service/README.md
+++ b/modules/tailscale-service/README.md
@@ -1,0 +1,194 @@
+#####################################################################
+# NOTE: This is a module and should not be run manually or standalone
+#####################################################################
+
+Creates a Kubernetes `LoadBalancer` Service that is exposed to a Tailscale
+tailnet through the Tailscale Kubernetes operator.
+
+Use this module after the operator has already been installed in the cluster.
+It is generic and can expose any workload that can be fronted by a Kubernetes
+Service selector.
+
+What this module manages:
+
+- One Kubernetes `Service` with `load_balancer_class = "tailscale"`
+- Tailscale hostname and tag annotations on that service
+- One or more service ports for the selected workload
+
+What this module expects from the caller:
+
+- A running Tailscale Kubernetes operator in the same cluster
+- A stable selector for the target workload
+- The desired tailnet hostname and service ports
+
+Creation boundary:
+
+- Created outside this module:
+  - The Tailscale operator itself
+  - The backend workload selected by `selector`
+  - Any tailnet ACL policy that governs access to the exposed service
+- Created by this module in Terraform:
+  - The Tailscale-backed Kubernetes `Service`
+  - The Service annotations and ports that drive the operator-managed proxy
+  - The optional one-time proxy restart workaround when enabled
+
+Inputs:
+
+- `namespace`
+- `name`
+- `tailnet_hostname`
+- `selector`
+- `ports`
+- `tags`
+- `additional_annotations`
+- `load_balancer_class`
+- `type`
+- `operator_namespace`
+- `restart_generated_proxy_once_after_create`
+- `restart_generated_proxy_strategy`
+- `kubectl_context`
+- `proxy_restart_timeout_seconds`
+
+Outputs:
+
+- `service_name`
+- `service_namespace`
+- `tailnet_hostname`
+- `tailnet_endpoints`
+
+Example usage:
+
+```hcl
+module "tailscale_service" {
+  source = "../../modules/tailscale-service"
+
+  namespace        = "my-app"
+  name             = "my-app-ts"
+  tailnet_hostname = "my-app"
+
+  selector = {
+    "app.kubernetes.io/name" = "my-app"
+  }
+
+  ports = [
+    {
+      name        = "http"
+      port        = 8080
+      target_port = 8080
+    }
+  ]
+
+  providers = {
+    kubernetes = kubernetes
+  }
+}
+```
+
+Example for exposing an internal REST service:
+
+```hcl
+module "my_rest_api_tailscale" {
+  source = "../../modules/tailscale-service"
+
+  namespace        = "platform"
+  name             = "my-rest-api-ts"
+  tailnet_hostname = "my-rest-api"
+
+  selector = {
+    "app.kubernetes.io/name"      = "my-rest-api"
+    "app.kubernetes.io/instance"  = "platform"
+    "app.kubernetes.io/component" = "api"
+  }
+
+  ports = [
+    {
+      name        = "http"
+      port        = 8080
+      target_port = 8080
+    }
+  ]
+
+  depends_on = [module.tailscale_operator]
+
+  providers = {
+    kubernetes = kubernetes
+  }
+}
+```
+
+Testing workflow:
+
+1. Install the operator with `modules/tailscale-operator`.
+2. Apply this module from the workload’s root Terraform module.
+3. Wait for the Service to receive a Tailscale ingress hostname.
+4. Test from an authorized tailnet device using the returned hostname or
+   `tailnet_endpoints` output.
+5. Tighten ACLs in Tailscale after confirming basic connectivity.
+
+
+Notes:
+
+- The Tailscale operator must already be installed in the target cluster.
+- Add an explicit `depends_on = [module.tailscale_operator]` in the calling
+  module when the operator and exposed service are created in the same apply.
+- Tailscale ACLs still determine which users or devices may reach the service.
+- For protected APIs, a successful unauthenticated `401` can still be a useful
+  validation signal because it proves the tailnet path and service forwarding
+  are working.
+- `restart_generated_proxy_once_after_create` is a temporary opt-in workaround,
+  not normal desired state. Leave it `false` unless you are hitting the stale
+  proxy behavior described below.
+- `restart_generated_proxy_strategy` defaults to `template_annotations`
+  because that is the cleaner declarative strategy. It discovers the
+  operator-generated StatefulSet by label and patches its pod-template
+  annotations through the Kubernetes provider.
+- The module ties that one-time patch to the Service UID and ignores later
+  drift in the patched template annotation, because the Tailscale operator can
+  reconcile the generated StatefulSet template after the rollout begins.
+- `local_exec` remains available as an explicit fallback when you prefer an
+  imperative restart plus an explicit readiness wait for the recreated pod.
+- If you enable `restart_generated_proxy_once_after_create`, set
+  `kubectl_context` explicitly when you choose the `local_exec` strategy so the
+  one-time pod delete targets the intended cluster.
+
+Design guidance:
+
+- Create the operator once per cluster, then add one `tailscale-service` module
+  per exposed workload.
+- Use stable, descriptive service names and hostnames so replacements are
+  obvious in both Terraform state and the tailnet admin console.
+- Prefer a narrow selector that matches only the intended backend pods.
+
+Troubleshooting:
+
+- If the proxy device is present on the tailnet and the backend is reachable
+  from inside the proxy pod, but external TCP or HTTP requests still time out,
+  the issue may be stale proxy state rather than your service definition.
+- Observed root cause:
+  the operator could create a proxy that looked healthy from Kubernetes and
+  Tailscale's point of view (`Machines` entry present, `tailscale ping` works,
+  backend reachable from inside the proxy), but the proxy still timed out for
+  inbound TCP and HTTP until the generated pod was recreated.
+- This matches the upstream Tailscale operator ingress issue tracked in
+  `tailscale/tailscale` issue `#12079`:
+  <https://github.com/tailscale/tailscale/issues/12079>
+- Temporary automation:
+  set `restart_generated_proxy_once_after_create = true` and
+  choose a restart strategy:
+  - `restart_generated_proxy_strategy = "template_annotations"` to perform a
+    provider-managed rollout against the discovered operator-generated
+    StatefulSet without relying on `local-exec`. This is the default and the
+    recommended option.
+  - `restart_generated_proxy_strategy = "local_exec"` plus
+    `kubectl_context = "<your-context>"` to automate the single post-create
+    pod delete and explicit readiness wait when you want that stronger
+    synchronous behavior.
+- Why the workaround helps:
+  recreating the generated proxy causes the operator-managed StatefulSet to
+  start a fresh pod, and that fresh pod can come up with working forwarding
+  state.
+- Follow-up work:
+  the declarative `template_annotations` strategy is cleaner, but unlike the
+  `local_exec` path it does not itself perform an explicit readiness wait for
+  the restarted proxy. Keep that tradeoff in mind if you intentionally choose
+  the fallback strategy.

--- a/modules/tailscale-service/main.tf
+++ b/modules/tailscale-service/main.tf
@@ -1,0 +1,165 @@
+locals {
+  use_local_exec_proxy_restart = (
+    var.restart_generated_proxy_once_after_create &&
+    var.restart_generated_proxy_strategy == "local_exec"
+  )
+  use_template_annotation_proxy_restart = (
+    var.restart_generated_proxy_once_after_create &&
+    var.restart_generated_proxy_strategy == "template_annotations"
+  )
+  generated_proxy_label_selector = join(",", [
+    "tailscale.com/managed=true",
+    "tailscale.com/parent-resource=${var.name}",
+    "tailscale.com/parent-resource-ns=${var.namespace}",
+    "tailscale.com/parent-resource-type=svc",
+  ])
+  tailnet_ingress_hostname = try([
+    for ingress in kubernetes_service_v1.this.status[0].load_balancer[0].ingress :
+    ingress.hostname
+    if try(trimspace(ingress.hostname), "") != ""
+  ][0], null)
+
+  service_annotations = merge(
+    var.additional_annotations,
+    {
+      "tailscale.com/hostname" = var.tailnet_hostname
+      "tailscale.com/tags"     = join(",", var.tags)
+    }
+  )
+}
+
+resource "kubernetes_service_v1" "this" {
+  metadata {
+    name        = var.name
+    namespace   = var.namespace
+    annotations = local.service_annotations
+  }
+
+  wait_for_load_balancer = local.use_template_annotation_proxy_restart
+
+  spec {
+    load_balancer_class = var.load_balancer_class
+    type                = var.type
+    selector            = var.selector
+
+    dynamic "port" {
+      for_each = var.ports
+
+      content {
+        name         = try(port.value.name, null)
+        port         = port.value.port
+        target_port  = port.value.target_port
+        protocol     = try(port.value.protocol, "TCP")
+        app_protocol = try(port.value.app_protocol, null)
+      }
+    }
+  }
+}
+
+data "kubernetes_resources" "generated_proxy_statefulset" {
+  count = local.use_template_annotation_proxy_restart ? 1 : 0
+
+  api_version    = "apps/v1"
+  kind           = "StatefulSet"
+  namespace      = var.operator_namespace
+  label_selector = local.generated_proxy_label_selector
+  limit          = 2
+
+  depends_on = [kubernetes_service_v1.this]
+}
+
+resource "kubernetes_annotations" "restart_generated_proxy_statefulset" {
+  count = local.use_template_annotation_proxy_restart ? 1 : 0
+
+  api_version = "apps/v1"
+  kind        = "StatefulSet"
+  force       = true
+
+  metadata {
+    name      = one([for object in data.kubernetes_resources.generated_proxy_statefulset[0].objects : object.metadata.name])
+    namespace = var.operator_namespace
+  }
+
+  template_annotations = {
+    "tailscale.nebius.ai/restarted-for-service-uid" = kubernetes_service_v1.this.metadata[0].uid
+  }
+
+  lifecycle {
+    # The Tailscale operator can reconcile away our one-time template annotation
+    # after the rollout starts. Ignore that steady-state drift, but still
+    # replace this resource when the Service UID changes so a Service
+    # recreation triggers one new rollout patch.
+    ignore_changes       = [template_annotations]
+    replace_triggered_by = [kubernetes_service_v1.this.metadata[0].uid]
+  }
+
+  depends_on = [data.kubernetes_resources.generated_proxy_statefulset]
+}
+
+# This stays imperative by default because it can both restart the operator-
+# managed proxy pod and wait for the recreated pod to become Ready.
+resource "terraform_data" "restart_generated_proxy_once" {
+  count = local.use_local_exec_proxy_restart ? 1 : 0
+
+  triggers_replace = {
+    service_uid = kubernetes_service_v1.this.metadata[0].uid
+  }
+
+  lifecycle {
+    precondition {
+      condition     = trimspace(coalesce(var.kubectl_context, "")) != ""
+      error_message = "kubectl_context must be set when restart_generated_proxy_once_after_create is true."
+    }
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      KUBECTL_CONTEXT = var.kubectl_context
+      PROXY_NAMESPACE = var.operator_namespace
+      SERVICE_NAME    = var.name
+      SERVICE_NS      = var.namespace
+      TIMEOUT_SECONDS = tostring(var.proxy_restart_timeout_seconds)
+    }
+
+    command = <<-EOT
+      set -euo pipefail
+
+      selector="${local.generated_proxy_label_selector}"
+      timeout_at=$((SECONDS + TIMEOUT_SECONDS))
+
+      while true; do
+        if kubectl --context "$KUBECTL_CONTEXT" -n "$PROXY_NAMESPACE" get pod -l "$selector" -o name 2>/dev/null | grep -q .; then
+          break
+        fi
+
+        if [ "$SECONDS" -ge "$timeout_at" ]; then
+          echo "Timed out waiting for generated Tailscale proxy pod for $SERVICE_NS/$SERVICE_NAME" >&2
+          exit 1
+        fi
+
+        sleep 2
+      done
+
+      kubectl --context "$KUBECTL_CONTEXT" -n "$PROXY_NAMESPACE" delete pod -l "$selector" --wait=true
+
+      timeout_at=$((SECONDS + TIMEOUT_SECONDS))
+      while true; do
+        if kubectl --context "$KUBECTL_CONTEXT" -n "$PROXY_NAMESPACE" get pod -l "$selector" -o name 2>/dev/null | grep -q .; then
+          break
+        fi
+
+        if [ "$SECONDS" -ge "$timeout_at" ]; then
+          echo "Timed out waiting for recreated Tailscale proxy pod for $SERVICE_NS/$SERVICE_NAME" >&2
+          exit 1
+        fi
+
+        sleep 2
+      done
+
+      kubectl --context "$KUBECTL_CONTEXT" -n "$PROXY_NAMESPACE" wait --for=condition=Ready pod -l "$selector" --timeout="$TIMEOUT_SECONDS"s
+    EOT
+  }
+
+  depends_on = [kubernetes_service_v1.this]
+}

--- a/modules/tailscale-service/outputs.tf
+++ b/modules/tailscale-service/outputs.tf
@@ -1,0 +1,26 @@
+output "service_name" {
+  description = "Name of the Kubernetes Service created for Tailscale exposure."
+  value       = kubernetes_service_v1.this.metadata[0].name
+}
+
+output "service_namespace" {
+  description = "Namespace of the Kubernetes Service created for Tailscale exposure."
+  value       = kubernetes_service_v1.this.metadata[0].namespace
+}
+
+output "tailnet_hostname" {
+  description = "MagicDNS hostname assigned to the Tailscale-backed service."
+  value       = local.tailnet_ingress_hostname
+}
+
+output "tailnet_endpoints" {
+  description = "Map of service port names or numbers to host:port endpoints on the tailnet."
+  value = local.tailnet_ingress_hostname == null ? {} : {
+    for port in var.ports :
+    coalesce(try(port.name, null), tostring(port.port)) => format(
+      "%s:%d",
+      local.tailnet_ingress_hostname,
+      port.port
+    )
+  }
+}

--- a/modules/tailscale-service/variables.tf
+++ b/modules/tailscale-service/variables.tf
@@ -1,0 +1,105 @@
+variable "namespace" {
+  description = "Namespace where the exposed Kubernetes Service should be created."
+  type        = string
+}
+
+variable "name" {
+  description = "Name of the Kubernetes Service created for Tailscale exposure."
+  type        = string
+}
+
+variable "tailnet_hostname" {
+  description = "Hostname advertised by Tailscale for this service."
+  type        = string
+}
+
+variable "selector" {
+  description = "Pod selector used by the Kubernetes Service."
+  type        = map(string)
+}
+
+variable "ports" {
+  description = "Ports exposed through the Tailscale-backed LoadBalancer Service."
+  type = list(object({
+    name         = optional(string)
+    port         = number
+    target_port  = number
+    protocol     = optional(string, "TCP")
+    app_protocol = optional(string)
+  }))
+
+  validation {
+    condition     = length(var.ports) > 0
+    error_message = "At least one port must be defined for a Tailscale service."
+  }
+}
+
+variable "tags" {
+  description = "Tailscale tags applied to the exposed service."
+  type        = list(string)
+  default     = ["tag:k8s"]
+}
+
+variable "additional_annotations" {
+  description = "Additional annotations to add to the Kubernetes Service metadata."
+  type        = map(string)
+  default     = {}
+}
+
+variable "load_balancer_class" {
+  description = "Load balancer class to use for the Kubernetes Service."
+  type        = string
+  default     = "tailscale"
+}
+
+variable "type" {
+  description = "Kubernetes Service type. Leave as LoadBalancer for Tailscale exposure."
+  type        = string
+  default     = "LoadBalancer"
+
+  validation {
+    condition     = var.type == "LoadBalancer"
+    error_message = "Tailscale service exposure requires type to be LoadBalancer."
+  }
+}
+
+variable "operator_namespace" {
+  description = "Namespace where the Tailscale operator creates its managed proxy pods."
+  type        = string
+  default     = "tailscale"
+}
+
+variable "restart_generated_proxy_once_after_create" {
+  description = "Opt-in workaround for stale Tailscale ingress proxy state. When true, restart the operator-generated proxy once after service creation or replacement."
+  type        = bool
+  default     = false
+}
+
+variable "restart_generated_proxy_strategy" {
+  description = "Strategy to use for the opt-in proxy restart workaround. template_annotations patches the generated StatefulSet template annotations through the Kubernetes provider. local_exec deletes the generated proxy pod and waits for readiness."
+  type        = string
+  default     = "template_annotations"
+
+  validation {
+    condition     = contains(["local_exec", "template_annotations"], var.restart_generated_proxy_strategy)
+    error_message = "restart_generated_proxy_strategy must be local_exec or template_annotations."
+  }
+}
+
+variable "kubectl_context" {
+  description = "Kubectl context to use for the opt-in proxy restart workaround when restart_generated_proxy_strategy is local_exec."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "proxy_restart_timeout_seconds" {
+  description = "Timeout, in seconds, for waiting on the generated Tailscale proxy pod when the opt-in restart workaround is enabled."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.proxy_restart_timeout_seconds > 0
+    error_message = "proxy_restart_timeout_seconds must be greater than zero."
+  }
+}

--- a/modules/tailscale-service/versions.tf
+++ b/modules/tailscale-service/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.0.1"
+    }
+  }
+}


### PR DESCRIPTION
## Release Notes (Mandatory Description)

This PR adds a reusable Terraform module set for private service exposure over Tailscale on Nebius Kubernetes clusters, along with a reusable Nebius MysteryBox + External Secrets integration for secret-backed operator auth.

New modules:

- `modules/tailscale-operator`
- `modules/tailscale-service`
- `modules/external-secrets-operator`
- `modules/external-secret-mysterybox`

## What this adds

### Tailscale operator and service modules

- installs the Tailscale Kubernetes Operator once per cluster
- exposes arbitrary Kubernetes Services privately to a tailnet through operator-managed proxy Services
- supports explicit secret-backed operator auth via `oauth_secret_name`
- defaults `enable_cilium_bpf_lb_sock_hostns_only = true` for Nebius MK8s compatibility
- includes an opt-in workaround for upstream stale proxy behavior:
  - `restart_generated_proxy_once_after_create = true`
  - `restart_generated_proxy_strategy = "template_annotations"` by default
  - `local_exec` remains available as an explicit fallback

### External Secrets modules

- installs External Secrets Operator with Helm
- syncs one Nebius MysteryBox secret into one Kubernetes Secret
- keeps downstream Terraform consumers on a secret-reference contract rather than secret values
- supports both `SecretStore` and `ClusterSecretStore`
- supports either following the MysteryBox primary version or pinning a specific version

## Validation performed

### `soperator`

Validated authenticated Slurm REST access over Tailscale:
- operator installed successfully
- unauthenticated request returned `401`
- authenticated `/slurm/v0.0.41/diag` returned valid Slurm JSON

### `k8s-training`

Validated generic arbitrary-service exposure over Tailscale:
- `whoami` served successfully over MagicDNS
- 2048 demo app served successfully over MagicDNS

### Secret-backed auth

Validated end-to-end:
- MysteryBox secret
- External Secrets sync
- Kubernetes Secret
- `tailscale-operator` consuming that Secret via `oauth_secret_name`

### OAuth rotation

Validated fresh-create behavior after rotation:
- promoted a new MysteryBox secret version to primary
- confirmed fresh Tailscale-backed service creation on both `k8s-training` and `soperator`
- after revoking the old credential, fresh service creation still succeeded

## Important caveats

### External Secrets bootstrap auth

The Nebius MysteryBox provider in External Secrets currently documents only secret-backed auth methods, so the bootstrap Kubernetes Secret containing Nebius Subject Credentials JSON still has to be created out of band.

### Rotation cleanup caveat

Fresh service creation after credential rotation works, but cleanup of older proxy-backed Services can fail if the old Tailscale OAuth credential is revoked before those older Services are deleted. In testing, this showed up as operator cleanup failures with `401 Unauthorized` / `API token invalid`.

Recommended safe order:
1. create new credential
2. promote new MysteryBox version
3. validate fresh service creation
4. delete any older proxy-backed Services that still need cleanup
5. revoke old credential

## Docs

Included README documentation for all four modules covering:
- design and creation boundaries
- supported deployment patterns
- Nebius/Cilium considerations
- External Secrets bootstrap requirements
- validation guidance
- rotation and troubleshooting notes
