### PR TITLE
Fix bastion public IP allocation

### DIFF
--- a/bastion/README.md
+++ b/bastion/README.md
@@ -110,7 +110,7 @@ This step allows you to retain the IP address even if the VM is deleted. If you 
    --parent-id <project-id> --name wireguard_allocation_pub \
    --format json | jq -r '.metadata.id'
    ```
-2. Assign the value from the previous step to the `public_ip_allocation_id` variable in [variables.tf](./variables.tf):
+2. Assign the value from the previous step to the `public_ip_allocation_id` variable in `terraform.tfvars`:
 
 ```bash
 public_ip_allocation_id = <public_ip_allocation_id>

--- a/bastion/main.tf
+++ b/bastion/main.tf
@@ -9,10 +9,12 @@ resource "nebius_compute_v1_instance" "bastion_instance" {
 
   network_interfaces = [
     {
-      name              = "eth0"
-      subnet_id         = var.subnet_id
-      ip_address        = {}
-      public_ip_address = {}
+      name       = "eth0"
+      subnet_id  = var.subnet_id
+      ip_address = {}
+      public_ip_address = {
+        allocation_id = var.public_ip_allocation_id
+      }
     }
   ]
 


### PR DESCRIPTION
## What changed

The bastion solution now passes `public_ip_allocation_id` into the instance public IP config. Before this change, the README described a stable public IP path, but Terraform always requested a fresh public IP.

I also changed the README to tell users to set the value in `terraform.tfvars`, not `variables.tf`.

## Checks

- `terraform -chdir=/Users/realz/code/nebius-solutions-library/bastion fmt -check`
- `terraform -chdir=/Users/realz/code/nebius-solutions-library/bastion validate`
- `git diff --check`
