### PR TITLE
[FEATURE] Add local NVME disks support

### DIFF
--- a/modules/cloud-init/simple-setup-init.tftpl
+++ b/modules/cloud-init/simple-setup-init.tftpl
@@ -1,4 +1,12 @@
 #cloud-config
+package_update: true
+package_upgrade: true
+%{if enable_local_disks}
+packages:
+  - mdadm
+  - nvme-cli
+
+%{endif}
 users:
 %{ for user in users}
   - name: ${user.user_name}
@@ -9,12 +17,8 @@ users:
       - ${user.ssh_public_key}
 %{ endfor}
 
-
+%{ if extra_disk_id != "" || shared_filesystem_id != "" || aws_access_key_id != "" || enable_local_disks }
 runcmd:
-- apt-get update
-- apt-get upgrade
-
-
 # mount disk if provided
 %{ if extra_disk_id != "" }
 # Prepare partition on secondary disk
@@ -76,8 +80,6 @@ runcmd:
 %{endif}
 
 %{if enable_local_disks}
-# install nvme
-- apt install -y nvme-cli
 # Create RAID 0 array
 - mdadm --create --force --verbose /dev/md0 --level=0 --raid-devices=6 /dev/nvme[0-5]n1
 - mkfs.ext4 /dev/md0
@@ -91,3 +93,4 @@ runcmd:
 - mdadm --detail --scan >> /etc/mdadm/mdadm.conf
 - update-initramfs -u
 %{endif}
+%{ endif }

--- a/modules/cloud-init/simple-setup-init.tftpl
+++ b/modules/cloud-init/simple-setup-init.tftpl
@@ -74,3 +74,20 @@ runcmd:
 - mount-s3 --upload-checksums=off --maximum-throughput-gbps=200 --allow-delete --allow-overwrite --allow-other --endpoint-url=https://storage.eu-north1.nebius.cloud:443 ${mount_bucket} ${s3_mount_path}
 %{endif}
 %{endif}
+
+%{if enable_local_disks}
+# install nvme
+- apt install -y nvme-cli
+# Create RAID 0 array
+- mdadm --create --force --verbose /dev/md0 --level=0 --raid-devices=6 /dev/nvme[0-5]n1
+- mkfs.ext4 /dev/md0
+- mkdir -p ${local_nvme_drives_path}
+- mount /dev/md0 ${local_nvme_drives_path}
+- echo "/dev/md0 ${local_nvme_drives_path} ext4 defaults,relatime,rw 0 0" >> /etc/fstab
+# Configure permissions
+- chown nobody:nogroup ${local_nvme_drives_path}
+- chmod 777 ${local_nvme_drives_path}
+# Ensure mdadm config is saved
+- mdadm --detail --scan >> /etc/mdadm/mdadm.conf
+- update-initramfs -u
+%{endif}

--- a/modules/cloud-init/simple-setup-init.tftpl
+++ b/modules/cloud-init/simple-setup-init.tftpl
@@ -3,8 +3,10 @@ package_update: true
 package_upgrade: true
 %{if enable_local_disks}
 packages:
-  - mdadm
   - nvme-cli
+%{ if local_disks_mount_mode == "raid0" }
+  - mdadm
+%{ endif }
 
 %{endif}
 users:
@@ -17,6 +19,177 @@ users:
       - ${user.ssh_public_key}
 %{ endfor}
 
