### PR TITLE
SCHED-1583: Limit max pods for Soperator worker node groups

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -54,6 +54,7 @@ locals {
       subset_index       = subset
       preemptible        = nodeset.preemptible
       reservation_policy = nodeset.reservation_policy
+      max_pods           = nodeset.max_pods
       local_nvme = {
         enabled         = try(nodeset.local_nvme.enabled, false)
         mount_path      = try(nodeset.local_nvme.mount_path, "/mnt/local-nvme")

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -367,6 +367,8 @@ slurm_nodeset_workers = [
     # By default, false.
     ephemeral_nodes                = false
     initial_number_ephemeral_nodes = 1
+    # Maximum number of pods per worker node. Default is 32 to reduce per-node Pod CIDR usage.
+    max_pods = 32
     # Optional local NVMe passthrough for this nodeset only.
     # Uses local instance disks, creates a RAID0 array and mounts it on the host via cloud-init.
     # mount_path: path used for both host RAID mount and jail submount.

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -763,6 +763,7 @@ variable "slurm_nodeset_workers" {
       mount_path      = optional(string, "/mnt/local-nvme")
       filesystem_type = optional(string, "ext4")
     }), {})
+    max_pods = optional(number, 32)
     node_local_image_disk = object({
       enabled = bool
       spec = optional(object({
@@ -830,6 +831,14 @@ variable "slurm_nodeset_workers" {
       worker.autoscaling.min_size == null || worker.autoscaling.min_size <= worker.size
     ])
     error_message = "Worker nodeset autoscaling.min_size must be less than or equal to size."
+  }
+
+  validation {
+    condition = alltrue([
+      for worker in var.slurm_nodeset_workers :
+      worker.max_pods > 0
+    ])
+    error_message = "Worker nodeset max_pods must be greater than 0."
   }
 
   validation {

--- a/soperator/modules/k8s/k8s_ng_workers_v2.tf
+++ b/soperator/modules/k8s/k8s_ng_workers_v2.tf
@@ -137,6 +137,8 @@ resource "nebius_mk8s_v1_node_group" "worker_v2" {
 
     reservation_policy = var.node_group_workers_v2[count.index].reservation_policy
 
+    max_pods = var.node_group_workers_v2[count.index].max_pods
+
     gpu_settings = (var.use_preinstalled_gpu_drivers && local.node_group_gpu_present_v2.worker[count.index]) ? {
       drivers_preset = lookup(var.platform_driver_presets, var.node_group_workers_v2[count.index].resource.platform)
     } : null

--- a/soperator/modules/k8s/variables.tf
+++ b/soperator/modules/k8s/variables.tf
@@ -155,6 +155,7 @@ variable "node_group_workers_v2" {
       policy          = optional(string)
       reservation_ids = optional(list(string))
     }))
+    max_pods = optional(number, 32)
     local_nvme = optional(object({
       enabled         = optional(bool, false)
       mount_path      = optional(string, "/mnt/local-nvme")
@@ -164,6 +165,14 @@ variable "node_group_workers_v2" {
     subset_index  = number
   }))
   default = []
+
+  validation {
+    condition = alltrue([
+      for worker in var.node_group_workers_v2 :
+      worker.max_pods > 0
+    ])
+    error_message = "Worker node group max_pods must be greater than 0."
+  }
 }
 
 variable "node_group_login" {


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Limits Soperator worker Mk8s nodegroups to max_pods = 32 by default to reduce per-node Pod CIDR usage and support larger clusters. The value is configurable per worker nodeset and is applied to all generated worker nodegroup shards, while non-worker nodegroups remain unchanged.
