### PR TITLE
SCHED-301: Scale KSM scrape limit for large clusters

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -336,6 +336,8 @@ module "slurm" {
   maintenance                    = var.maintenance
   maintenance_ignore_node_groups = var.maintenance_ignore_node_groups
 
+  kube_state_metrics_max_scrape_size = var.kube_state_metrics_max_scrape_size
+
   use_preinstalled_gpu_drivers  = var.use_preinstalled_gpu_drivers
   cuda_version                  = lookup(var.platform_cuda_versions, var.slurm_nodeset_workers[0].resource.platform)
   controller_state_on_filestore = var.controller_state_on_filestore

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -569,6 +569,11 @@ telemetry_enabled = true
 # ---
 dcgm_job_mapping_enabled = true
 
+# Optional kube-state-metrics scrape size override in bytes.
+# By default, it is raised automatically for large clusters.
+# ---
+# kube_state_metrics_max_scrape_size = 150554432
+
 # Configuration of the Soperator Notifier (https://github.com/nebius/soperator/tree/main/helm/soperator-notifier).
 # ---
 # soperator_notifier = {

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1204,6 +1204,18 @@ variable "dcgm_job_mapping_enabled" {
   default     = true
 }
 
+variable "kube_state_metrics_max_scrape_size" {
+  description = "Maximum kube-state-metrics HTTP scrape size in bytes. Leave null to let the Slurm module raise it automatically for large clusters."
+  type        = number
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.kube_state_metrics_max_scrape_size == null || var.kube_state_metrics_max_scrape_size > 0
+    error_message = "kube_state_metrics_max_scrape_size must be greater than 0 when set."
+  }
+}
+
 variable "soperator_notifier" {
   description = "Configuration of the Soperator Notifier (https://github.com/nebius/soperator/tree/main/helm/soperator-notifier)."
   type = object({

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -169,6 +169,19 @@ locals {
   # This sets metrics ingestion capacity for larger clusters properly
   vm_agent_queue_count = 2 + floor(sum(var.node_count.worker) / 60)
 
+  # kube-state-metrics starts exceeding the default 32MiB scrape limit around 1.1k workers.
+  kube_state_metrics_large_cluster_worker_threshold = 1000
+  kube_state_metrics_large_cluster_max_scrape_size  = 150554432
+  kube_state_metrics_max_scrape_size = (
+    var.kube_state_metrics_max_scrape_size != null
+    ? var.kube_state_metrics_max_scrape_size
+    : (
+      sum(var.node_count.worker) >= local.kube_state_metrics_large_cluster_worker_threshold
+      ? local.kube_state_metrics_large_cluster_max_scrape_size
+      : null
+    )
+  )
+
   namespace = {
     logs       = "logs-system"
     monitoring = "monitoring-system"

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -302,6 +302,8 @@ resource "helm_release" "soperator_fluxcd_cm" {
 
     vm_agent_queue_count = local.vm_agent_queue_count
 
+    kube_state_metrics_max_scrape_size = local.kube_state_metrics_max_scrape_size
+
     slurm_nodesets_partitions = var.slurm_nodesets_partitions
     nodesets                  = var.worker_nodesets
 

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -120,6 +120,10 @@ resources:
             version: ${vmstack_version}
             %{~ endif ~}
             values:
+              %{~ if kube_state_metrics_max_scrape_size != null ~}
+              kubeStateMetrics:
+                maxScrapeSize: "${kube_state_metrics_max_scrape_size}"
+              %{~ endif ~}
               vmagent:
                 spec:
                   extraArgs:

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -419,6 +419,18 @@ variable "dcgm_job_mapping_enabled" {
   default     = true
 }
 
+variable "kube_state_metrics_max_scrape_size" {
+  description = "Maximum kube-state-metrics HTTP scrape size in bytes. Leave null to raise it automatically for large clusters."
+  type        = number
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.kube_state_metrics_max_scrape_size == null || var.kube_state_metrics_max_scrape_size > 0
+    error_message = "kube_state_metrics_max_scrape_size must be greater than 0 when set."
+  }
+}
+
 variable "dcgm_job_map_dir" {
   description = "Directory where HPC job mapping files are located"
   type        = string


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Automatically raises the kube-state-metrics scrape size for large Soperator clusters based on total worker count, while keeping smaller clusters on the default limit. Also adds an explicit override for cases where the automatic threshold needs tuning.