### PR TITLE
SCHED-1445: Change default MK8S deployment strategy for Soperator clusters

### DIFF
--- a/soperator/modules/k8s/k8s_ng_workers_v2.tf
+++ b/soperator/modules/k8s/k8s_ng_workers_v2.tf
@@ -92,6 +92,16 @@ resource "nebius_mk8s_v1_node_group" "worker_v2" {
     ]
   }
 
+  strategy = {
+    max_unavailable = {
+      percent = 50
+    }
+    max_surge = {
+      percent = 0
+    }
+    drain_timeout = null
+  }
+
   template = {
     metadata = {
       labels = merge(


### PR DESCRIPTION
## Release Notes (Mandatory Description)