### PR TITLE
SCHED-1177: Fix wait_for_flux_hr falsely erroring during Flux reconciliation

### DIFF
--- a/soperator/modules/slurm/scripts/wait_for_flux_hr.sh.tmpl
+++ b/soperator/modules/slurm/scripts/wait_for_flux_hr.sh.tmpl
@@ -26,17 +26,21 @@ get_elapsed_time() {
 get_state_summary() {
   local ready_reason=$(echo "$HR_JSON" | jq -r '.status.conditions[]? | select(.type=="Ready") | .reason' 2>/dev/null)
   local released_reason=$(echo "$HR_JSON" | jq -r '.status.conditions[]? | select(.type=="Released") | .reason' 2>/dev/null)
+  local reconciling_status=$(echo "$HR_JSON" | jq -r '.status.conditions[]? | select(.type=="Reconciling") | .status' 2>/dev/null)
+  local reconciling_reason=$(echo "$HR_JSON" | jq -r '.status.conditions[]? | select(.type=="Reconciling") | .reason' 2>/dev/null)
 
   if [ -z "$ready_reason" ]; then
     ready_reason="Unknown"
   fi
 
-  # Only show Released status if it has a meaningful value
+  local summary="Ready=$ready_reason"
   if [ -n "$released_reason" ]; then
-    echo "Ready=$ready_reason, Released=$released_reason"
-  else
-    echo "Ready=$ready_reason"
+    summary="$summary, Released=$released_reason"
   fi
+  if [ "$reconciling_status" = "True" ] && [ -n "$reconciling_reason" ]; then
+    summary="$summary, Reconciling=$reconciling_reason"
+  fi
+  echo "$summary"
 }
 
 # Print detailed HelmRelease status
@@ -107,10 +111,18 @@ check_hr_failure() {
   local released_message=$(echo "$HR_JSON" | jq -r '.status.conditions[]? | select(.type=="Released") | .message' 2>/dev/null)
   local ready_reason=$(echo "$HR_JSON" | jq -r '.status.conditions[]? | select(.type=="Ready") | .reason' 2>/dev/null)
   local ready_message=$(echo "$HR_JSON" | jq -r '.status.conditions[]? | select(.type=="Ready") | .message' 2>/dev/null)
+  local reconciling_status=$(echo "$HR_JSON" | jq -r '.status.conditions[]? | select(.type=="Reconciling") | .status' 2>/dev/null)
 
   # Check for Released condition failure reasons
   case "$released_reason" in
     InstallFailed|UpgradeFailed|GetLastReleaseFailed|ReconcileStrategyFailed)
+      # Install/upgrade failures are stale while Flux is still reconciling;
+      # retry exhaustion removes the Reconciling condition and falls through.
+      case "$released_reason" in
+        InstallFailed|UpgradeFailed)
+          [ "$reconciling_status" = "True" ] && return 1
+          ;;
+      esac
       echo ""
       echo "ERROR: HelmRelease $HELMRELEASE_NAME has failed!"
       echo "Reason: $released_reason"


### PR DESCRIPTION
## Problem

`wait_for_flux_hr.sh` treats `Released=InstallFailed` and `Released=UpgradeFailed` as terminal errors, but Flux keeps these reasons on the condition until retry exhaustion. While Flux is still retrying (`Reconciling=True`), the script exits 1 and fails the Terraform apply even though Flux would likely recover.

## Solution

- Read the `Reconciling` condition alongside `Released`.
- When `Released` is `InstallFailed` or `UpgradeFailed` but `Reconciling=True`, skip the failure exit and keep waiting. Retry exhaustion removes the `Reconciling` condition, so the existing terminal-error path still fires once Flux gives up.
- Include `Reconciling=<reason>` in the one-line state summary for visibility.

## Testing

E2E run: https://github.com/nebius/soperator/actions/runs/24651519785

## Release Notes

Fix: `wait_for_flux_hr` no longer fails Terraform applies on transient Flux install or upgrade retries.