### PR TITLE
remove sensitive and lifecycle fields

### DIFF
--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1171,7 +1171,6 @@ variable "backups_password" {
   description = "Password for encrypting jail backups."
   type        = string
   nullable    = false
-  sensitive   = true
 }
 
 variable "backups_schedule" {

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -329,10 +329,6 @@ resource "helm_release" "soperator_fluxcd_bootstrap" {
     name  = "helmRepository.url"
     value = var.operator_stable ? "oci://cr.eu-north1.nebius.cloud/soperator" : "oci://cr.eu-north1.nebius.cloud/soperator-unstable"
   }
-
-  lifecycle {
-    ignore_changes = all
-  }
 }
 
 resource "helm_release" "soperator_fluxcd_ad_hoc_cm" {


### PR DESCRIPTION
## Release Notes (Mandatory Description)
Removed: sensitive for `backups_password` since it hides diff for umbrella chart configmap values.
Removed: lifecycle for `soperator_fluxcd_bootstrap` configmap