### PR TITLE
SCHED-1401: Fix backups bucket destroy race with Slurm teardown

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -304,6 +304,12 @@ module "slurm" {
     module.o11y,
     module.fluxcd,
     module.backups,
+    # Forces destroy order slurm -> backups_store.cleanup_bucket -> bucket, so
+    # Slurm backup workloads stop writing before the bucket is emptied. Without
+    # this the cleanup ran in parallel with Slurm teardown and restic kept
+    # writing to the bucket during aws s3 rm, causing BucketNotEmpty. See
+    # SCHED-1401.
+    module.backups_store,
   ]
 
   source = "../../modules/slurm"

--- a/soperator/modules/backups_store/main.tf
+++ b/soperator/modules/backups_store/main.tf
@@ -18,20 +18,32 @@ resource "terraform_data" "cleanup_bucket" {
     when        = destroy
     working_dir = path.root
     interpreter = ["/bin/bash", "-c"]
-    command     = <<EOT
-which aws
-if [ $? != 0 ]; then
-  echo "AWS cli not found, skipping"
-  exit 0
-fi
-
-if ! aws s3api head-bucket --bucket ${self.triggers_replace.bucket_name} 2>/dev/null; then
-  echo "Bucket ${self.triggers_replace.bucket_name} doesn't exist, skipping cleanup"
-  exit 0
-fi
-
-aws s3 rm s3://${self.triggers_replace.bucket_name}/ --recursive
-EOT
+    command     = <<-EOT
+      set -eu
+      command -v aws >/dev/null || { echo "aws cli not found, skipping"; exit 0; }
+      bucket="${self.triggers_replace.bucket_name}"
+      if ! aws s3api head-bucket --bucket "$bucket" 2>/dev/null; then
+        echo "Bucket $bucket doesn't exist, skipping cleanup"
+        exit 0
+      fi
+      # The caller's depends_on guarantees module.slurm finished destroying before we run, but helm uninstall
+      # returns as soon as k8s accepts the delete request -- backup pods are still in Terminating state and
+      # restic can keep writing for up to terminationGracePeriodSeconds.
+      # Loop until list-objects-v2 confirms the bucket is empty so the subsequent bucket delete
+      # doesn't race with the termination tail.
+      for i in 1 2 3 4 5; do
+        aws s3 rm "s3://$bucket/" --recursive || true
+        sleep 5
+        count=$(aws s3api list-objects-v2 --bucket "$bucket" --query 'KeyCount' --output text 2>/dev/null || echo "?")
+        if [ "$count" = "0" ] || [ "$count" = "None" ]; then
+          echo "Bucket $bucket emptied on pass $i"
+          exit 0
+        fi
+        echo "Bucket $bucket still has $count objects after pass $i, retrying"
+      done
+      echo "Bucket $bucket still not empty after 5 passes"
+      exit 1
+    EOT
   }
 }
 


### PR DESCRIPTION
## Problem

On `terraform destroy`, the backups bucket cleanup provisioner lived inside `module.backups_store` and ran in parallel with `module.slurm` teardown. Slurm backup pods were still writing objects into the bucket while `aws s3 rm` was draining it, so the bucket was non-empty when the `nebius_storage_v1_bucket` delete ran and destroy failed.

## Solution

Basically, add an extra dependency in the tf resources graph:

- Add `module.backups_store` to `module.slurm`'s `depends_on`. Terraform then reverses the destroy order to `slurm -> backups_store.cleanup_bucket -> bucket`, so Slurm's backup pods stop writing before the bucket is emptied.
- Rewrite the in-module `cleanup_bucket` provisioner with a short retry loop (`aws s3 rm --recursive` + `list-objects-v2` verification, up to 5 passes with a 5s sleep) to absorb objects that still drain out during k8s pod termination — `helm uninstall` returns as soon as k8s accepts the delete request, but pods remain in `Terminating` for up to `terminationGracePeriodSeconds` and restic keeps writing during that window.

## Testing

https://github.com/nebius/soperator/actions/runs/24193197140

## Related

- nebius/soperator#2411 — E2E harness recovery patch that empties the leaked backups bucket before init-time `tf destroy`, so state left behind by pre-fix runs self-heals on the next run.

## Release Notes

Fix: `terraform destroy` no longer races with Slurm backup pods when emptying the backups bucket.