### PR TITLE
SCHED-1464: rely on HelmRelease defaults for otel logs collector

### DIFF
--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -70,8 +70,6 @@ resources:
               %{~ if opentelemetry_collector_version != "" ~}
               version: ${opentelemetry_collector_version}
               %{~ endif ~}
-              interval: 5m
-              timeout: 5m
               values:
                 resources:
                   requests:


### PR DESCRIPTION
## Problem

The otel logs collector `HelmRelease` in `terraform_fluxcd_values.yaml.tftpl` had `interval: 5m` and `timeout: 5m` hardcoded, overriding the defaults wired through the chart.

## Solution

- Drop the explicit `interval` and `timeout` fields from the `opentelemetry.logs` block so the `HelmRelease` picks up defaults.

## Testing

Terraform template change only; verified the rendered values no longer emit the two fields.

## Release Notes

None