### PR TITLE
soperator/example: forbid /home in filestore_jail_submounts

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -69,6 +69,7 @@ resource "terraform_data" "check_variables" {
     terraform_data.check_slurm_nodeset_accounting,
     terraform_data.check_nfs,
     terraform_data.check_nfs_exclusivity,
+    terraform_data.check_jail_submount_paths,
     terraform_data.check_local_nvme,
   ]
 }

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -76,6 +76,7 @@ filestore_jail = {
 # Additional shared filesystems to be mounted inside jail.
 # If a big filesystem is needed it's better to deploy this additional storage because jails bigger than 12 TiB
 # ARE NOT BACKED UP by default.
+# Do not use "/home" here. That path is reserved for the home-directory NFS mount.
 # ---
 # filestore_jail_submounts = [{
 #   name       = "data"

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -312,6 +312,18 @@ resource "terraform_data" "check_nfs_exclusivity" {
   }
 }
 
+resource "terraform_data" "check_jail_submount_paths" {
+  lifecycle {
+    precondition {
+      condition = alltrue([
+        for sm in var.filestore_jail_submounts :
+        sm.mount_path != "/home"
+      ])
+      error_message = "filestore_jail_submounts must not use \"/home\" as mount_path. That path is reserved for home directories, and backing /home with shared filestore causes severe performance degradation."
+    }
+  }
+}
+
 resource "terraform_data" "check_nfs" {
   depends_on = [
     terraform_data.check_region,


### PR DESCRIPTION
## Release Notes (Mandatory Description)

This PR adds a missing Terraform validation in the soperator example configuration to prevent filestore_jail_submounts from using /home as a mount path.

Mounting shared filestore at /home can severely degrade cluster responsiveness by putting latency-sensitive home-directory traffic on the same path as heavier shared-storage workloads. The change fails fast at the Terraform layer and updates the example comments to make the restriction explicit.