### PR TITLE
k8s-training: enable CDI for driverless MIG GPU operator

### DIFF
--- a/k8s-training/helm.tf
+++ b/k8s-training/helm.tf
@@ -18,6 +18,7 @@ module "gpu-operator" {
   parent_id    = var.parent_id
   cluster_id   = nebius_mk8s_v1_cluster.k8s-cluster.id
   mig_strategy = var.mig_strategy
+  cdi_enabled  = local.gpu_operator_cdi_enabled
 }
 
 module "gpu-operator-custom" {
@@ -27,6 +28,7 @@ module "gpu-operator-custom" {
   ]
   source       = "../modules/gpu-operator-custom"
   mig_strategy = var.mig_strategy != null ? var.mig_strategy : "none"
+  cdi_enabled  = local.gpu_operator_cdi_enabled
 }
 
 
@@ -39,10 +41,10 @@ module "device-plugin" {
 }
 
 module "o11y" {
-  source     = "../modules/o11y"
-  parent_id  = var.parent_id
-  tenant_id  = var.tenant_id
-  cluster_id = nebius_mk8s_v1_cluster.k8s-cluster.id
+  source                    = "../modules/o11y"
+  parent_id                 = var.parent_id
+  tenant_id                 = var.tenant_id
+  cluster_id                = nebius_mk8s_v1_cluster.k8s-cluster.id
   k8s_node_group_sa_id      = var.enable_k8s_node_group_sa ? nebius_iam_v1_service_account.k8s_node_group_sa[0].id : null
   k8s_node_group_sa_enabled = var.enable_k8s_node_group_sa
 

--- a/k8s-training/locals.tf
+++ b/k8s-training/locals.tf
@@ -66,12 +66,16 @@ locals {
   gpu_nodes_platform = coalesce(var.gpu_nodes_platform, local.current_region_defaults.gpu_nodes_platform)
   gpu_nodes_preset   = coalesce(var.gpu_nodes_preset, local.current_region_defaults.gpu_nodes_preset)
   infiniband_fabric  = coalesce(var.infiniband_fabric, local.current_region_defaults.infiniband_fabric)
-
   platform_to_cuda = {
     gpu-b200-sxm-a = "cuda12.8"
     gpu-b200-sxm   = "cuda12.8"
   }
   device_preset = lookup(local.platform_to_cuda, local.gpu_nodes_platform, "cuda13.0")
+  gpu_operator_cdi_enabled = (
+    !var.gpu_nodes_driverfull_image &&
+    var.mig_strategy != null &&
+    var.mig_strategy != "none"
+  ) ? true : null
   #List of official MIG configs https://docs.nvidia.com/datacenter/tesla/mig-user-guide/supported-mig-profiles.html
   valid_mig_parted_configs = {
     "gpu-h100-sxm"   = ["all-disabled", "all-enabled", "all-balanced", "all-1g.10gb", "all-1g.10gb.me", "all-1g.20gb", "all-2g.20gb", "all-3g.40gb", "all-4g.40gb", "all-7g.80gb"]

--- a/modules/gpu-operator-custom/helm.tf
+++ b/modules/gpu-operator-custom/helm.tf
@@ -8,7 +8,7 @@ resource "helm_release" "gpu-operator" {
   atomic           = true
   timeout          = 600
 
-  set = [
+  set = concat([
     # Node Feature Discovery
     {
       name  = "nfd.enabled"
@@ -98,5 +98,10 @@ resource "helm_release" "gpu-operator" {
       name  = "gds.enabled"
       value = var.gds_enabled
     },
-  ]
+    ], var.cdi_enabled == null ? [] : [
+    {
+      name  = "cdi.enabled"
+      value = var.cdi_enabled
+    },
+  ])
 }

--- a/modules/gpu-operator-custom/variables.tf
+++ b/modules/gpu-operator-custom/variables.tf
@@ -57,6 +57,12 @@ variable "mig_strategy" {
   }
 }
 
+variable "cdi_enabled" {
+  description = "Whether to explicitly enable CDI for the GPU Operator."
+  type        = bool
+  default     = null
+}
+
 variable "gds_enabled" {
   description = "Enable GPU Direct Storage support."
   type        = bool

--- a/modules/gpu-operator/main.tf
+++ b/modules/gpu-operator/main.tf
@@ -17,6 +17,7 @@ resource "nebius_applications_v1alpha1_k8s_release" "this" {
       "dcgmExporter.serviceMonitor.relabelings[0].sourceLabels[0]" = var.relabel_dcgm_exporter ? "__meta_kubernetes_pod_label_app" : null
       "dcgmExporter.serviceMonitor.relabelings[0].targetLabel"     = var.relabel_dcgm_exporter ? "app_kubernetes_io_name" : null
       "mig.strategy"                                               = var.mig_strategy != null ? var.mig_strategy : null
+      "cdi.enabled"                                                = var.cdi_enabled
     }
   }
 }

--- a/modules/gpu-operator/variables.tf
+++ b/modules/gpu-operator/variables.tf
@@ -36,3 +36,9 @@ variable "mig_strategy" {
     error_message = "Invalid MIG strategy '${coalesce(var.mig_strategy, "null")}'. Must be one of ['none', 'single', 'mixed'] or left unset."
   }
 }
+
+variable "cdi_enabled" {
+  description = "Whether to explicitly enable CDI for the GPU Operator."
+  type        = bool
+  default     = null
+}


### PR DESCRIPTION

Summary
- enable CDI by default for the driverless MIG path in k8s-training
- pass the CDI decision through both GPU operator module interfaces
- keep the driverfull/device-plugin path unchanged

Why
- we reproduced the same MIG capability-device issue with CDI disabled on both Nebius marketplace GPU Operator and upstream NVIDIA GPU Operator v25.10.0
- enabling CDI provides the full higher-numbered MIG cap devices under /run/nvidia/driver/dev/nvidia-caps for the driverless MIG path

Implementation
- add a computed local in k8s-training for the driverless MIG condition:
  - gpu_nodes_driverfull_image = false
  - mig_strategy != null
  - mig_strategy != "none"
- pass cdi_enabled into both gpu-operator modules
- wire cdi.enabled into both the marketplace and custom Helm GPU Operator paths

Validation
- Deployed to a sandbox tenant successfully. 
- terraform validate succeeded locally
- offline Terraform console checks confirmed:
  - local.gpu_operator_cdi_enabled = true
  - GPU Operator path remains selected for driverless MIG
  - device-plugin path remains disabled for driverless MIG