### PR TITLE
Add forbid_deletion aka deletion protection support for shared filesy…

### DIFF
--- a/soperator/README.md
+++ b/soperator/README.md
@@ -80,8 +80,8 @@ By default, `soperator-telemetry` is used as a profile for public o11y setup. Yo
 Create a "jail" filesystem in the Nebius Console. Jail is a shared filesystem for all Slurm nodes.
 It is called "jail" because it resembles [FreeBSD jail mechanism](https://en.wikipedia.org/wiki/FreeBSD_jail).
 
-This step is required for those who wants to persist their jail data after the cluster deletion.
-You can offload storage creation to the Terraform script instead, but it will be deleted with the cluster in this case.
+This step is required for those who want to persist their jail data after the cluster deletion.
+You can offload storage creation to the Terraform script instead, but it will be deleted with the cluster unless you set `forbid_deletion = true` in the filesystem `spec`.
 
 ![Create Filesystem 1](imgs/create_fs_1.png)
 ![Create Filesystem 2](imgs/create_fs_2.png)
@@ -108,6 +108,15 @@ filestore_jail = {
     id = "computefilesystem-<YOUR-FILESYSTEM-ID>"
   }
 }
+
+# Or create the jail filesystem with Terraform and protect it from deletion
+# filestore_jail = {
+#   spec = {
+#     size_gibibytes       = 2048
+#     block_size_kibibytes = 4
+#     forbid_deletion      = true
+#   }
+# }
 
 # ...
 
@@ -203,6 +212,103 @@ or connect using the login script:
 ```bash
 ./login.sh -k ~/.ssh/<private_key>
 ```
+
+### 9. (Optional) Destroy the Cluster and Retain Terraform-Created Shared Filesystems
+
+If Terraform created the shared filesystems from `spec` blocks and you want to delete the cluster while keeping the data, first protect the filesystems and then remove only those retained filesystems from Terraform state before running `terraform destroy`.
+
+1. Enable deletion protection on each Terraform-created shared filesystem that must be retained.
+
+```hcl
+filestore_jail = {
+  spec = {
+    size_gibibytes       = 2048
+    block_size_kibibytes = 4
+    forbid_deletion      = true
+  }
+}
+
+filestore_jail_submounts = [{
+  name       = "data"
+  mount_path = "/mnt/data"
+  spec = {
+    size_gibibytes       = 4096
+    block_size_kibibytes = 32
+    forbid_deletion      = true
+  }
+}]
+```
+
+2. Apply the deletion-protection change before removing anything from state.
+
+```bash
+terraform plan
+terraform apply
+```
+
+Confirm the plan only updates deletion protection on the filesystems you intend to retain.
+
+3. Record the retained filesystem IDs and the exact Terraform resource addresses.
+
+```bash
+terraform state list | grep 'module.filestore.nebius_compute_v1_filesystem'
+terraform state show 'module.filestore.nebius_compute_v1_filesystem.jail[0]'
+terraform state show 'module.filestore.nebius_compute_v1_filesystem.jail_submount["data"]'
+```
+
+4. Back up the Terraform state according to your team's state-management process. For a local backup, store the state file securely because it may contain sensitive values.
+
+```bash
+terraform state pull > terraform-state-before-retaining-filesystems.tfstate
+```
+
+5. Remove only the retained filesystems from Terraform state. This makes Terraform forget those filesystems so the cluster destroy does not try to delete them.
+
+```bash
+terraform state rm 'module.filestore.nebius_compute_v1_filesystem.jail[0]'
+terraform state rm 'module.filestore.nebius_compute_v1_filesystem.jail_submount["data"]'
+```
+
+If you also created and want to retain controller spool or accounting filesystems, remove their resource addresses as well:
+
+```bash
+terraform state rm 'module.filestore.nebius_compute_v1_filesystem.controller_spool[0]'
+terraform state rm 'module.filestore.nebius_compute_v1_filesystem.accounting[0]'
+```
+
+6. Verify the destroy plan before applying it.
+
+```bash
+terraform plan -destroy
+```
+
+Confirm that the retained `nebius_compute_v1_filesystem` resources are not listed for deletion. If a retained filesystem still appears in the destroy plan, stop and check the state addresses before continuing.
+
+7. Destroy the remaining cluster resources.
+
+```bash
+terraform destroy
+```
+
+8. To reuse the retained filesystems in a future cluster, configure them as `existing` filesystems with the IDs recorded earlier.
+
+```hcl
+filestore_jail = {
+  existing = {
+    id = "computefilesystem-<RETAINED-JAIL-ID>"
+  }
+}
+
+filestore_jail_submounts = [{
+  name       = "data"
+  mount_path = "/mnt/data"
+  existing = {
+    id = "computefilesystem-<RETAINED-DATA-ID>"
+  }
+}]
+```
+
+`forbid_deletion = true` prevents accidental provider-side deletion, but removing the retained filesystems from Terraform state is what allows `terraform destroy` to complete without trying to delete them.
 
 ## (Optional) Test Your Installation
 

