### PR TITLE
Ensure that system node pool is up before other node pools

### DIFF
--- a/soperator/modules/k8s/k8s_ng_accounting.tf
+++ b/soperator/modules/k8s/k8s_ng_accounting.tf
@@ -3,6 +3,7 @@ resource "nebius_mk8s_v1_node_group" "accounting" {
 
   depends_on = [
     nebius_mk8s_v1_cluster.this,
+    nebius_mk8s_v1_node_group.system.this,
     terraform_data.check_resource_preset_sufficiency,
   ]
 

--- a/soperator/modules/k8s/k8s_ng_controller.tf
+++ b/soperator/modules/k8s/k8s_ng_controller.tf
@@ -1,6 +1,7 @@
 resource "nebius_mk8s_v1_node_group" "controller" {
   depends_on = [
     nebius_mk8s_v1_cluster.this,
+    nebius_mk8s_v1_node_group.system.this,
     terraform_data.check_resource_preset_sufficiency,
   ]
 

--- a/soperator/modules/k8s/k8s_ng_login.tf
+++ b/soperator/modules/k8s/k8s_ng_login.tf
@@ -1,6 +1,7 @@
 resource "nebius_mk8s_v1_node_group" "login" {
   depends_on = [
     nebius_mk8s_v1_cluster.this,
+    nebius_mk8s_v1_node_group.system.this,
     terraform_data.check_resource_preset_sufficiency,
   ]
 

--- a/soperator/modules/k8s/k8s_ng_nfs.tf
+++ b/soperator/modules/k8s/k8s_ng_nfs.tf
@@ -3,6 +3,7 @@ resource "nebius_mk8s_v1_node_group" "nfs" {
 
   depends_on = [
     nebius_mk8s_v1_cluster.this,
+    nebius_mk8s_v1_node_group.system.this,
     terraform_data.check_resource_preset_sufficiency,
   ]
 

--- a/soperator/modules/k8s/k8s_ng_workers_v2.tf
+++ b/soperator/modules/k8s/k8s_ng_workers_v2.tf
@@ -45,6 +45,7 @@ resource "nebius_mk8s_v1_node_group" "worker_v2" {
 
   depends_on = [
     nebius_mk8s_v1_cluster.this,
+    nebius_mk8s_v1_node_group.system.this,
     nebius_compute_v1_gpu_cluster.this_v2,
     terraform_data.check_resource_preset_sufficiency,
   ]


### PR DESCRIPTION
#966

## Release Notes (Mandatory Description)

This commit resolves an issue seen where a worker/nfs/accounting node pool is provisioned in the cluster before the system node pool. That causes kubernetes to attempt to place the cilium pods on the new node pool and fail (due to the taints) which in turn then blocks the remainder of the deployment.

Explicit dependencies between pools may make deployment slightly slower but defends against this particular issue