### PR TITLE
SCHED-292: Configure OpenTelemetry batch settings

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -338,6 +338,7 @@ module "slurm" {
   maintenance_ignore_node_groups = var.maintenance_ignore_node_groups
 
   kube_state_metrics_max_scrape_size = var.kube_state_metrics_max_scrape_size
+  opentelemetry_batch                = var.opentelemetry_batch
 
   use_preinstalled_gpu_drivers  = var.use_preinstalled_gpu_drivers
   cuda_version                  = lookup(var.platform_cuda_versions, var.slurm_nodeset_workers[0].resource.platform)

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -576,6 +576,15 @@ dcgm_job_mapping_enabled = true
 # ---
 # kube_state_metrics_max_scrape_size = 150554432
 
+# Optional OpenTelemetry batch processor overrides for logs, jail logs, and events collectors.
+# By default, chart values are used.
+# ---
+# opentelemetry_batch = {
+#   timeout             = "1s"
+#   send_batch_size     = 2000
+#   send_batch_max_size = 5000
+# }
+
 # Configuration of the Soperator Notifier (https://github.com/nebius/soperator/tree/main/helm/soperator-notifier).
 # ---
 # soperator_notifier = {

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1225,6 +1225,54 @@ variable "kube_state_metrics_max_scrape_size" {
   }
 }
 
+variable "opentelemetry_batch" {
+  description = "OpenTelemetry batch processor overrides for logs, jail logs, and events collectors. Leave null to use chart defaults."
+  type = object({
+    timeout             = optional(string)
+    send_batch_size     = optional(number)
+    send_batch_max_size = optional(number)
+  })
+  default  = null
+  nullable = true
+
+  validation {
+    condition = (
+      var.opentelemetry_batch == null ||
+      var.opentelemetry_batch.timeout == null ||
+      trimspace(var.opentelemetry_batch.timeout) != ""
+    )
+    error_message = "opentelemetry_batch.timeout must be non-empty when set."
+  }
+
+  validation {
+    condition = (
+      var.opentelemetry_batch == null ||
+      var.opentelemetry_batch.send_batch_size == null ||
+      var.opentelemetry_batch.send_batch_size > 0
+    )
+    error_message = "opentelemetry_batch.send_batch_size must be greater than 0 when set."
+  }
+
+  validation {
+    condition = (
+      var.opentelemetry_batch == null ||
+      var.opentelemetry_batch.send_batch_max_size == null ||
+      var.opentelemetry_batch.send_batch_max_size > 0
+    )
+    error_message = "opentelemetry_batch.send_batch_max_size must be greater than 0 when set."
+  }
+
+  validation {
+    condition = (
+      var.opentelemetry_batch == null ||
+      var.opentelemetry_batch.send_batch_size == null ||
+      var.opentelemetry_batch.send_batch_max_size == null ||
+      var.opentelemetry_batch.send_batch_max_size >= var.opentelemetry_batch.send_batch_size
+    )
+    error_message = "opentelemetry_batch.send_batch_max_size must be greater than or equal to send_batch_size when both are set."
+  }
+}
+
 variable "soperator_notifier" {
   description = "Configuration of the Soperator Notifier (https://github.com/nebius/soperator/tree/main/helm/soperator-notifier)."
   type = object({

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -182,6 +182,16 @@ locals {
     )
   )
 
+  opentelemetry_batch_enabled = (
+    var.opentelemetry_batch != null
+    ? anytrue([
+      var.opentelemetry_batch.timeout != null,
+      var.opentelemetry_batch.send_batch_size != null,
+      var.opentelemetry_batch.send_batch_max_size != null,
+    ])
+    : false
+  )
+
   namespace = {
     logs       = "logs-system"
     monitoring = "monitoring-system"

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -85,6 +85,8 @@ resource "helm_release" "soperator_fluxcd_cm" {
     k8up_version                       = var.k8up_version
     mariadb_operator_version           = var.mariadb_operator_version
     opentelemetry_collector_version    = var.opentelemetry_collector_version
+    opentelemetry_batch                = var.opentelemetry_batch
+    opentelemetry_batch_enabled        = local.opentelemetry_batch_enabled
     prometheus_crds_version            = var.prometheus_crds_version
     security_profiles_operator_version = var.security_profiles_operator_version
     vmstack_version                    = var.vmstack_version

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -66,6 +66,18 @@ resources:
           region: ${region}
           opentelemetry:
             enabled: ${telemetry_enabled}
+            %{~ if opentelemetry_batch_enabled ~}
+            batch:
+              %{~ if opentelemetry_batch.timeout != null ~}
+              timeout: ${opentelemetry_batch.timeout}
+              %{~ endif ~}
+              %{~ if opentelemetry_batch.send_batch_size != null ~}
+              sendBatchSize: ${opentelemetry_batch.send_batch_size}
+              %{~ endif ~}
+              %{~ if opentelemetry_batch.send_batch_max_size != null ~}
+              sendBatchMaxSize: ${opentelemetry_batch.send_batch_max_size}
+              %{~ endif ~}
+            %{~ endif ~}
             logs:
               %{~ if opentelemetry_collector_version != "" ~}
               version: ${opentelemetry_collector_version}

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -431,6 +431,54 @@ variable "kube_state_metrics_max_scrape_size" {
   }
 }
 
+variable "opentelemetry_batch" {
+  description = "OpenTelemetry batch processor overrides for logs, jail logs, and events collectors. Leave null to use chart defaults."
+  type = object({
+    timeout             = optional(string)
+    send_batch_size     = optional(number)
+    send_batch_max_size = optional(number)
+  })
+  default  = null
+  nullable = true
+
+  validation {
+    condition = (
+      var.opentelemetry_batch == null ||
+      var.opentelemetry_batch.timeout == null ||
+      trimspace(var.opentelemetry_batch.timeout) != ""
+    )
+    error_message = "opentelemetry_batch.timeout must be non-empty when set."
+  }
+
+  validation {
+    condition = (
+      var.opentelemetry_batch == null ||
+      var.opentelemetry_batch.send_batch_size == null ||
+      var.opentelemetry_batch.send_batch_size > 0
+    )
+    error_message = "opentelemetry_batch.send_batch_size must be greater than 0 when set."
+  }
+
+  validation {
+    condition = (
+      var.opentelemetry_batch == null ||
+      var.opentelemetry_batch.send_batch_max_size == null ||
+      var.opentelemetry_batch.send_batch_max_size > 0
+    )
+    error_message = "opentelemetry_batch.send_batch_max_size must be greater than 0 when set."
+  }
+
+  validation {
+    condition = (
+      var.opentelemetry_batch == null ||
+      var.opentelemetry_batch.send_batch_size == null ||
+      var.opentelemetry_batch.send_batch_max_size == null ||
+      var.opentelemetry_batch.send_batch_max_size >= var.opentelemetry_batch.send_batch_size
+    )
+    error_message = "opentelemetry_batch.send_batch_max_size must be greater than or equal to send_batch_size when both are set."
+  }
+}
+
 variable "dcgm_job_map_dir" {
   description = "Directory where HPC job mapping files are located"
   type        = string


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Adds Terraform-level configuration for OpenTelemetry batch processor settings used by logs, jail logs, and events collectors. By default, Terraform does not override the chart values; users can set opentelemetry_batch to customize timeout, send_batch_size, and send_batch_max_size when needed.