--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -88,6 +88,7 @@ module "filestore" {
       disk_type            = "NETWORK_SSD"
       size_gibibytes       = var.filestore_controller_spool.spec.size_gibibytes
       block_size_kibibytes = var.filestore_controller_spool.spec.block_size_kibibytes
+      forbid_deletion      = var.filestore_controller_spool.spec.forbid_deletion
     } : null
     existing = var.filestore_controller_spool.existing != null ? {
       id = var.filestore_controller_spool.existing.id
@@ -99,6 +100,7 @@ module "filestore" {
       disk_type            = "NETWORK_SSD"
       size_gibibytes       = var.filestore_accounting.spec.size_gibibytes
       block_size_kibibytes = var.filestore_accounting.spec.block_size_kibibytes
+      forbid_deletion      = var.filestore_accounting.spec.forbid_deletion
     } : null
     existing = var.filestore_accounting.existing != null ? {
       id = var.filestore_accounting.existing.id
@@ -110,6 +112,7 @@ module "filestore" {
       disk_type            = "NETWORK_SSD"
       size_gibibytes       = var.filestore_jail.spec.size_gibibytes
       block_size_kibibytes = var.filestore_jail.spec.block_size_kibibytes
+      forbid_deletion      = var.filestore_jail.spec.forbid_deletion
     } : null
     existing = var.filestore_jail.existing != null ? {
       id = var.filestore_jail.existing.id
@@ -122,6 +125,7 @@ module "filestore" {
       disk_type            = "NETWORK_SSD"
       size_gibibytes       = submount.spec.size_gibibytes
       block_size_kibibytes = submount.spec.block_size_kibibytes
+      forbid_deletion      = submount.spec.forbid_deletion
     } : null
     existing = submount.existing != null ? {
       id = submount.existing.id

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -43,6 +43,7 @@ filestore_controller_spool = {
   spec = {
     size_gibibytes       = 128
     block_size_kibibytes = 4
+    forbid_deletion      = false
   }
 }
 # Or use existing filestore.
@@ -61,6 +62,7 @@ filestore_controller_spool = {
 #   spec = {
 #     size_gibibytes       = 2048
 #     block_size_kibibytes = 4
+#     forbid_deletion      = false
 #   }
 # }
 # Or use existing filestore.
@@ -81,6 +83,7 @@ filestore_jail = {
 #   spec = {
 #     size_gibibytes       = 2048
 #     block_size_kibibytes = 4
+#     forbid_deletion      = false
 #   }
 # }]
 # Or use existing filestores.
@@ -134,6 +137,7 @@ filestore_accounting = {
   spec = {
     size_gibibytes       = 512
     block_size_kibibytes = 4
+    forbid_deletion      = false
   }
 }
 # Or use existing filestore.

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -161,6 +161,7 @@ variable "filestore_controller_spool" {
     spec = optional(object({
       size_gibibytes       = number
       block_size_kibibytes = number
+      forbid_deletion      = optional(bool, false)
     }))
   })
   nullable = false
@@ -183,6 +184,7 @@ variable "filestore_jail" {
     spec = optional(object({
       size_gibibytes       = number
       block_size_kibibytes = number
+      forbid_deletion      = optional(bool, false)
     }))
   })
   nullable = false
@@ -225,6 +227,7 @@ variable "filestore_jail_submounts" {
     spec = optional(object({
       size_gibibytes       = number
       block_size_kibibytes = number
+      forbid_deletion      = optional(bool, false)
     }))
   }))
   default = []
@@ -343,6 +346,7 @@ variable "filestore_accounting" {
     spec = optional(object({
       size_gibibytes       = number
       block_size_kibibytes = number
+      forbid_deletion      = optional(bool, false)
     }))
   })
   default  = null

--- a/soperator/modules/filestore/main.tf
+++ b/soperator/modules/filestore/main.tf
@@ -8,6 +8,7 @@ resource "nebius_compute_v1_filesystem" "controller_spool" {
   type             = var.controller_spool.spec.disk_type
   size_bytes       = provider::units::from_gib(var.controller_spool.spec.size_gibibytes)
   block_size_bytes = provider::units::from_kib(var.controller_spool.spec.block_size_kibibytes)
+  forbid_deletion  = var.controller_spool.spec.forbid_deletion
 
   lifecycle {
     ignore_changes = [
@@ -44,6 +45,7 @@ resource "nebius_compute_v1_filesystem" "jail" {
   type             = var.jail.spec.disk_type
   size_bytes       = provider::units::from_gib(var.jail.spec.size_gibibytes)
   block_size_bytes = provider::units::from_kib(var.jail.spec.block_size_kibibytes)
+  forbid_deletion  = var.jail.spec.forbid_deletion
 
   lifecycle {
     ignore_changes = [
@@ -73,10 +75,11 @@ locals {
 resource "nebius_compute_v1_filesystem" "jail_submount" {
   for_each = tomap({ for submount in var.jail_submounts :
     submount.name => {
-      name    = local.name.jail_submount[submount.name]
-      type    = submount.spec.disk_type
-      storage = provider::units::from_gib(submount.spec.size_gibibytes)
-      block   = provider::units::from_kib(submount.spec.block_size_kibibytes)
+      name            = local.name.jail_submount[submount.name]
+      type            = submount.spec.disk_type
+      storage         = provider::units::from_gib(submount.spec.size_gibibytes)
+      block           = provider::units::from_kib(submount.spec.block_size_kibibytes)
+      forbid_deletion = submount.spec.forbid_deletion
     }
     if submount.spec != null
   })
@@ -88,6 +91,7 @@ resource "nebius_compute_v1_filesystem" "jail_submount" {
   type             = each.value.type
   size_bytes       = each.value.storage
   block_size_bytes = each.value.block
+  forbid_deletion  = each.value.forbid_deletion
 
   lifecycle {
     ignore_changes = [
@@ -137,6 +141,7 @@ resource "nebius_compute_v1_filesystem" "accounting" {
   type             = var.accounting.spec.disk_type
   size_bytes       = provider::units::from_gib(var.accounting.spec.size_gibibytes)
   block_size_bytes = provider::units::from_kib(var.accounting.spec.block_size_kibibytes)
+  forbid_deletion  = var.accounting.spec.forbid_deletion
 }
 data "nebius_compute_v1_filesystem" "accounting" {
   count = local.accounting_needed ? (var.accounting.existing != null ? 1 : 0) : 0

--- a/soperator/modules/filestore/variables.tf
+++ b/soperator/modules/filestore/variables.tf
@@ -20,6 +20,7 @@ variable "controller_spool" {
       disk_type            = string
       size_gibibytes       = number
       block_size_kibibytes = number
+      forbid_deletion      = optional(bool, false)
     }))
   })
   nullable = false
@@ -42,6 +43,7 @@ variable "jail" {
       disk_type            = string
       size_gibibytes       = number
       block_size_kibibytes = number
+      forbid_deletion      = optional(bool, false)
     }))
   })
   nullable = false
@@ -65,6 +67,7 @@ variable "jail_submounts" {
       disk_type            = string
       size_gibibytes       = number
       block_size_kibibytes = number
+      forbid_deletion      = optional(bool, false)
     }))
   }))
   default = []
