### PR TITLE
k8s-training: make B200 CUDA driverfull preset - move B200 to CUDA 13

### DIFF
--- a/k8s-training/locals.tf
+++ b/k8s-training/locals.tf
@@ -66,17 +66,7 @@ locals {
   gpu_nodes_platform = coalesce(var.gpu_nodes_platform, local.current_region_defaults.gpu_nodes_platform)
   gpu_nodes_preset   = coalesce(var.gpu_nodes_preset, local.current_region_defaults.gpu_nodes_preset)
   infiniband_fabric  = coalesce(var.infiniband_fabric, local.current_region_defaults.infiniband_fabric)
-  k8s_minor_version  = var.k8s_version == null ? null : join(".", slice(split(".", var.k8s_version), 0, 2))
-  b200_platforms     = ["gpu-b200-sxm", "gpu-b200-sxm-a"]
-  b200_device_preset_by_k8s_minor = {
-    "1.32" = "cuda12.8"
-    "1.33" = "cuda13.0"
-  }
-  device_preset = contains(local.b200_platforms, local.gpu_nodes_platform) ? lookup(
-    local.b200_device_preset_by_k8s_minor,
-    local.k8s_minor_version,
-    "cuda12.8",
-  ) : "cuda13.0"
+  device_preset      = "cuda13.0"
   gpu_operator_cdi_enabled = (
     !var.gpu_nodes_driverfull_image &&
     var.mig_strategy != null &&

--- a/k8s-training/locals.tf
+++ b/k8s-training/locals.tf
@@ -66,11 +66,17 @@ locals {
   gpu_nodes_platform = coalesce(var.gpu_nodes_platform, local.current_region_defaults.gpu_nodes_platform)
   gpu_nodes_preset   = coalesce(var.gpu_nodes_preset, local.current_region_defaults.gpu_nodes_preset)
   infiniband_fabric  = coalesce(var.infiniband_fabric, local.current_region_defaults.infiniband_fabric)
-  platform_to_cuda = {
-    gpu-b200-sxm-a = "cuda12.8"
-    gpu-b200-sxm   = "cuda12.8"
+  k8s_minor_version = var.k8s_version == null ? null : join(".", slice(split(".", var.k8s_version), 0, 2))
+  b200_platforms    = ["gpu-b200-sxm", "gpu-b200-sxm-a"]
+  b200_device_preset_by_k8s_minor = {
+    "1.32" = "cuda12.8"
+    "1.33" = "cuda13.0"
   }
-  device_preset = lookup(local.platform_to_cuda, local.gpu_nodes_platform, "cuda13.0")
+  device_preset = contains(local.b200_platforms, local.gpu_nodes_platform) ? lookup(
+    local.b200_device_preset_by_k8s_minor,
+    local.k8s_minor_version,
+    "cuda12.8",
+  ) : "cuda13.0"
   gpu_operator_cdi_enabled = (
     !var.gpu_nodes_driverfull_image &&
     var.mig_strategy != null &&

--- a/k8s-training/locals.tf
+++ b/k8s-training/locals.tf
@@ -66,8 +66,8 @@ locals {
   gpu_nodes_platform = coalesce(var.gpu_nodes_platform, local.current_region_defaults.gpu_nodes_platform)
   gpu_nodes_preset   = coalesce(var.gpu_nodes_preset, local.current_region_defaults.gpu_nodes_preset)
   infiniband_fabric  = coalesce(var.infiniband_fabric, local.current_region_defaults.infiniband_fabric)
-  k8s_minor_version = var.k8s_version == null ? null : join(".", slice(split(".", var.k8s_version), 0, 2))
-  b200_platforms    = ["gpu-b200-sxm", "gpu-b200-sxm-a"]
+  k8s_minor_version  = var.k8s_version == null ? null : join(".", slice(split(".", var.k8s_version), 0, 2))
+  b200_platforms     = ["gpu-b200-sxm", "gpu-b200-sxm-a"]
   b200_device_preset_by_k8s_minor = {
     "1.32" = "cuda12.8"
     "1.33" = "cuda13.0"

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -32,6 +32,15 @@ variable "k8s_version" {
   description = "Kubernetes version to be used in the cluster. Leave null to use backend default (recommended), or choose 1.31 or above."
   type        = string
   default     = null
+
+  validation {
+    condition = !(
+      var.k8s_version == null &&
+      var.gpu_nodes_driverfull_image &&
+      contains(["gpu-b200-sxm", "gpu-b200-sxm-a"], local.gpu_nodes_platform)
+    )
+    error_message = "Set 'k8s_version' explicitly when using driverfull B200 GPU nodes so Terraform can select a compatible CUDA driver preset."
+  }
 }
 
 variable "etcd_cluster_size" {

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -32,15 +32,6 @@ variable "k8s_version" {
   description = "Kubernetes version to be used in the cluster. Leave null to use backend default (recommended), or choose 1.31 or above."
   type        = string
   default     = null
-
-  validation {
-    condition = !(
-      var.k8s_version == null &&
-      var.gpu_nodes_driverfull_image &&
-      contains(["gpu-b200-sxm", "gpu-b200-sxm-a"], local.gpu_nodes_platform)
-    )
-    error_message = "Set 'k8s_version' explicitly when using driverfull B200 GPU nodes so Terraform can select a compatible CUDA driver preset."
-  }
 }
 
 variable "etcd_cluster_size" {


### PR DESCRIPTION
To address the issue: 
```
PublicNodeGroup.ToNebiusMachineTemplate: no implementation found for the given drivers preset: cuda12.8, platform: gpu-b200-sxm, os:
│ request = 2358382a-c536-4632-b74a-636e40a7bbc5
│ caused by service error:
│   Bad Request BadRequest: service mk8s, violations:
│     spec.inner: Internal error: PublicNodeGroup.ToNebiusMachineTemplate: no implementation found for the given drivers preset: cuda12.8, platform: gpu-b200-sxm, os:

```
Compatibility check:
nebius mk8s node-group get-compatibility-matrix --cluster-kubernetes-version 1.33 --platform gpu-b200-sxm

Summary
- move B200 driverfull preset to CUDA 13
- simplify the previous version-aware logic and remove the extra k8s_version validation

Why
- MK8s compatibility for B200 on Kubernetes 1.33 shows cuda13.0
- CUDA 12 image families are being deprecated
- this keeps the Terraform behavior aligned with the newer supported image direction

Validation

Validation
- Applied and tested, deployed from local branch successfully 
- terraform fmt, init, and plan were re-run locally
- temporary validation env changes were reverted before push
- terraform console confirmed:
  - gpu-b200-sxm + Any k8s_version => local.device_preset = "cuda13.0"