+%{if enable_local_disks}
+write_files:
+  - path: /usr/local/sbin/prepare-local-nvme.sh
+    owner: root:root
+    permissions: "0755"
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      MODE="${local_disks_mount_mode}"
+      MD_DEV="/dev/md0"
+      MOUNTPOINT="${local_nvme_drives_path}"
+      EXPECTED_DISKS=6
+
+      log() {
+        echo "[local-nvme] $*"
+      }
+
+      discover_nvme_disks() {
+        udevadm settle || true
+
+        mapfile -t NVME_DISKS < <(
+          find /dev -maxdepth 1 -regextype posix-extended -regex '/dev/nvme[0-9]+n1' -print | sort -V
+        )
+
+        ROOT_SOURCE="$(findmnt -n -o SOURCE / || true)"
+        ROOT_PKNAME="$(lsblk -no PKNAME "$ROOT_SOURCE" 2>/dev/null | head -n1 || true)"
+        if [[ -n "$ROOT_PKNAME" ]]; then
+          ROOT_DISK="/dev/$ROOT_PKNAME"
+          FILTERED=()
+          for disk in "$${NVME_DISKS[@]}"; do
+            if [[ "$disk" != "$ROOT_DISK" ]]; then
+              FILTERED+=("$disk")
+            fi
+          done
+          NVME_DISKS=("$${FILTERED[@]}")
+        fi
+
+        DISK_COUNT="$${#NVME_DISKS[@]}"
+        if [[ "$DISK_COUNT" -ne "$EXPECTED_DISKS" ]]; then
+          log "Expected $EXPECTED_DISKS local NVMe disks, found $DISK_COUNT: $${NVME_DISKS[*]}"
+          exit 1
+        fi
+      }
+
+      rewrite_fstab() {
+        tmp_fstab="$(mktemp)"
+        awk -v mountpoint="$MOUNTPOINT" '$2 != mountpoint && index($2, mountpoint "/disk-") != 1 { print }' /etc/fstab > "$tmp_fstab"
+        cat "$tmp_fstab" > /etc/fstab
+        rm -f "$tmp_fstab"
+      }
+
+      ensure_mount_permissions() {
+        local path="$1"
+
+        chown nobody:nogroup "$path"
+        chmod 777 "$path"
+      }
+
+      prepare_raid0() {
+        if mountpoint -q "$MOUNTPOINT"; then
+          ensure_mount_permissions "$MOUNTPOINT"
+          return 0
+        fi
+
+        if [[ -e "$MD_DEV" ]]; then
+          log "$MD_DEV already exists"
+        elif mdadm --examine "$${NVME_DISKS[@]}" >/dev/null 2>&1; then
+          log "Assembling existing RAID array"
+          mdadm --assemble "$MD_DEV" "$${NVME_DISKS[@]}"
+        else
+          log "Creating RAID 0 array from $${NVME_DISKS[*]}"
+          mdadm --create --force --verbose "$MD_DEV" --level=0 --raid-devices="$DISK_COUNT" "$${NVME_DISKS[@]}"
+        fi
+
+        udevadm settle || true
+
+        if ! blkid "$MD_DEV" >/dev/null 2>&1; then
+          mkfs.ext4 -F "$MD_DEV"
+        fi
+
+        UUID="$(blkid -s UUID -o value "$MD_DEV")"
+        if [[ -z "$UUID" ]]; then
+          log "Unable to determine filesystem UUID for $MD_DEV"
+          exit 1
+        fi
+
+        rewrite_fstab
+        echo "UUID=$UUID $MOUNTPOINT ext4 defaults,relatime,rw,nofail 0 0" >> /etc/fstab
+
+        mountpoint -q "$MOUNTPOINT" || mount "$MOUNTPOINT"
+        ensure_mount_permissions "$MOUNTPOINT"
+
+        mkdir -p /etc/mdadm
+        tmp_mdadm="$(mktemp)"
+        mdadm --detail --scan > "$tmp_mdadm"
+        if [[ ! -f /etc/mdadm/mdadm.conf ]] || ! cmp -s "$tmp_mdadm" /etc/mdadm/mdadm.conf; then
+          cat "$tmp_mdadm" > /etc/mdadm/mdadm.conf
+          update-initramfs -u
+        fi
+        rm -f "$tmp_mdadm"
+      }
+
+      prepare_raw() {
+        rewrite_fstab
+
+        index=0
+        for disk in "$${NVME_DISKS[@]}"; do
+          fs_type="$(blkid -s TYPE -o value "$disk" 2>/dev/null || true)"
+          if [[ -z "$fs_type" ]]; then
+            log "Creating ext4 filesystem on $disk"
+            mkfs.ext4 -F "$disk"
+            fs_type="ext4"
+          fi
+
+          if [[ "$fs_type" != "ext4" ]]; then
+            log "Unsupported existing signature on $disk: $fs_type"
+            exit 1
+          fi
+
+          uuid="$(blkid -s UUID -o value "$disk")"
+          if [[ -z "$uuid" ]]; then
+            log "Unable to determine filesystem UUID for $disk"
+            exit 1
+          fi
+
+          disk_mount="$MOUNTPOINT/disk-$index"
+          mkdir -p "$disk_mount"
+          echo "UUID=$uuid $disk_mount ext4 defaults,relatime,rw,nofail 0 0" >> /etc/fstab
+          mountpoint -q "$disk_mount" || mount "$disk_mount"
+          ensure_mount_permissions "$disk_mount"
+
+          index=$((index + 1))
+        done
+
+        ensure_mount_permissions "$MOUNTPOINT"
+      }
+
+      mkdir -p "$MOUNTPOINT"
+      discover_nvme_disks
+
+      case "$MODE" in
+        raid0)
+          prepare_raid0
+          ;;
+        raw)
+          prepare_raw
+          ;;
+        *)
+          log "Unsupported local disks mount mode: $MODE"
+          exit 1
+          ;;
+      esac
+  - path: /etc/systemd/system/local-nvme.service
+    owner: root:root
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Prepare and mount local NVMe disks
+      After=systemd-udev-settle.service
+      Wants=systemd-udev-settle.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/usr/local/sbin/prepare-local-nvme.sh
+
+      [Install]
+      WantedBy=multi-user.target
+
+%{endif}
 %{ if extra_disk_id != "" || shared_filesystem_id != "" || aws_access_key_id != "" || enable_local_disks }
 runcmd:
 # mount disk if provided