@@ -88,6 +91,7 @@ variable "accounting" {
       disk_type            = string
       size_gibibytes       = number
       block_size_kibibytes = number
+      forbid_deletion      = optional(bool, false)
     }))
   })
   nullable = true

--- a/soperator/test/README.md
+++ b/soperator/test/README.md
@@ -67,6 +67,7 @@ filestore_jail_submounts = [{
   spec = {
     size_gibibytes       = 4096
     block_size_kibibytes = 32
+    forbid_deletion      = true
   }
 }]
 ```


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Adds `forbid_deletion` support for Soperator-managed shared filesystems.

This lets deployments opt into Nebius filesystem deletion protection for shared Soperator filesystems created by Terraform. The parameter defaults to `false` to preserve current behavior, but can be enabled per filesystem in `terraform.tfvars`.

## What Changed

- Added optional `forbid_deletion` fields to the Soperator installation filesystem specs:
  - `filestore_controller_spool.spec`
  - `filestore_jail.spec`
  - `filestore_jail_submounts[*].spec`
  - `filestore_accounting.spec`
- Passed the new value through `soperator/installations/example/main.tf` into the `filestore` module.
- Added `forbid_deletion` to all `nebius_compute_v1_filesystem` resources in `soperator/modules/filestore`.
- Updated the example `terraform.tfvars` to show the new parameter.
- Updated README documentation with a data-retention workflow for destroying a cluster while retaining protected shared filesystems.

## Behavior

By default, nothing changes:

```hcl
forbid_deletion = false
```
When enabled:

```hcl
forbid_deletion = true
```

Nebius refuses to delete the filesystem even if Terraform attempts to destroy it. This allows users to intentionally retain shared filesystems while tearing down the rest of a Soperator cluster.

## Validation

Ran:
```hcl
terraform fmt soperator/modules/filestore soperator/installations/example
git diff --check
terraform -chdir=soperator/installations/example init -backend=false
terraform -chdir=soperator/installations/example validate
```

Also performed a live CPU-only Soperator retention test in an ignored local installation directory.

Test flow:

- Provisioned a small CPU-only Soperator cluster with tiny shared filesystems.
- Enabled forbid_deletion = true on the shared filesystems.
- Confirmed the cluster deployed successfully.
- Ran terraform destroy.
- Confirmed non-filesystem cluster resources were deleted.
- Confirmed destroy failed intentionally on the shared filesystems with:
`filesystem cannot be deleted because forbid_deletion is set`

This is the expected behavior and confirms the retention protection works.
