### PR TITLE
soperator/example: add missing variable validations

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -68,6 +68,7 @@ resource "terraform_data" "check_variables" {
     terraform_data.check_slurm_nodeset,
     terraform_data.check_slurm_nodeset_accounting,
     terraform_data.check_nfs,
+    terraform_data.check_nfs_exclusivity,
     terraform_data.check_local_nvme,
   ]
 }

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -299,6 +299,15 @@ variable "nfs" {
     error_message = "NFS size must be a multiple of 93 GiB and maximum value is 262074 GiB"
   }
 }
+resource "terraform_data" "check_nfs_exclusivity" {
+  lifecycle {
+    precondition {
+      condition     = !(var.nfs.enabled && var.nfs_in_k8s.enabled)
+      error_message = "nfs.enabled and nfs_in_k8s.enabled cannot both be true. Choose one NFS backend: either an external NFS server (nfs.enabled) or the in-cluster NFS provisioner (nfs_in_k8s.enabled)."
+    }
+  }
+}
+
 resource "terraform_data" "check_nfs" {
   depends_on = [
     terraform_data.check_region,
@@ -363,6 +372,24 @@ variable "nfs_in_k8s" {
 If NFS in K8s is enabled, filesystem_type, disk_type, and size_gibibytes must be set.
 Additionally, if disk_type is NETWORK_SSD_IO_M3 or NETWORK_SSD_NON_REPLICATED, size_gibibytes must be a multiple of 93.
 EOT
+  }
+
+  validation {
+    condition = (
+      !var.nfs_in_k8s.enabled
+      || var.nfs_in_k8s.disk_type == null
+      || contains(["NETWORK_SSD", "NETWORK_SSD_NON_REPLICATED", "NETWORK_SSD_IO_M3"], var.nfs_in_k8s.disk_type)
+    )
+    error_message = "nfs_in_k8s.disk_type must be one of: NETWORK_SSD, NETWORK_SSD_NON_REPLICATED, NETWORK_SSD_IO_M3."
+  }
+
+  validation {
+    condition = (
+      !var.nfs_in_k8s.enabled
+      || var.nfs_in_k8s.filesystem_type == null
+      || contains(["ext4", "xfs"], var.nfs_in_k8s.filesystem_type)
+    )
+    error_message = "nfs_in_k8s.filesystem_type must be one of: ext4, xfs."
   }
 }
 
@@ -437,12 +464,33 @@ variable "k8s_cluster_node_ssh_access_users" {
   }))
   nullable = false
   default  = []
+
+  validation {
+    condition = alltrue([
+      for u in var.k8s_cluster_node_ssh_access_users : length(u.public_keys) >= 1
+    ])
+    error_message = "Each entry in k8s_cluster_node_ssh_access_users must have at least one public key."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for u in var.k8s_cluster_node_ssh_access_users : [
+        for k in u.public_keys : length(k) > 0
+      ]
+    ]))
+    error_message = "Public keys in k8s_cluster_node_ssh_access_users must not be empty strings."
+  }
 }
 
 variable "etcd_cluster_size" {
-  description = "Size of the etcd cluster."
+  description = "Size of the etcd cluster. Must be a positive odd number (1, 3, 5…) to maintain quorum."
   type        = number
   default     = 3
+
+  validation {
+    condition     = var.etcd_cluster_size >= 1 && var.etcd_cluster_size % 2 == 1
+    error_message = "etcd_cluster_size must be a positive odd number (1, 3, 5…) to maintain quorum."
+  }
 }
 
 # endregion k8s
@@ -564,6 +612,10 @@ variable "slurm_nodeset_system" {
   validation {
     condition     = var.slurm_nodeset_system.min_size >= 3
     error_message = "Minimum size of the system node group must be at least 3."
+  }
+  validation {
+    condition     = var.slurm_nodeset_system.max_size >= var.slurm_nodeset_system.min_size
+    error_message = "System nodeset max_size must be greater than or equal to min_size."
   }
 }
 
@@ -1051,6 +1103,11 @@ variable "slurm_shared_memory_size_gibibytes" {
   description = "Shared memory size for Slurm controller and worker nodes in GiB."
   type        = number
   default     = 64
+
+  validation {
+    condition     = var.slurm_shared_memory_size_gibibytes > 0
+    error_message = "slurm_shared_memory_size_gibibytes must be greater than 0."
+  }
 }
 
 # endregion Config
