### PR TITLE
Expose k8s training RTX and Filestore deletion protection options

### DIFF
--- a/k8s-training/filesystem.tf
+++ b/k8s-training/filesystem.tf
@@ -5,6 +5,7 @@ resource "nebius_compute_v1_filesystem" "shared-filesystem" {
   type             = var.filestore_disk_type
   size_bytes       = provider::units::from_gib(var.filestore_disk_size_gibibytes)
   block_size_bytes = provider::units::from_kib(var.filestore_block_size_kibibytes)
+  forbid_deletion  = var.filestore_forbid_deletion
 
   lifecycle {
     ignore_changes = [

--- a/k8s-training/gpu_cluster.tf
+++ b/k8s-training/gpu_cluster.tf
@@ -1,5 +1,5 @@
 resource "nebius_compute_v1_gpu_cluster" "fabric_2" {
-  count = var.enable_gpu_cluster ? 1 : 0
+  count = local.enable_gpu_cluster ? 1 : 0
 
   infiniband_fabric = local.infiniband_fabric
   parent_id         = var.parent_id

--- a/k8s-training/locals.tf
+++ b/k8s-training/locals.tf
@@ -20,42 +20,36 @@ locals {
       cpu_nodes_preset   = "16vcpu-64gb"
       gpu_nodes_platform = "gpu-h200-sxm"
       gpu_nodes_preset   = "8gpu-128vcpu-1600gb"
-      infiniband_fabric  = "fabric-5"
     }
     eu-north1 = {
       cpu_nodes_platform = "cpu-d3"
       cpu_nodes_preset   = "16vcpu-64gb"
       gpu_nodes_platform = "gpu-h100-sxm"
       gpu_nodes_preset   = "8gpu-128vcpu-1600gb"
-      infiniband_fabric  = "fabric-3"
     }
     eu-north2 = {
       cpu_nodes_platform = "cpu-d3"
       cpu_nodes_preset   = "16vcpu-64gb"
       gpu_nodes_platform = "gpu-h200-sxm"
       gpu_nodes_preset   = "8gpu-128vcpu-1600gb"
-      infiniband_fabric  = "eu-north2-a"
     }
     us-central1 = {
       cpu_nodes_platform = "cpu-d3"
       cpu_nodes_preset   = "16vcpu-64gb"
       gpu_nodes_platform = "gpu-h200-sxm"
       gpu_nodes_preset   = "8gpu-128vcpu-1600gb"
-      infiniband_fabric  = "us-central1-a"
     }
     me-west1 = {
       cpu_nodes_platform = "cpu-d3"
       cpu_nodes_preset   = "16vcpu-64gb"
       gpu_nodes_platform = "gpu-b200-sxm-a"
       gpu_nodes_preset   = "8gpu-160vcpu-1792gb"
-      infiniband_fabric  = "ramon"
     }
     uk-south1 = {
       cpu_nodes_platform = "cpu-d3"
       cpu_nodes_preset   = "16vcpu-64gb"
       gpu_nodes_platform = "gpu-b300-sxm"
       gpu_nodes_preset   = "8gpu-192vcpu-2768gb"
-      infiniband_fabric  = "uk-south1-a"
     }
   }
 
@@ -65,7 +59,8 @@ locals {
   cpu_nodes_platform = coalesce(var.cpu_nodes_platform, local.current_region_defaults.cpu_nodes_platform)
   gpu_nodes_platform = coalesce(var.gpu_nodes_platform, local.current_region_defaults.gpu_nodes_platform)
   gpu_nodes_preset   = coalesce(var.gpu_nodes_preset, local.current_region_defaults.gpu_nodes_preset)
-  infiniband_fabric  = coalesce(var.infiniband_fabric, local.current_region_defaults.infiniband_fabric)
+  infiniband_fabric  = var.infiniband_fabric
+  enable_gpu_cluster = local.infiniband_fabric != null ? trimspace(local.infiniband_fabric) != "" : false
   device_preset      = "cuda13.0"
   gpu_operator_cdi_enabled = (
     !var.gpu_nodes_driverfull_image &&

--- a/k8s-training/main.tf
+++ b/k8s-training/main.tf
@@ -115,6 +115,13 @@ resource "nebius_mk8s_v1_node_group" "cpu-only" {
 resource "nebius_mk8s_v1_node_group" "gpu" {
   count = var.gpu_node_groups
 
+  lifecycle {
+    precondition {
+      condition     = !local.enable_gpu_cluster || startswith(local.gpu_nodes_preset, "8gpu-")
+      error_message = "GPU clustering requires an 8-GPU preset. Leave 'infiniband_fabric' empty for single-GPU presets such as '${local.gpu_nodes_preset}'."
+    }
+  }
+
   autoscaling = var.gpu_nodes_autoscaling.enabled ? {
     min_node_count = var.gpu_nodes_autoscaling.min_size == null ? var.gpu_nodes_autoscaling.max_size : var.gpu_nodes_autoscaling.min_size
     max_node_count = var.gpu_nodes_autoscaling.max_size
@@ -165,7 +172,7 @@ resource "nebius_mk8s_v1_node_group" "gpu" {
         }
       }
     ] : null
-    gpu_cluster  = var.enable_gpu_cluster ? nebius_compute_v1_gpu_cluster.fabric_2[0] : null
+    gpu_cluster  = local.enable_gpu_cluster ? nebius_compute_v1_gpu_cluster.fabric_2[0] : null
     gpu_settings = var.gpu_nodes_driverfull_image ? { drivers_preset = local.device_preset } : null
     preemptible = var.gpu_nodes_preemptible ? {
       on_preemption = "STOP"

--- a/k8s-training/terraform.tfvars
+++ b/k8s-training/terraform.tfvars
@@ -37,8 +37,7 @@ cpu_nodes_preset   = "4vcpu-16gb" # CPU nodes preset
 gpu_nodes_platform = "gpu-h200-sxm"        # GPU nodes platform: gpu-h100-sxm, gpu-h200-sxm, gpu-b200-sxm
 gpu_nodes_preset   = "8gpu-128vcpu-1600gb" # GPU nodes preset: 8gpu-128vcpu-1600gb, 8gpu-128vcpu-1600gb, 8gpu-160vcpu-1792gb
 # Infiniband fabrics: https://docs.nebius.com/compute/clusters/gpu#fabrics
-infiniband_fabric  = ""   # Infiniband fabric name
-enable_gpu_cluster = true # Disable for RTX6000 deployments or single-node deployments.
+infiniband_fabric = "" # Leave empty to disable GPU clustering for RTX6000 deployments or single-node deployments.
 
 gpu_nodes_driverfull_image = true
 enable_k8s_node_group_sa   = true

--- a/k8s-training/terraform.tfvars
+++ b/k8s-training/terraform.tfvars
@@ -37,7 +37,8 @@ cpu_nodes_preset   = "4vcpu-16gb" # CPU nodes preset
 gpu_nodes_platform = "gpu-h200-sxm"        # GPU nodes platform: gpu-h100-sxm, gpu-h200-sxm, gpu-b200-sxm
 gpu_nodes_preset   = "8gpu-128vcpu-1600gb" # GPU nodes preset: 8gpu-128vcpu-1600gb, 8gpu-128vcpu-1600gb, 8gpu-160vcpu-1792gb
 # Infiniband fabrics: https://docs.nebius.com/compute/clusters/gpu#fabrics
-infiniband_fabric = "" # Infiniband fabric name
+infiniband_fabric  = ""   # Infiniband fabric name
+enable_gpu_cluster = true # Disable for RTX6000 deployments or single-node deployments.
 
 gpu_nodes_driverfull_image = true
 enable_k8s_node_group_sa   = true
@@ -69,6 +70,7 @@ enable_filestore               = false # Enable or disable Filestore integration
 existing_filestore             = ""    # If enable_filestore = true, with this variable we can add existing filestore. Require string, example existing_filestore = "computefilesystem-e00r7z9vfxmg1bk99s"
 filestore_disk_size_gibibytes  = 100   # Set Filestore disk size in Gbytes.
 filestore_block_size_kibibytes = 4     # Set Filestore block size in bytes
+filestore_forbid_deletion      = false # Set to true to protect Terraform-created Filestore from deletion.
 
 # KubeRay Cluster
 # for GPU isolation to work with kuberay, gpu_nodes_driverfull_image must be set 

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -77,6 +77,12 @@ variable "filestore_block_size_kibibytes" {
   default     = 4 # 4kb
 }
 
+variable "filestore_forbid_deletion" {
+  description = "Protect Terraform-created Filestore from deletion."
+  type        = bool
+  default     = false
+}
+
 variable "filestore_mount_path" {
   description = "Mount path for the shared filesystem on Kubernetes nodes."
   type        = string

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -201,19 +201,8 @@ variable "gpu_disk_size" {
   default     = "1023"
 }
 
-variable "enable_gpu_cluster" {
-  description = "Enable GPU clustering and InfiniBand for the GPU node group."
-  type        = bool
-  default     = true
-
-  validation {
-    condition     = !var.enable_gpu_cluster || startswith(local.gpu_nodes_preset, "8gpu-")
-    error_message = "GPU clustering requires an 8-GPU preset. Set 'enable_gpu_cluster = false' for single-GPU presets such as '${local.gpu_nodes_preset}'."
-  }
-}
-
 variable "infiniband_fabric" {
-  description = "Infiniband's fabric name."
+  description = "InfiniBand fabric name. Leave null or empty to disable GPU clustering."
   type        = string
   default     = null
 }


### PR DESCRIPTION

## Release Notes (Mandatory Description)

Add enable_gpu_cluster to the k8s-training tfvars sample so RTX6000 and single-node deployments can explicitly disable GPU clustering while the default 8-GPU training path remains enabled.

Add filestore_forbid_deletion to k8s-training and pass it through to the Nebius filesystem forbid_deletion field, allowing option to protect the shared filestore.
