### PR TITLE
Harden k8s-training CI failure handling and bucket cleanup

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -180,7 +180,78 @@ jobs:
 
     # Run Terraform Tests
     - name: Terraform Test
-      run: terraform test -junit-xml=tests/reports/TEST-result-${{ github.run_id }}.xml
+      timeout-minutes: 150
+      run: |
+        report_path="tests/reports/TEST-result-${{ github.run_id }}.xml"
+
+        if [ "${{ matrix.solution }}" != "k8s-training" ]; then
+          terraform test -junit-xml="${report_path}"
+          exit $?
+        fi
+
+        cluster_name="${TF_VAR_cluster_name:-k8s-training}"
+        gpu_node_group_name="${cluster_name}-ng-gpu-0"
+        poll_seconds=60
+
+        terraform test -junit-xml="${report_path}" &
+        test_pid=$!
+
+        stop_test() {
+          if kill -0 "${test_pid}" 2>/dev/null; then
+            kill "${test_pid}" || true
+            wait "${test_pid}" || true
+          fi
+        }
+
+        # Fail early when the GPU node group reaches a terminal provisioning state.
+        while kill -0 "${test_pid}" 2>/dev/null; do
+          cluster_id="$(
+            { nebius mk8s v1 cluster list --parent-id "${TF_VAR_parent_id}" --format json 2>/dev/null || true; } \
+              | jq -r --arg name "${cluster_name}" '
+                  [(.items // [])[] | select(.metadata.name == $name)]
+                  | sort_by(.metadata.created_at)
+                  | last
+                  | .metadata.id // empty
+                '
+          )"
+
+          if [ -n "${cluster_id}" ]; then
+            node_group_json="$(
+              { nebius mk8s v1 node-group list --parent-id "${cluster_id}" --format json 2>/dev/null || true; } \
+                | jq -c --arg name "${gpu_node_group_name}" '
+                    [(.items // [])[] | select(.metadata.name == $name)]
+                    | sort_by(.metadata.created_at)
+                    | last // empty
+                  '
+            )"
+
+            if [ -n "${node_group_json}" ] && printf '%s\n' "${node_group_json}" | jq -e '
+              (.status.events // [])
+              | map(.last_occurrence)
+              | any(
+                  (.code == "ComputeInstanceCreationFailed") or
+                  (.code == "NodeNotFound" and ((.message // "") | contains("STOPPED for longer than")))
+                )
+            ' >/dev/null; then
+              echo "Detected fatal GPU node provisioning event for ${gpu_node_group_name}"
+              printf '%s\n' "${node_group_json}" | jq -r '
+                (.status.events // [])
+                | map(.last_occurrence)
+                | map(select(
+                    (.code == "ComputeInstanceCreationFailed") or
+                    (.code == "NodeNotFound" and ((.message // "") | contains("STOPPED for longer than")))
+                  ))
+                | .[]
+              '
+              stop_test
+              exit 1
+            fi
+          fi
+
+          sleep "${poll_seconds}"
+        done
+
+        wait "${test_pid}"
 
     - name: Set date in report
       run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -263,7 +263,7 @@ jobs:
         tests/reports/TEST-result-${{ github.run_id }}.xml
 
     - name: Upload test results
-      run: s3cmd sync tests/reports s3://terraform-test-reports/${{ matrix.solution.name }}/
+      run: s3cmd sync tests/reports s3://terraform-test-reports/${{ matrix.solution }}/
       if: always()
 
     - name: Load test report history

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -253,7 +253,7 @@ jobs:
     
     - name: Setup s3cmd
       run: |
-        pip3 install s3cmd --no-cache --quiet
+        pip3 install s3cmd boto3 --no-cache --quiet
         s3cmd --configure --dump-config \
         --access_key="${{ secrets.SA_ACCESS_KEY_ID }}" \
         --secret_key="${{ secrets.SA_SECRET_KEY }}" \
@@ -263,14 +263,77 @@ jobs:
     
     - name: Cleanup buckets
       continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.SA_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.SA_SECRET_KEY }}
       run: |
-        for resource in \
-          "storage bucket" \
-        ; do
-        echo Cleaning up buckets $resource 
-        eval nebius --format json $resource list \
-          | jq -r 'try .items[] | select(.metadata.name!="terraform-test-reports") | .metadata.name' \
-          | eval xargs -r -t -n 1 -I {} s3cmd del --force --recursive s3://{}
+        set -euo pipefail
+        mapfile -t buckets < <(
+          nebius --format json storage bucket list \
+            | jq -r 'try .items[] | select(.metadata.name!="terraform-test-reports") | .metadata.name'
+        )
+
+        for bucket in "${buckets[@]}"; do
+          [ -z "${bucket}" ] && continue
+          echo "Cleaning up bucket ${bucket}"
+          s3cmd del --force --recursive "s3://${bucket}" || true
+
+          BUCKET_NAME="${bucket}" python3 - <<'PY'
+import os
+import boto3
+from botocore.config import Config
+
+bucket = os.environ["BUCKET_NAME"]
+client = boto3.client(
+    "s3",
+    endpoint_url="https://storage.eu-north1.nebius.cloud",
+    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+    region_name="eu-north1",
+    config=Config(signature_version="s3v4"),
+)
+
+def batched(items, size=1000):
+    chunk = []
+    for item in items:
+        chunk.append(item)
+        if len(chunk) == size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+def delete_versions_and_markers():
+    paginator = client.get_paginator("list_object_versions")
+    entries = []
+    for page in paginator.paginate(Bucket=bucket):
+        for version in page.get("Versions", []):
+            entries.append({"Key": version["Key"], "VersionId": version["VersionId"]})
+        for marker in page.get("DeleteMarkers", []):
+            entries.append({"Key": marker["Key"], "VersionId": marker["VersionId"]})
+    for entry_batch in batched(entries):
+        client.delete_objects(Bucket=bucket, Delete={"Objects": entry_batch, "Quiet": True})
+    print(f"[cleanup] deleted version entries: {len(entries)} from {bucket}")
+
+def abort_multipart_uploads():
+    paginator = client.get_paginator("list_multipart_uploads")
+    aborted = 0
+    for page in paginator.paginate(Bucket=bucket):
+        for upload in page.get("Uploads", []):
+            client.abort_multipart_upload(Bucket=bucket, Key=upload["Key"], UploadId=upload["UploadId"])
+            aborted += 1
+    print(f"[cleanup] aborted multipart uploads: {aborted} from {bucket}")
+
+try:
+    delete_versions_and_markers()
+except Exception as err:
+    print(f"[cleanup] warning deleting versions for {bucket}: {err}")
+
+try:
+    abort_multipart_uploads()
+except Exception as err:
+    print(f"[cleanup] warning aborting multipart uploads for {bucket}: {err}")
+PY
         done
 
     - name: Perform forced cleanup

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -251,91 +251,6 @@ jobs:
           --parent-id ${{ env.TF_VAR_parent_id }} \
           --private-key-file /tmp/sa.pem
     
-    - name: Setup s3cmd
-      run: |
-        pip3 install s3cmd boto3 --no-cache --quiet
-        s3cmd --configure --dump-config \
-        --access_key="${{ secrets.SA_ACCESS_KEY_ID }}" \
-        --secret_key="${{ secrets.SA_SECRET_KEY }}" \
-        --host="storage.eu-north1.nebius.cloud:443" \
-        --host-bucket="%(bucket)s.storage.eu-north1.nebius.cloud" \
-        > ~/.s3cfg
-    
-    - name: Cleanup buckets
-      continue-on-error: true
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.SA_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.SA_SECRET_KEY }}
-      run: |
-        set -euo pipefail
-        mapfile -t buckets < <(
-          nebius --format json storage bucket list \
-            | jq -r 'try .items[] | select(.metadata.name!="terraform-test-reports") | .metadata.name'
-        )
-
-        for bucket in "${buckets[@]}"; do
-          [ -z "${bucket}" ] && continue
-          echo "Cleaning up bucket ${bucket}"
-          s3cmd del --force --recursive "s3://${bucket}" || true
-
-          BUCKET_NAME="${bucket}" python3 - <<'PY'
-import os
-import boto3
-from botocore.config import Config
-
-bucket = os.environ["BUCKET_NAME"]
-client = boto3.client(
-    "s3",
-    endpoint_url="https://storage.eu-north1.nebius.cloud",
-    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
-    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-    region_name="eu-north1",
-    config=Config(signature_version="s3v4"),
-)
-
-def batched(items, size=1000):
-    chunk = []
-    for item in items:
-        chunk.append(item)
-        if len(chunk) == size:
-            yield chunk
-            chunk = []
-    if chunk:
-        yield chunk
-
-def delete_versions_and_markers():
-    paginator = client.get_paginator("list_object_versions")
-    entries = []
-    for page in paginator.paginate(Bucket=bucket):
-        for version in page.get("Versions", []):
-            entries.append({"Key": version["Key"], "VersionId": version["VersionId"]})
-        for marker in page.get("DeleteMarkers", []):
-            entries.append({"Key": marker["Key"], "VersionId": marker["VersionId"]})
-    for entry_batch in batched(entries):
-        client.delete_objects(Bucket=bucket, Delete={"Objects": entry_batch, "Quiet": True})
-    print(f"[cleanup] deleted version entries: {len(entries)} from {bucket}")
-
-def abort_multipart_uploads():
-    paginator = client.get_paginator("list_multipart_uploads")
-    aborted = 0
-    for page in paginator.paginate(Bucket=bucket):
-        for upload in page.get("Uploads", []):
-            client.abort_multipart_upload(Bucket=bucket, Key=upload["Key"], UploadId=upload["UploadId"])
-            aborted += 1
-    print(f"[cleanup] aborted multipart uploads: {aborted} from {bucket}")
-
-try:
-    delete_versions_and_markers()
-except Exception as err:
-    print(f"[cleanup] warning deleting versions for {bucket}: {err}")
-
-try:
-    abort_multipart_uploads()
-except Exception as err:
-    print(f"[cleanup] warning aborting multipart uploads for {bucket}: {err}")
-PY
-        done
-
     - name: Perform forced cleanup
       run: |
         for resource in \
@@ -345,10 +260,30 @@ PY
           "compute v1 disk" \
           "compute v1 gpu-cluster" \
           "vpc v1alpha1 allocation" \
-          "storage bucket" \
         ; do
           echo Deleting all $resource
           eval nebius --format json $resource list \
           | jq -r 'try .items[] | select(.metadata.name!="terraform-test-reports") | .metadata.id' \
           | eval xargs -r -n 1 nebius $resource delete --id
         done
+
+    - name: Force delete storage buckets (ttl=0)
+      run: |
+        nebius --format json storage bucket list --parent-id "${TF_VAR_parent_id}" \
+          | jq -r '(.items // [])[] | select(.metadata.name!="terraform-test-reports") | .metadata.id' \
+          | while read -r bucket_id; do
+              [ -z "${bucket_id}" ] && continue
+              echo "Deleting bucket ${bucket_id} with --ttl 0"
+              nebius storage bucket delete --id "${bucket_id}" --ttl 0 || true
+            done
+
+    - name: Purge scheduled storage buckets
+      continue-on-error: true
+      run: |
+        nebius --format json storage bucket list --parent-id "${TF_VAR_parent_id}" \
+          | jq -r '(.items // [])[] | select(.metadata.name!="terraform-test-reports") | select((.status.purge_at // null) != null) | .metadata.id' \
+          | while read -r bucket_id; do
+              [ -z "${bucket_id}" ] && continue
+              echo "Purging bucket ${bucket_id}"
+              nebius storage bucket purge --id "${bucket_id}" || true
+            done

--- a/k8s-training/tests/k8s-training-kuberay.tftest.hcl
+++ b/k8s-training/tests/k8s-training-kuberay.tftest.hcl
@@ -1,6 +1,6 @@
 ###GLOBAL VARIABLES OWERWITE BLOCK###
 variables {
-  gpu_nodes_platform = "gpu-h100-sxm"
+  gpu_nodes_platform    = "gpu-h100-sxm"
   gpu_nodes_preemptible = true
 }
 ######
@@ -27,6 +27,6 @@ run "full_training_kuberay_apply" {
   command = apply
 
   variables {
-    enable_kuberay = true
+    enable_kuberay_cluster = true
   }
 }

--- a/k8s-training/tests/main.tftest.hcl
+++ b/k8s-training/tests/main.tftest.hcl
@@ -1,6 +1,6 @@
 ###GLOBALVARIABLES OWERWITE BLOCK###
 variables {
-  gpu_nodes_platform = "gpu-h100-sxm"
+  gpu_nodes_platform    = "gpu-h100-sxm"
   gpu_nodes_preemptible = true
 }
 ######


### PR DESCRIPTION
## Release Notes (Mandatory Description)
This PR hardens the `k8s-training` Terraform CI path so mk8s/GPU provisioning failures are detected more clearly, bounded by timeout, and followed by more reliable cleanup.

It also fixes a stale KubeRay test input and a Terraform test report upload path issue that could otherwise make CI fail for the wrong reason.

## Changes

### Fix stale KubeRay test input

Updated `k8s-training/tests/k8s-training-kuberay.tftest.hcl`.

Changed stale input:

`enable_kuberay = true`

to the currently declared variable:

`enable_kuberay_cluster = true`

The old `enable_kuberay` variable is no longer declared by `k8s-training`. The current variables are `enable_kuberay_cluster` and `enable_kuberay_service`.

### Add k8s-training Terraform Test watcher

Updated `.github/workflows/terraform.yml` so non-`k8s-training` solutions still run plain `terraform test`.

For `k8s-training`, the workflow now runs `terraform test` in the background and watches the mk8s GPU node group for known fatal provisioning events.

The watcher fails early on:

- `ComputeInstanceCreationFailed`
- `NodeNotFound` with message containing `STOPPED for longer than`

This does not make GPU capacity available or make mk8s provisioning succeed. It makes known terminal provisioning failures visible earlier instead of letting CI hang or fail later with less useful context.

### Add Terraform Test timeout

Added a hard upper bound to the `Terraform Test` step:

`timeout-minutes: 150`

If the watcher does not catch a known fatal event, the step is still bounded.

### Improve bucket cleanup

Updated `cleanup-infra` bucket cleanup behavior:

- Removed storage buckets from the generic forced cleanup loop.
- Added Nebius-native bucket deletion with `nebius storage bucket delete --ttl 0`.
- Added best-effort purge for buckets with `status.purge_at`.
- Continued excluding `terraform-test-reports`.

This is intended to handle versioned bucket cleanup more reliably than recursive `s3cmd del`, especially when object versions or delete markers remain.

### Fix Terraform report upload path

Changed the report upload path from:

`${{ matrix.solution.name }}`

to:

`${{ matrix.solution }}`

`matrix.solution` is a string in this workflow, not an object.

### Formatting

Applied a small `terraform fmt` alignment change in `k8s-training/tests/main.tftest.hcl`.

## Testing Performed

### Git and mergeability

Ran:

`git fetch origin`

`git merge-tree --write-tree origin/main HEAD`

`git diff --check origin/main...HEAD`

Result: no merge conflicts and no whitespace issues.

### Workflow syntax

Validated that the GitHub Actions workflow YAML parses successfully.

Also checked embedded workflow `run:` blocks with `bash -n` after substituting GitHub expressions.

Result: passed.

### Terraform formatting

Ran from `k8s-training`:

`terraform fmt -check -recursive . ../modules`

Result: passed.

### Terraform validate

Ran `terraform init -backend=false` and `terraform validate` in a detached temporary worktree to avoid polluting the real checkout.

Result: passed.

### Mock workflow harness

Ran a local mock harness against the actual workflow snippets to verify behavior without creating Nebius resources.

Covered cases:

- Non-`k8s-training` still runs plain `terraform test`.
- `k8s-training` succeeds when no fatal node-group event is returned.
- `k8s-training` exits `1` when a mocked `NodeNotFound` / `STOPPED for longer than` event appears.
- Report upload path uses `${{ matrix.solution }}`.
- Bucket delete skips `terraform-test-reports` and uses `delete --ttl 0`.
- Bucket purge only purges non-report buckets with `status.purge_at`.

Result: passed.

## Notes

This PR intentionally does not run the real `terraform test` path locally, because that requires the CI Nebius project, credentials, and mk8s/GPU resources. The real GitHub Actions run is still the authoritative test for actual mk8s/GPU provisioning behavior.