@@ -80,17 +253,7 @@ runcmd:
 %{endif}
 
 %{if enable_local_disks}
-# Create RAID 0 array
-- mdadm --create --force --verbose /dev/md0 --level=0 --raid-devices=6 /dev/nvme[0-5]n1
-- mkfs.ext4 /dev/md0
-- mkdir -p ${local_nvme_drives_path}
-- mount /dev/md0 ${local_nvme_drives_path}
-- echo "/dev/md0 ${local_nvme_drives_path} ext4 defaults,relatime,rw 0 0" >> /etc/fstab
-# Configure permissions
-- chown nobody:nogroup ${local_nvme_drives_path}
-- chmod 777 ${local_nvme_drives_path}
-# Ensure mdadm config is saved
-- mdadm --detail --scan >> /etc/mdadm/mdadm.conf
-- update-initramfs -u
+- systemctl daemon-reload
+- systemctl enable --now local-nvme.service
 %{endif}
 %{ endif }

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -4,7 +4,7 @@ resource "nebius_compute_v1_disk" "boot-disk" {
   block_size_bytes    = 4096
   size_bytes          = 1024 * 1024 * 1024 * var.boot_disk_size_gb
   type                = "NETWORK_SSD"
-  source_image_family = { image_family = "ubuntu24.04-cuda12" }
+  source_image_family = { image_family = var.boot_disk_image }
 }
 
 resource "nebius_compute_v1_disk" "extra-storage-disk" {

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -88,6 +88,7 @@ resource "nebius_compute_v1_instance" "instance" {
     mount_bucket            = var.mount_bucket,
     s3_mount_path           = var.s3_mount_path
     enable_local_disks      = var.enable_local_disks
+    local_disks_mount_mode  = var.local_disks_mount_mode
     local_nvme_drives_path  = var.local_nvme_drives_path
   })
 }

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -50,6 +50,13 @@ resource "nebius_compute_v1_instance" "instance" {
 
 
   gpu_cluster = var.gpu_cluster != "" ? { id = var.gpu_cluster } : {}
+  local_disks = var.enable_local_disks ? {
+    passthrough_group = {
+      requested = true
+    }
+  } : null
+
+
   secondary_disks = var.add_extra_storage ? [
     {
       attach_mode = "READ_WRITE"
@@ -80,12 +87,12 @@ resource "nebius_compute_v1_instance" "instance" {
     aws_secret_access_key   = var.aws_secret_access_key,
     mount_bucket            = var.mount_bucket,
     s3_mount_path           = var.s3_mount_path
+    enable_local_disks      = var.enable_local_disks
+    local_nvme_drives_path  = var.local_nvme_drives_path
   })
 }
 
 resource "local_file" "cloud_init_variables_log" {
   content  = local.cloud_init_log
   filename = "${path.module}/cloud-init-variables.log"
-
-
 }

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -121,6 +121,17 @@ variable "enable_local_disks" {
   }
 }
 
