### PR TITLE
SCHED-1183: Retry transient Nebius API failures in TF provider and disk cleanup

### DIFF
--- a/soperator/installations/example/terraform.tf
+++ b/soperator/installations/example/terraform.tf
@@ -34,7 +34,10 @@ terraform {
 }
 
 provider "nebius" {
-  domain = "api.eu.nebius.cloud:443"
+  domain            = "api.eu.nebius.cloud:443"
+  timeout           = "10m"
+  per_retry_timeout = "1m"
+  retries           = 10
 }
 
 provider "units" {}

--- a/soperator/modules/cleanup/scripts/disk_cleanup.sh
+++ b/soperator/modules/cleanup/scripts/disk_cleanup.sh
@@ -43,7 +43,9 @@ while true; do
 done
 
 
+retry_script="$(dirname "$0")/../../scripts/retry.sh"
+
 for id in "${result_ids[@]}"; do
   echo "Deleting leftover disk $id..."
-  nebius compute disk delete --id "$id"
+  "$retry_script" -- nebius compute disk delete --id "$id"
 done


### PR DESCRIPTION
## Problem

`terraform destroy` intermittently fails with `rpc error: code = DeadlineExceeded` on filesystem `Delete` calls. The Nebius Go SDK defaults are 3 retries × 20s per attempt (60s total budget), which isn't enough when the filestore backend stalls — all four filesystem deletes time out in lockstep at the 60s mark.

`disk_cleanup.sh` separately calls `nebius compute disk delete` with no retries; with `set -euo pipefail`, a single transient `DeadlineExceeded` aborts the whole destroy step.

See SCHED-1183 for the SDK-default analysis (`DefaultTimeout = 1m`, `DefaultRetries = 3`, `DefaultPerRetry = 20s`).

## Solution

- `nebius` provider in the example installation: `timeout = 10m`, `per_retry_timeout = 1m`, `retries = 10`. Replaces the SDK defaults of 3 × 20s with 10 × 1m within a 10m total budget.
- `disk_cleanup.sh`: wrap the `nebius compute disk delete` call with the existing `modules/scripts/retry.sh` helper (defaults: 5 retries × 2s).

## Testing

Manual: cleanup script still deletes disks via the retry wrapper. Provider change is config-only.
https://github.com/nebius/soperator/actions/runs/24991378350

## Release Notes

Fix: Soperator install/destroy tolerate transient Nebius API failures via larger provider retry budget and a retry wrapper around disk deletes.