@@ -1228,8 +1285,8 @@ variable "active_checks_scope" {
   description = "Scope of active checks. Defines what active checks should be checked during cluster bootstrap."
   default     = ""
   validation {
-    condition     = contains(["dev", "testing", "prod_quick", "prod_acceptance", "essential"], var.active_checks_scope)
-    error_message = "active_checks_scope should be one of: dev, testing, prod_quick, prod_acceptance, essential."
+    condition     = contains(["", "dev", "testing", "prod_quick", "prod_acceptance", "essential"], var.active_checks_scope)
+    error_message = "active_checks_scope must be one of: dev, testing, prod_quick, prod_acceptance, essential (or empty string to skip active checks)."
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes six validation gaps in `soperator/installations/example/variables.tf`. One is a bug that causes `terraform validate` to fail with the default configuration; the rest are missing guards that would catch misconfigurations at plan time instead of silently producing broken clusters.

---

## Changes

### 🐛 Bug fix

**`active_checks_scope` — validation rejected its own default value**

The allowed set was `["dev", "testing", "prod_quick", "prod_acceptance", "essential"]` but the default is `""`. Any plan that didn't explicitly set this variable would fail validation. Fixed by adding `""` to the allowed set and clarifying the error message.

---

### ✅ New validations

**`etcd_cluster_size` — must be a positive odd number**

etcd requires an odd cluster size to maintain quorum (split-brain prevention). The variable had no validation, so a user could set `etcd_cluster_size = 2` or `4` and get a broken etcd cluster. Added: `>= 1 && % 2 == 1`.

**`slurm_nodeset_system` — `max_size` must be ≥ `min_size`**

The system nodeset already validated `min_size >= 3` but had no check that `max_size >= min_size`. A user could set `min_size = 5, max_size = 3` without any error. Added the missing cross-field check.

**`nfs_in_k8s` — `disk_type` and `filesystem_type` must be valid values**

The existing validation only checked that these fields are non-null when `enabled = true`, and checked the size alignment rule for two specific disk types — but never validated that `disk_type` or `filesystem_type` are actually legal values. An invalid string would pass validation and fail later at apply time. Added enum checks consistent with the rest of the codebase:
- `disk_type`: `NETWORK_SSD | NETWORK_SSD_NON_REPLICATED | NETWORK_SSD_IO_M3`
- `filesystem_type`: `ext4 | xfs`

**`nfs.enabled` and `nfs_in_k8s.enabled` are mutually exclusive**

Both NFS backends could be enabled simultaneously with no error, which would produce a broken configuration. Added a `terraform_data.check_nfs_exclusivity` precondition to catch this at plan time, and wired it into the existing `check_variables` dependency gate so it runs before any resources are created.

**`slurm_shared_memory_size_gibibytes` — must be > 0**

No lower-bound guard existed. A zero or negative value would pass validation. Added `> 0`.

**`k8s_cluster_node_ssh_access_users` — each user must have at least one non-empty key**

`slurm_login_ssh_root_public_keys` already validates that the list is non-empty and keys are non-empty strings, but `k8s_cluster_node_ssh_access_users[*].public_keys` had no equivalent check. A user entry with an empty `public_keys` list or blank key strings would pass silently. Added both checks.

---

## Files changed

| File | Change |
|---|---|
| `soperator/installations/example/variables.tf` | 6 new/fixed validation blocks + 1 new `terraform_data` resource |
| `soperator/installations/example/main.tf` | Wire `check_nfs_exclusivity` into `check_variables` depends_on |

## Test plan

- [ ] `terraform validate` passes with default variable values
- [ ] `terraform validate` passes with a typical production `terraform.tfvars`
- [ ] Setting `active_checks_scope = ""` (default) no longer fails validation
- [ ] Setting `etcd_cluster_size = 2` produces a clear error
- [ ] Setting `slurm_nodeset_system = { min_size = 5, max_size = 3, ... }` produces a clear error
- [ ] Setting `nfs_in_k8s = { enabled = true, disk_type = "INVALID", ... }` produces a clear error
- [ ] Setting both `nfs.enabled = true` and `nfs_in_k8s.enabled = true` produces a clear error
- [ ] Setting `slurm_shared_memory_size_gibibytes = 0` produces a clear error
- [ ] Setting a user entry with empty `public_keys = []` in `k8s_cluster_node_ssh_access_users` produces a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)