+variable "local_disks_mount_mode" {
+  description = "How cloud-init should mount requested local NVMe disks. Use 'raid0' for a single RAID0 mount or 'raw' to mount each device separately."
+  type        = string
+  default     = "raid0"
+
+  validation {
+    condition     = contains(["raid0", "raw"], var.local_disks_mount_mode)
+    error_message = "Local disks mount mode must be one of: raid0, raw."
+  }
+}
+
 variable "local_nvme_drives_path" {
   description = "Mount path for local NVMe drives"
   type        = string

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -86,6 +86,12 @@ variable "boot_disk_size_gb" {
   description = "size of the boot disk"
 }
 
+variable "boot_disk_image" {
+  type        = string
+  default     = "ubuntu24.04-cuda13.0"
+  description = "Image family to use for the boot disk."
+}
+
 variable "extra_storage_size_gb" {
   type        = number
   default     = 50

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -98,6 +98,34 @@ variable "extra_storage_class" {
   description = "Network type of additional disk being added"
 }
 
+variable "enable_local_disks" {
+  description = "Whether to request local NVMe passthrough disks"
+  type        = bool
+  default     = false
+
+  validation {
+    condition = (
+      !var.enable_local_disks ||
+      (
+        var.platform == "gpu-b300-sxm" &&
+        var.preset == "8gpu-192vcpu-2768gb"
+      )
+    )
+    error_message = "Local disks are supported only on B300 platform with preset 8gpu-192vcpu-2768gb."
+  }
+}
+
+variable "local_nvme_drives_path" {
+  description = "Mount path for local NVMe drives"
+  type        = string
+  default     = "/scratch"
+
+  validation {
+    condition     = startswith(var.local_nvme_drives_path, "/")
+    error_message = "Local NVMe drives path must be an absolute path."
+  }
+}
+
 variable "public_ip" {
   type        = bool
   default     = true

--- a/vm-instance/main.tf
+++ b/vm-instance/main.tf
@@ -17,6 +17,7 @@ module "instance-module" {
   preset                  = var.preset
   platform                = var.platform
   boot_disk_size_gb       = var.boot_disk_size_gb
+  boot_disk_image         = var.boot_disk_image
   shared_filesystem_id    = var.shared_filesystem_id
   shared_filesystem_mount = var.shared_filesystem_mount
   extra_path              = var.extra_path

--- a/vm-instance/main.tf
+++ b/vm-instance/main.tf
@@ -29,4 +29,6 @@ module "instance-module" {
   aws_access_key_id       = var.aws_access_key_id
   aws_secret_access_key   = var.aws_secret_access_key
   preemptible             = var.preemptible
+  enable_local_disks      = var.enable_local_disks
+  local_nvme_drives_path  = var.local_nvme_drives_path
 }

--- a/vm-instance/main.tf
+++ b/vm-instance/main.tf
@@ -31,5 +31,6 @@ module "instance-module" {
   aws_secret_access_key   = var.aws_secret_access_key
   preemptible             = var.preemptible
   enable_local_disks      = var.enable_local_disks
+  local_disks_mount_mode  = var.local_disks_mount_mode
   local_nvme_drives_path  = var.local_nvme_drives_path
 }

--- a/vm-instance/terraform.tfvars
+++ b/vm-instance/terraform.tfvars
@@ -25,5 +25,6 @@ preemptible    = false
 
 shared_filesystem_id = ""
 mount_bucket         = ""
+enable_local_disks = false # Only B300 supportes local disk
 
 fabric = "fabric-n"

--- a/vm-instance/variables.tf
+++ b/vm-instance/variables.tf
@@ -136,3 +136,26 @@ variable "preemptible" {
   type        = bool
   default     = false
 }
+
+variable "enable_local_disks" {
+  description = "Whether to request local NVMe passthrough disks"
+  type        = bool
+  default     = false
+
+  validation {
+    condition = (
+      !var.enable_local_disks ||
+      (
+        var.platform == "gpu-b300-sxm" &&
+        var.preset == "8gpu-192vcpu-2768gb"
+      )
+    )
+    error_message = "Local disks are supported only on B300 platform with preset 8gpu-192vcpu-2768gb."
+  }
+}
+
+variable "local_nvme_drives_path" {
+  description = "Mount path for local NVMe drives"
+  type        = string
+  default     = "/scratch"
+}

--- a/vm-instance/variables.tf
+++ b/vm-instance/variables.tf
@@ -160,6 +160,17 @@ variable "enable_local_disks" {
   }
 }
 
+variable "local_disks_mount_mode" {
+  description = "How cloud-init should mount requested local NVMe disks. Use 'raid0' for a single RAID0 mount or 'raw' to mount each device separately."
+  type        = string
+  default     = "raid0"
+
+  validation {
+    condition     = contains(["raid0", "raw"], var.local_disks_mount_mode)
+    error_message = "Local disks mount mode must be one of: raid0, raw."
+  }
+}
+
 variable "local_nvme_drives_path" {
   description = "Mount path for local NVMe drives"
   type        = string

--- a/vm-instance/variables.tf
+++ b/vm-instance/variables.tf
@@ -96,6 +96,12 @@ variable "boot_disk_size_gb" {
   description = "size of boot disk"
 }
 
+variable "boot_disk_image" {
+  type        = string
+  default     = "ubuntu24.04-cuda13.0"
+  description = "Image family to use for the boot disk."
+}
+
 variable "public_ip" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Release Notes (Mandatory Description)
The B300 platform supports local disks, though additional steps are required to enable them within the tenant. This PR was created to add support for deployment via Terraform.