### PR TITLE
custom-nat-gateway: add existing-VPC NAT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Enhance security with a Wireguard VPN instance by minimizing the use of public I
 
 Deploys a Bastion instance that serves as a secure jump host for your infrastructure. It improves the security by minimizing the use of Public IPs and limiting access to the rest of the environment. 
 
+[Custom NAT gateway](./custom-nat-gateway/README.md)
+
+Deploys a dedicated gateway VM, custom route table, and private workload subnet so selected subnets can route internet egress through a Nebius-hosted NAT gateway instead of the default egress gateway.
+
 ### Integration
 
 [Anyscale](./anyscale/README.md)

--- a/custom-nat-gateway/README.md
+++ b/custom-nat-gateway/README.md
@@ -1,0 +1,124 @@
+# Creating a custom NAT gateway
+
+This example deploys a custom NAT gateway in Nebius AI Cloud.
+
+It creates:
+
+* resources inside an existing VPC network
+* a gateway subnet for the NAT VM
+* a private workload subnet
+* a private `/32` allocation for the gateway VM
+* a public `/32` allocation for the gateway VM
+* a route table with `0.0.0.0/0` pointed at the gateway private allocation
+* an optional private test VM whose outbound traffic uses the gateway VM
+
+The gateway VM must stay in its own subnet. The private route table belongs on the workload subnet only. If you attach it to the gateway subnet, the gateway routes to itself and stops working.
+
+## Prerequisites
+
+1. Install [Nebius CLI](https://docs.nebius.com/cli/).
+2. Configure a Nebius CLI profile with access to the target project.
+3. Install [Terraform](https://www.terraform.io/).
+4. Install `jq`.
+
+## Installation
+
+1. Configure `NEBIUS_TENANT_ID`, `NEBIUS_PROJECT_ID`, and `NEBIUS_REGION` in `environment.sh`.
+2. Load the environment:
+
+   ```bash
+   source ./environment.sh
+   ```
+
+3. Initialize Terraform:
+
+   ```bash
+   terraform init
+   ```
+
+4. Update `terraform.tfvars` with your VPC network ID and SSH settings.
+5. Preview the deployment:
+
+   ```bash
+   terraform plan
+   ```
+
+6. Apply the configuration:
+
+   ```bash
+   terraform apply
+   ```
+
+## Configuration variables
+
+Set these values in `terraform.tfvars`:
+
+* `vpc_network_id`
+* `ssh_user_name`
+* `ssh_public_key`
+* `deploy_test_vm`
+
+If you want a different footprint, adjust the VM presets and disk sizes in `variables.tf`.
+
+`vpc_network_id` is required. The example validates that the network exists and belongs to the project in `parent_id`. If the network lookup fails, or the network belongs to a different project, Terraform fails before it creates any subnet or route table resources.
+
+## What Terraform deploys
+
+The flow is:
+
+1. Validate the existing VPC network ID against the target project.
+2. Create a dedicated gateway subnet.
+3. Create a private workload subnet.
+4. Create a private allocation in the gateway subnet.
+5. Create a public allocation in the gateway subnet.
+6. Create the gateway VM with the private and public allocations attached to `eth0`.
+7. Configure IPv4 forwarding and the `iptables` MASQUERADE rule on the gateway VM through cloud-init.
+8. Create a custom route table in the same network.
+9. Create a default route in that route table that points to the gateway private allocation.
+10. Associate the custom route table only with the workload subnet.
+11. Optionally create a private workload VM in the routed subnet.
+
+## Verifying the NAT gateway
+
+After `terraform apply`, get the outputs:
+
+```bash
+terraform output
+```
+
+Then:
+
+1. SSH to the gateway VM.
+2. SSH from the gateway VM to the private workload VM.
+3. On the workload VM, run:
+
+   ```bash
+   curl ifconfig.me
+   ```
+
+The command should return the public IP of the gateway VM.
+
+You can also use the generated SSH jump command from `terraform output ssh_jump_command`.
+
+If `deploy_test_vm = false`, Terraform still creates the gateway, route table, and private subnet. The workload VM outputs are `null` in that mode.
+
+## Tests
+
+This example includes a `terraform test` smoke test.
+
+The test checks:
+
+* the private subnet is attached to the custom route table
+* the default route points to the gateway private allocation
+* the gateway and workload IP outputs are populated when the test VM is enabled
+
+## Useful outputs
+
+The solution exposes:
+
+* the existing network ID
+* gateway public IP
+* gateway private IP
+* workload private IP
+* route table ID
+* a ready-to-copy SSH jump command

--- a/custom-nat-gateway/disks.tf
+++ b/custom-nat-gateway/disks.tf
@@ -1,0 +1,18 @@
+resource "nebius_compute_v1_disk" "gateway_boot_disk" {
+  parent_id           = var.parent_id
+  name                = "${var.name_prefix}-gateway-boot-disk"
+  size_bytes          = var.gateway_boot_disk_size_gib * 1024 * 1024 * 1024
+  block_size_bytes    = 4096
+  type                = "NETWORK_SSD"
+  source_image_family = { image_family = var.source_image_family }
+}
+
+resource "nebius_compute_v1_disk" "workload_boot_disk" {
+  count               = var.deploy_test_vm ? 1 : 0
+  parent_id           = var.parent_id
+  name                = "${var.name_prefix}-workload-boot-disk"
+  size_bytes          = var.workload_boot_disk_size_gib * 1024 * 1024 * 1024
+  block_size_bytes    = 4096
+  type                = "NETWORK_SSD"
+  source_image_family = { image_family = var.source_image_family }
+}

--- a/custom-nat-gateway/environment.sh
+++ b/custom-nat-gateway/environment.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Set the following environment variables:
+# NEBIUS_TENANT_ID='tenant-...'
+# NEBIUS_PROJECT_ID='project-...'
+# NEBIUS_REGION='eu-north1'
+
+if [ -z "${NEBIUS_TENANT_ID}" ]; then
+  echo "Error: NEBIUS_TENANT_ID is not set"
+  return 1
+fi
+
+if [ -z "${NEBIUS_PROJECT_ID}" ]; then
+  echo "Error: NEBIUS_PROJECT_ID is not set"
+  return 1
+fi
+
+if [ -z "${NEBIUS_REGION}" ]; then
+  echo "Error: NEBIUS_REGION is not set"
+  return 1
+fi
+
+unset NEBIUS_IAM_TOKEN
+export NEBIUS_IAM_TOKEN=$(nebius iam get-access-token)
+
+export NEBIUS_BUCKET_NAME="tfstate-custom-nat-gateway-$(echo -n "${NEBIUS_TENANT_ID}-${NEBIUS_PROJECT_ID}" | md5sum | awk '$0=$1')"
+EXISTS=$(nebius storage bucket list \
+  --parent-id "${NEBIUS_PROJECT_ID}" \
+  --format json \
+  | jq -r --arg BUCKET "${NEBIUS_BUCKET_NAME}" 'try .items[] | select(.metadata.name == $BUCKET) | .metadata.name')
+
+if [ -z "${EXISTS}" ]; then
+  nebius storage bucket create \
+    --name "${NEBIUS_BUCKET_NAME}" \
+    --parent-id "${NEBIUS_PROJECT_ID}" \
+    --versioning-policy enabled >/dev/null
+  echo "Created bucket: ${NEBIUS_BUCKET_NAME}"
+else
+  echo "Using existing bucket: ${NEBIUS_BUCKET_NAME}"
+fi
+
+cat > terraform_backend_override.tf <<EOF
+terraform {
+  backend "s3" {
+    bucket = "${NEBIUS_BUCKET_NAME}"
+    key    = "custom-nat-gateway.tfstate"
+
+    endpoints = {
+      s3 = "https://storage.${NEBIUS_REGION}.nebius.cloud:443"
+    }
+    region = "${NEBIUS_REGION}"
+
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+  }
+}
+EOF
+
+export TF_VAR_parent_id="${NEBIUS_PROJECT_ID}"
+
+echo "Exported variables:"
+echo "NEBIUS_TENANT_ID: ${NEBIUS_TENANT_ID}"
+echo "NEBIUS_PROJECT_ID: ${NEBIUS_PROJECT_ID}"
+echo "NEBIUS_REGION: ${NEBIUS_REGION}"
+echo "NEBIUS_BUCKET_NAME: ${NEBIUS_BUCKET_NAME}"

--- a/custom-nat-gateway/locals.tf
+++ b/custom-nat-gateway/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  ssh_public_key = var.ssh_public_key.key != null ? var.ssh_public_key.key : (
+    fileexists(pathexpand(var.ssh_public_key.path)) ? file(pathexpand(var.ssh_public_key.path)) : null
+  )
+}

--- a/custom-nat-gateway/main.tf
+++ b/custom-nat-gateway/main.tf
@@ -1,0 +1,171 @@
+data "external" "existing_network" {
+  program = ["bash", "${path.module}/scripts/validate-network.sh"]
+
+  query = {
+    network_id = var.vpc_network_id
+    parent_id  = var.parent_id
+  }
+}
+
+resource "terraform_data" "network_validation" {
+  input = data.external.existing_network.result
+
+  lifecycle {
+    precondition {
+      condition     = data.external.existing_network.result.network_exists == "true"
+      error_message = "VPC network ${var.vpc_network_id} was not found or could not be read with the current Nebius CLI credentials. ${data.external.existing_network.result.error}"
+    }
+
+    precondition {
+      condition     = data.external.existing_network.result.project_matches == "true"
+      error_message = "VPC network ${var.vpc_network_id} does not belong to project ${var.parent_id}."
+    }
+  }
+}
+
+resource "nebius_vpc_v1_subnet" "gateway_subnet" {
+  parent_id  = var.parent_id
+  network_id = var.vpc_network_id
+  name       = "${var.name_prefix}-gateway-subnet"
+
+  depends_on = [terraform_data.network_validation]
+}
+
+resource "nebius_vpc_v1_route_table" "nat_gateway_table" {
+  parent_id  = var.parent_id
+  network_id = var.vpc_network_id
+  name       = "${var.name_prefix}-route-table"
+
+  depends_on = [terraform_data.network_validation]
+}
+
+resource "nebius_vpc_v1_subnet" "private_subnet" {
+  parent_id      = var.parent_id
+  network_id     = var.vpc_network_id
+  route_table_id = nebius_vpc_v1_route_table.nat_gateway_table.id
+  name           = "${var.name_prefix}-private-subnet"
+
+  depends_on = [terraform_data.network_validation]
+}
+
+resource "nebius_vpc_v1_allocation" "gateway_private_ip" {
+  parent_id = var.parent_id
+  name      = "${var.name_prefix}-gateway-private-ip"
+
+  ipv4_private = {
+    cidr      = "/32"
+    subnet_id = nebius_vpc_v1_subnet.gateway_subnet.id
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "nebius_vpc_v1_allocation" "gateway_public_ip" {
+  parent_id = var.parent_id
+  name      = "${var.name_prefix}-gateway-public-ip"
+
+  ipv4_public = {
+    cidr      = "/32"
+    subnet_id = nebius_vpc_v1_subnet.gateway_subnet.id
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "nebius_vpc_v1_allocation" "workload_private_ip" {
+  count     = var.deploy_test_vm ? 1 : 0
+  parent_id = var.parent_id
+  name      = "${var.name_prefix}-workload-private-ip"
+
+  ipv4_private = {
+    cidr      = "/32"
+    subnet_id = nebius_vpc_v1_subnet.private_subnet.id
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "nebius_compute_v1_instance" "gateway_vm" {
+  parent_id = var.parent_id
+  name      = "${var.name_prefix}-gateway-vm"
+
+  boot_disk = {
+    attach_mode   = "READ_WRITE"
+    existing_disk = nebius_compute_v1_disk.gateway_boot_disk
+  }
+
+  network_interfaces = [
+    {
+      name      = "eth0"
+      subnet_id = nebius_vpc_v1_subnet.gateway_subnet.id
+      ip_address = {
+        allocation_id = nebius_vpc_v1_allocation.gateway_private_ip.id
+      }
+      public_ip_address = {
+        allocation_id = nebius_vpc_v1_allocation.gateway_public_ip.id
+      }
+    }
+  ]
+
+  resources = {
+    platform = var.gateway_platform
+    preset   = var.gateway_preset
+  }
+
+  cloud_init_user_data = templatefile("../modules/cloud-init/nat-gateway-cloud-init.tftpl", {
+    ssh_user_name  = var.ssh_user_name
+    ssh_public_key = local.ssh_public_key
+  })
+}
+
+resource "nebius_vpc_v1_route" "default_to_gateway" {
+  parent_id = nebius_vpc_v1_route_table.nat_gateway_table.id
+  name      = "${var.name_prefix}-default-route"
+
+  destination = {
+    cidr = "0.0.0.0/0"
+  }
+
+  next_hop = {
+    allocation = {
+      id = nebius_vpc_v1_allocation.gateway_private_ip.id
+    }
+  }
+}
+
+resource "nebius_compute_v1_instance" "workload_vm" {
+  count     = var.deploy_test_vm ? 1 : 0
+  parent_id = var.parent_id
+  name      = "${var.name_prefix}-workload-vm"
+
+  boot_disk = {
+    attach_mode   = "READ_WRITE"
+    existing_disk = nebius_compute_v1_disk.workload_boot_disk[0]
+  }
+
+  network_interfaces = [
+    {
+      name      = "eth0"
+      subnet_id = nebius_vpc_v1_subnet.private_subnet.id
+      ip_address = {
+        allocation_id = nebius_vpc_v1_allocation.workload_private_ip[0].id
+      }
+    }
+  ]
+
+  resources = {
+    platform = var.workload_platform
+    preset   = var.workload_preset
+  }
+
+  cloud_init_user_data = templatefile("../modules/cloud-init/private-vm-cloud-init.tftpl", {
+    ssh_user_name  = var.ssh_user_name
+    ssh_public_key = local.ssh_public_key
+  })
+}

--- a/custom-nat-gateway/output.tf
+++ b/custom-nat-gateway/output.tf
@@ -1,0 +1,34 @@
+output "network_id" {
+  description = "ID of the existing VPC network used by the NAT gateway solution."
+  value       = var.vpc_network_id
+}
+
+output "gateway_public_ip" {
+  description = "Public IP address of the gateway VM."
+  value       = split("/", nebius_vpc_v1_allocation.gateway_public_ip.status.details.allocated_cidr)[0]
+}
+
+output "gateway_private_ip" {
+  description = "Private IP address used as the route next hop."
+  value       = split("/", nebius_vpc_v1_allocation.gateway_private_ip.status.details.allocated_cidr)[0]
+}
+
+output "workload_private_ip" {
+  description = "Private IP address of the workload VM when deploy_test_vm is true."
+  value       = var.deploy_test_vm ? split("/", nebius_vpc_v1_allocation.workload_private_ip[0].status.details.allocated_cidr)[0] : null
+}
+
+output "route_table_id" {
+  description = "ID of the custom route table assigned to the private subnet."
+  value       = nebius_vpc_v1_route_table.nat_gateway_table.id
+}
+
+output "workload_subnet_id" {
+  description = "ID of the private workload subnet."
+  value       = nebius_vpc_v1_subnet.private_subnet.id
+}
+
+output "ssh_jump_command" {
+  description = "SSH command that jumps through the gateway VM to the private workload VM when deploy_test_vm is true."
+  value       = var.deploy_test_vm ? "ssh -J ${var.ssh_user_name}@${split("/", nebius_vpc_v1_allocation.gateway_public_ip.status.details.allocated_cidr)[0]} ${var.ssh_user_name}@${split("/", nebius_vpc_v1_allocation.workload_private_ip[0].status.details.allocated_cidr)[0]}" : null
+}

--- a/custom-nat-gateway/provider.tf
+++ b/custom-nat-gateway/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    external = {
+      source = "hashicorp/external"
+    }
+    nebius = {
+      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+    }
+  }
+}
+
+provider "nebius" {
+  domain = "api.eu.nebius.cloud:443"
+}

--- a/custom-nat-gateway/scripts/validate-network.sh
+++ b/custom-nat-gateway/scripts/validate-network.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+query="$(cat)"
+network_id="$(printf '%s' "$query" | jq -r '.network_id // empty')"
+parent_id="$(printf '%s' "$query" | jq -r '.parent_id // empty')"
+
+if [[ -z "$network_id" || -z "$parent_id" ]]; then
+  printf '%s\n' '{"network_exists":"false","project_matches":"false","error":"network_id and parent_id are required"}'
+  exit 0
+fi
+
+if ! network_json="$(/Users/realz/.nebius/bin/nebius vpc network get --id "$network_id" --format json 2>&1)"; then
+  printf '{"network_exists":"false","project_matches":"false","error":%s}\n' "$(printf '%s' "$network_json" | jq -Rs .)"
+  exit 0
+fi
+
+network_parent_id="$(printf '%s' "$network_json" | jq -r '.metadata.parent_id // .parent_id // empty')"
+network_name="$(printf '%s' "$network_json" | jq -r '.metadata.name // .name // empty')"
+
+project_matches="false"
+if [[ "$network_parent_id" == "$parent_id" ]]; then
+  project_matches="true"
+fi
+
+printf '{"network_exists":"true","project_matches":"%s","network_name":%s,"network_parent_id":%s,"error":""}\n' \
+  "$project_matches" \
+  "$(printf '%s' "$network_name" | jq -Rs .)" \
+  "$(printf '%s' "$network_parent_id" | jq -Rs .)"

--- a/custom-nat-gateway/terraform.tfvars
+++ b/custom-nat-gateway/terraform.tfvars
@@ -1,0 +1,12 @@
+# Existing VPC network
+# vpc_network_id = "vpcnetwork-..."
+
+# SSH config
+# ssh_user_name = "ubuntu"
+# ssh_public_key = {
+#   key  = "put your public ssh key here"
+#   path = "put path to public ssh key here"
+# }
+
+# Optional test VM
+# deploy_test_vm = true

--- a/custom-nat-gateway/tests/main.tftest.hcl
+++ b/custom-nat-gateway/tests/main.tftest.hcl
@@ -1,0 +1,28 @@
+run "custom_nat_gateway_apply" {
+  command = apply
+
+  assert {
+    condition     = nebius_vpc_v1_subnet.private_subnet.route_table_id == nebius_vpc_v1_route_table.nat_gateway_table.id
+    error_message = "Private subnet is not associated with the custom NAT gateway route table."
+  }
+
+  assert {
+    condition     = nebius_vpc_v1_route.default_to_gateway.next_hop.allocation.id == nebius_vpc_v1_allocation.gateway_private_ip.id
+    error_message = "Default route does not point to the gateway private allocation."
+  }
+
+  assert {
+    condition     = output.gateway_public_ip != ""
+    error_message = "Gateway public IP output is empty."
+  }
+
+  assert {
+    condition     = output.gateway_private_ip != ""
+    error_message = "Gateway private IP output is empty."
+  }
+
+  assert {
+    condition     = output.workload_private_ip != ""
+    error_message = "Workload private IP output is empty."
+  }
+}

--- a/custom-nat-gateway/variables.tf
+++ b/custom-nat-gateway/variables.tf
@@ -1,0 +1,89 @@
+variable "parent_id" {
+  description = "Project ID."
+  type        = string
+}
+
+variable "vpc_network_id" {
+  description = "Existing VPC network ID where the NAT gateway subnets and route table will be created."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = trimspace(var.vpc_network_id) != "" && can(regex("^vpcnetwork-", trimspace(var.vpc_network_id)))
+    error_message = "vpc_network_id must be set to an existing VPC network ID like vpcnetwork-...."
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix used for resource names."
+  type        = string
+  default     = "custom-nat-gateway"
+}
+
+variable "ssh_user_name" {
+  description = "SSH username used on both virtual machines."
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key used to access the virtual machines."
+  type = object({
+    key  = optional(string),
+    path = optional(string, "~/.ssh/id_ed25519.pub")
+  })
+  default = {}
+
+  validation {
+    condition     = var.ssh_public_key.key != null || fileexists(pathexpand(var.ssh_public_key.path))
+    error_message = "SSH public key must be set by `key` or by file `path`."
+  }
+}
+
+variable "source_image_family" {
+  description = "Image family used for both virtual machines."
+  type        = string
+  default     = "ubuntu24.04-driverless"
+}
+
+variable "gateway_platform" {
+  description = "Platform used by the NAT gateway VM."
+  type        = string
+  default     = "cpu-d3"
+}
+
+variable "gateway_preset" {
+  description = "Preset used by the NAT gateway VM."
+  type        = string
+  default     = "4vcpu-16gb"
+}
+
+variable "gateway_boot_disk_size_gib" {
+  description = "Gateway VM boot disk size in GiB."
+  type        = number
+  default     = 50
+}
+
+variable "workload_platform" {
+  description = "Platform used by the private test VM."
+  type        = string
+  default     = "cpu-d3"
+}
+
+variable "workload_preset" {
+  description = "Preset used by the private test VM."
+  type        = string
+  default     = "4vcpu-16gb"
+}
+
+variable "workload_boot_disk_size_gib" {
+  description = "Private test VM boot disk size in GiB."
+  type        = number
+  default     = 30
+}
+
+variable "deploy_test_vm" {
+  description = "When true, deploy the private test VM and its private allocation."
+  type        = bool
+  default     = true
+}

--- a/modules/cloud-init/nat-gateway-cloud-init.tftpl
+++ b/modules/cloud-init/nat-gateway-cloud-init.tftpl
@@ -1,0 +1,35 @@
+#cloud-config
+users:
+  - name: ${ssh_user_name}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ${ssh_public_key}
+
+write_files:
+  - path: /etc/sysctl.d/99-nebius-custom-nat-gateway.conf
+    permissions: "0644"
+    owner: root:root
+    content: |
+      net.ipv4.ip_forward=1
+  - path: /etc/systemd/system/nebius-custom-nat-gateway.service
+    permissions: "0644"
+    owner: root:root
+    content: |
+      [Unit]
+      Description=Configure Nebius custom NAT gateway
+      Wants=network-online.target
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/sbin/sysctl -w net.ipv4.ip_forward=1
+      ExecStart=/bin/sh -c '/usr/sbin/iptables -t nat -C POSTROUTING -o eth0 -j MASQUERADE || /usr/sbin/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE'
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable --now nebius-custom-nat-gateway.service

--- a/modules/cloud-init/private-vm-cloud-init.tftpl
+++ b/modules/cloud-init/private-vm-cloud-init.tftpl
@@ -1,0 +1,7 @@
+#cloud-config
+users:
+  - name: ${ssh_user_name}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ${ssh_public_key}


### PR DESCRIPTION
## What changed

- adds a new `custom-nat-gateway` Terraform example
- creates a gateway subnet, a private workload subnet, a custom route table, and a gateway VM that handles outbound NAT
- expects an existing VPC through `vpc_network_id` instead of creating a new network
- adds a CLI-backed validation step so the run fails early if the VPC is missing or belongs to the wrong project
- adds `deploy_test_vm` so the private workload VM can be turned off when you only want the gateway path
- adds README and smoke-test coverage for the example

## Validation

- `terraform -chdir=custom-nat-gateway fmt`
- `terraform -chdir=custom-nat-gateway init -backend=false`
- `terraform -chdir=custom-nat-gateway validate`
- `terraform -chdir=custom-nat-gateway test` against a live Nebius project