### PR TITLE
Add generic Kubernetes RBAC bindings module

### DIFF
--- a/k8s-training/README.md
+++ b/k8s-training/README.md
@@ -145,6 +145,66 @@ filesystem_csi = {
 
 This Terraform automation installs the CSI driver and configures the StorageClass only. Verification, pod-level validation, and cleanup remain in `filesystem-csi-validation/` as an explicit opt-in workflow.
 
+### Kubernetes RBAC access bindings
+
+Kubernetes RBAC can be managed by Terraform after the access model has been
+approved. It is disabled by default.
+
+An approved Nebius Cloud group cluster-admin binding can be declared like this:
+
+```hcl
+mk8s_rbac_bindings = {
+  enabled = true
+  cluster_role_bindings = {
+    nebius_viewer_cluster_admin = {
+      name      = "nebius-cluster-admin"
+      role_name = "cluster-admin"
+      subjects = [
+        {
+          kind      = "Group"
+          name      = "nebius:viewer"
+          api_group = "rbac.authorization.k8s.io"
+        }
+      ]
+    }
+  }
+}
+```
+
+For namespace-only access, create the namespace and bind one of the built-in
+ClusterRoles such as `view`, `edit`, or `admin`:
+
+```hcl
+mk8s_rbac_bindings = {
+  enabled = true
+  namespaces = {
+    workload = {
+      name = "workload"
+    }
+  }
+  namespace_role_bindings = {
+    workload_admin = {
+      name      = "workload-admin"
+      namespace = "workload"
+      role_kind = "ClusterRole"
+      role_name = "admin"
+      subjects = [
+        {
+          kind      = "Group"
+          name      = "nebius:viewer"
+          api_group = "rbac.authorization.k8s.io"
+        }
+      ]
+    }
+  }
+}
+```
+
+Temporary elevated access should be kept as an explicit Terraform change and
+removed after validation so Terraform destroys the binding on the next apply.
+This module does not manage Nebius IAM group membership, kubeconfig sharing, or
+private endpoint/bastion access.
+
 ## Connecting to the cluster
 
 ### Preparing the environment

--- a/k8s-training/README.md
+++ b/k8s-training/README.md
@@ -153,7 +153,7 @@ approved. It is disabled by default.
 An approved Nebius Cloud group cluster-admin binding can be declared like this:
 
 ```hcl
-mk8s_rbac_bindings = {
+k8s_rbac_bindings = {
   enabled = true
   cluster_role_bindings = {
     nebius_viewer_cluster_admin = {
@@ -175,7 +175,7 @@ For namespace-only access, create the namespace and bind one of the built-in
 ClusterRoles such as `view`, `edit`, or `admin`:
 
 ```hcl
-mk8s_rbac_bindings = {
+k8s_rbac_bindings = {
   enabled = true
   namespaces = {
     workload = {

--- a/k8s-training/output.tf
+++ b/k8s-training/output.tf
@@ -38,12 +38,3 @@ output "filesystem_csi" {
     default_storage_class_patch = var.filesystem_csi.make_default_storage_class
   } : null
 }
-
-output "k8s_rbac_bindings" {
-  description = "Kubernetes RBAC resources created for Kubernetes cluster access."
-  value = var.k8s_rbac_bindings.enabled ? {
-    namespaces              = module.k8s_rbac_bindings[0].namespaces
-    cluster_role_bindings   = module.k8s_rbac_bindings[0].cluster_role_bindings
-    namespace_role_bindings = module.k8s_rbac_bindings[0].namespace_role_bindings
-  } : null
-}

--- a/k8s-training/output.tf
+++ b/k8s-training/output.tf
@@ -39,11 +39,11 @@ output "filesystem_csi" {
   } : null
 }
 
-output "mk8s_rbac_bindings" {
-  description = "Kubernetes RBAC resources created for mk8s cluster access."
-  value = var.mk8s_rbac_bindings.enabled ? {
-    namespaces              = module.mk8s_rbac_bindings[0].namespaces
-    cluster_role_bindings   = module.mk8s_rbac_bindings[0].cluster_role_bindings
-    namespace_role_bindings = module.mk8s_rbac_bindings[0].namespace_role_bindings
+output "k8s_rbac_bindings" {
+  description = "Kubernetes RBAC resources created for Kubernetes cluster access."
+  value = var.k8s_rbac_bindings.enabled ? {
+    namespaces              = module.k8s_rbac_bindings[0].namespaces
+    cluster_role_bindings   = module.k8s_rbac_bindings[0].cluster_role_bindings
+    namespace_role_bindings = module.k8s_rbac_bindings[0].namespace_role_bindings
   } : null
 }

--- a/k8s-training/output.tf
+++ b/k8s-training/output.tf
@@ -38,3 +38,12 @@ output "filesystem_csi" {
     default_storage_class_patch = var.filesystem_csi.make_default_storage_class
   } : null
 }
+
+output "mk8s_rbac_bindings" {
+  description = "Kubernetes RBAC resources created for mk8s cluster access."
+  value = var.mk8s_rbac_bindings.enabled ? {
+    namespaces              = module.mk8s_rbac_bindings[0].namespaces
+    cluster_role_bindings   = module.mk8s_rbac_bindings[0].cluster_role_bindings
+    namespace_role_bindings = module.mk8s_rbac_bindings[0].namespace_role_bindings
+  } : null
+}

--- a/k8s-training/rbac_bindings.tf
+++ b/k8s-training/rbac_bindings.tf
@@ -1,11 +1,11 @@
-module "mk8s_rbac_bindings" {
-  count = var.mk8s_rbac_bindings.enabled ? 1 : 0
+module "k8s_rbac_bindings" {
+  count = var.k8s_rbac_bindings.enabled ? 1 : 0
 
   source = "../modules/k8s-rbac-bindings"
 
-  namespaces              = var.mk8s_rbac_bindings.namespaces
-  cluster_role_bindings   = var.mk8s_rbac_bindings.cluster_role_bindings
-  namespace_role_bindings = var.mk8s_rbac_bindings.namespace_role_bindings
+  namespaces              = var.k8s_rbac_bindings.namespaces
+  cluster_role_bindings   = var.k8s_rbac_bindings.cluster_role_bindings
+  namespace_role_bindings = var.k8s_rbac_bindings.namespace_role_bindings
   default_labels = {
     "app.kubernetes.io/managed-by" = "terraform"
     "library-solution"             = "k8s-training"

--- a/k8s-training/rbac_bindings.tf
+++ b/k8s-training/rbac_bindings.tf
@@ -1,0 +1,22 @@
+module "mk8s_rbac_bindings" {
+  count = var.mk8s_rbac_bindings.enabled ? 1 : 0
+
+  source = "../modules/k8s-rbac-bindings"
+
+  namespaces              = var.mk8s_rbac_bindings.namespaces
+  cluster_role_bindings   = var.mk8s_rbac_bindings.cluster_role_bindings
+  namespace_role_bindings = var.mk8s_rbac_bindings.namespace_role_bindings
+  default_labels = {
+    "app.kubernetes.io/managed-by" = "terraform"
+    "library-solution"             = "k8s-training"
+  }
+
+  providers = {
+    kubernetes = kubernetes
+  }
+
+  depends_on = [
+    nebius_mk8s_v1_node_group.cpu-only,
+    nebius_mk8s_v1_node_group.gpu,
+  ]
+}

--- a/k8s-training/terraform.tfvars
+++ b/k8s-training/terraform.tfvars
@@ -4,7 +4,7 @@ cluster_name = "k8s-training"
 # SSH config
 ssh_user_name = "ubuntu" # Username you want to use to connect to the nodes
 ssh_public_key = {
-  key = "put customers public ssh key here"
+  key = "put Nebius Cloud user's public SSH key here"
   # path = "put path to public ssh key here"
 }
 
@@ -70,6 +70,14 @@ existing_filestore             = ""    # If enable_filestore = true, with this v
 filestore_disk_size_gibibytes  = 100   # Set Filestore disk size in Gbytes.
 filestore_block_size_kibibytes = 4     # Set Filestore block size in bytes
 
+# Shared filesystem CSI driver. Enable only when using Shared Filesystem.
+# filesystem_csi = {
+#   chart_version                       = "0.1.5"
+#   namespace                           = "kube-system"
+#   make_default_storage_class          = true
+#   previous_default_storage_class_name = "compute-csi-default-sc"
+# }
+
 # KubeRay Cluster
 # for GPU isolation to work with kuberay, gpu_nodes_driverfull_image must be set 
 # to false.  This is because we enable acess to infiniband via securityContext.privileged
@@ -98,6 +106,25 @@ kuberay_max_gpu_replicas = 8
 # KubeRay Service
 # Enable to deploy KubeRay Operator with RayService CR 
 enable_kuberay_service = false
+
+# Optional Kubernetes RBAC bindings for mk8s cluster access.
+# Keep disabled until the access model is approved.
+# mk8s_rbac_bindings = {
+#   enabled = true
+#   cluster_role_bindings = {
+#     nebius_viewer_cluster_admin = {
+#       name      = "nebius-cluster-admin"
+#       role_name = "cluster-admin"
+#       subjects = [
+#         {
+#           kind      = "Group"
+#           name      = "nebius:viewer"
+#           api_group = "rbac.authorization.k8s.io"
+#         }
+#       ]
+#     }
+#   }
+# }
 
 # enable OPA gatekeeper (default: false)
 # enable_opa_gatekeeper = true 

--- a/k8s-training/terraform.tfvars
+++ b/k8s-training/terraform.tfvars
@@ -107,9 +107,9 @@ kuberay_max_gpu_replicas = 8
 # Enable to deploy KubeRay Operator with RayService CR 
 enable_kuberay_service = false
 
-# Optional Kubernetes RBAC bindings for mk8s cluster access.
+# Optional Kubernetes RBAC bindings for Kubernetes cluster access.
 # Keep disabled until the access model is approved.
-# mk8s_rbac_bindings = {
+# k8s_rbac_bindings = {
 #   enabled = true
 #   cluster_role_bindings = {
 #     nebius_viewer_cluster_admin = {

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -430,8 +430,8 @@ variable "enable_opa_gatekeeper" {
   default     = false
 }
 
-variable "mk8s_rbac_bindings" {
-  description = "Optional Kubernetes RBAC bindings for mk8s cluster access. Disabled by default; set enabled = true only after the access model is approved."
+variable "k8s_rbac_bindings" {
+  description = "Optional Kubernetes RBAC bindings for Kubernetes cluster access. Disabled by default; set enabled = true only after the access model is approved."
   type = object({
     enabled = optional(bool, false)
     namespaces = optional(map(object({
@@ -470,10 +470,10 @@ variable "mk8s_rbac_bindings" {
 
   validation {
     condition = (
-      !var.mk8s_rbac_bindings.enabled ||
-      length(var.mk8s_rbac_bindings.cluster_role_bindings) +
-      length(var.mk8s_rbac_bindings.namespace_role_bindings) > 0
+      !var.k8s_rbac_bindings.enabled ||
+      length(var.k8s_rbac_bindings.cluster_role_bindings) +
+      length(var.k8s_rbac_bindings.namespace_role_bindings) > 0
     )
-    error_message = "When mk8s_rbac_bindings.enabled is true, set at least one cluster_role_bindings or namespace_role_bindings entry."
+    error_message = "When k8s_rbac_bindings.enabled is true, set at least one cluster_role_bindings or namespace_role_bindings entry."
   }
 }

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -429,3 +429,51 @@ variable "enable_opa_gatekeeper" {
   type        = bool
   default     = false
 }
+
+variable "mk8s_rbac_bindings" {
+  description = "Optional Kubernetes RBAC bindings for mk8s cluster access. Disabled by default; set enabled = true only after the access model is approved."
+  type = object({
+    enabled = optional(bool, false)
+    namespaces = optional(map(object({
+      name        = optional(string)
+      labels      = optional(map(string), {})
+      annotations = optional(map(string), {})
+    })), {})
+    cluster_role_bindings = optional(map(object({
+      name      = optional(string)
+      role_name = string
+      subjects = list(object({
+        kind      = string
+        name      = string
+        api_group = optional(string)
+        namespace = optional(string)
+      }))
+      labels      = optional(map(string), {})
+      annotations = optional(map(string), {})
+    })), {})
+    namespace_role_bindings = optional(map(object({
+      name      = optional(string)
+      namespace = string
+      role_kind = optional(string, "ClusterRole")
+      role_name = string
+      subjects = list(object({
+        kind      = string
+        name      = string
+        api_group = optional(string)
+        namespace = optional(string)
+      }))
+      labels      = optional(map(string), {})
+      annotations = optional(map(string), {})
+    })), {})
+  })
+  default = {}
+
+  validation {
+    condition = (
+      !var.mk8s_rbac_bindings.enabled ||
+      length(var.mk8s_rbac_bindings.cluster_role_bindings) +
+      length(var.mk8s_rbac_bindings.namespace_role_bindings) > 0
+    )
+    error_message = "When mk8s_rbac_bindings.enabled is true, set at least one cluster_role_bindings or namespace_role_bindings entry."
+  }
+}

--- a/modules/k8s-rbac-bindings/README.md
+++ b/modules/k8s-rbac-bindings/README.md
@@ -1,0 +1,135 @@
+# k8s-rbac-bindings
+
+Manages Kubernetes RBAC bindings for Kubernetes clusters.
+
+Use this module when Nebius IAM groups or other Kubernetes subjects need a
+reviewable mapping to cluster-wide or namespace-scoped access, and you want
+Terraform to own the RBAC resources instead of applying ad hoc `kubectl`
+manifests.
+
+## What this module manages
+
+- Optional target namespaces
+- Cluster-wide `ClusterRoleBinding` resources
+- Namespace-scoped `RoleBinding` resources
+
+## What this module does not manage
+
+- Nebius IAM group membership
+- Kubeconfig generation or distribution
+- Bastion, VPN, or private endpoint tunneling
+- Time-based expiry for temporary elevated access
+
+## Inputs
+
+- `default_labels`
+- `namespaces`
+- `cluster_role_bindings`
+- `namespace_role_bindings`
+
+## Outputs
+
+- `namespaces`
+- `cluster_role_bindings`
+- `namespace_role_bindings`
+
+## Example: cluster-admin access
+
+```hcl
+module "k8s_rbac_bindings" {
+  source = "../../modules/k8s-rbac-bindings"
+
+  cluster_role_bindings = {
+    nebius_viewer_cluster_admin = {
+      name      = "nebius-cluster-admin"
+      role_name = "cluster-admin"
+      subjects = [
+        {
+          kind      = "Group"
+          name      = "nebius:viewer"
+          api_group = "rbac.authorization.k8s.io"
+        }
+      ]
+    }
+  }
+
+  providers = {
+    kubernetes = kubernetes
+  }
+}
+```
+
+## Example: namespace-only access
+
+```hcl
+module "k8s_rbac_bindings" {
+  source = "../../modules/k8s-rbac-bindings"
+
+  namespaces = {
+    workload = {
+      name = "workload"
+    }
+  }
+
+  namespace_role_bindings = {
+    workload_admin = {
+      name      = "workload-admin"
+      namespace = "workload"
+      role_kind = "ClusterRole"
+      role_name = "admin"
+      subjects = [
+        {
+          kind      = "Group"
+          name      = "nebius:viewer"
+          api_group = "rbac.authorization.k8s.io"
+        }
+      ]
+    }
+  }
+
+  providers = {
+    kubernetes = kubernetes
+  }
+}
+```
+
+## Example: read-only cluster visibility
+
+```hcl
+module "k8s_rbac_bindings" {
+  source = "../../modules/k8s-rbac-bindings"
+
+  cluster_role_bindings = {
+    nebius_viewer_read_only = {
+      name      = "nebius-viewer-read-only"
+      role_name = "view"
+      subjects = [
+        {
+          kind      = "Group"
+          name      = "nebius:viewer"
+          api_group = "rbac.authorization.k8s.io"
+        }
+      ]
+    }
+  }
+
+  providers = {
+    kubernetes = kubernetes
+  }
+}
+```
+
+## Temporary elevated access
+
+Use the same `cluster_role_bindings` or `namespace_role_bindings` shape, but
+keep the access grant explicit in the cluster Terraform configuration and
+remove it when validation is complete. Terraform will then destroy the binding
+on the next apply.
+
+## Security notes
+
+- Keep `cluster-admin` bindings opt-in and explicitly approved.
+- Prefer namespace-scoped `admin`, `edit`, or `view` bindings when full cluster
+  administration is not required.
+- Keep Nebius IAM group membership changes outside this module so Kubernetes
+  RBAC and identity lifecycle stay reviewable separately.

--- a/modules/k8s-rbac-bindings/examples/basic/main.tf
+++ b/modules/k8s-rbac-bindings/examples/basic/main.tf
@@ -1,0 +1,25 @@
+module "k8s_rbac_bindings" {
+  source = "../.."
+
+  namespaces = {
+    workload = {
+      name = "workload"
+    }
+  }
+
+  namespace_role_bindings = {
+    workload_admin = {
+      name      = "workload-admin"
+      namespace = "workload"
+      role_kind = "ClusterRole"
+      role_name = "admin"
+      subjects = [
+        {
+          kind      = "Group"
+          name      = "nebius:viewer"
+          api_group = "rbac.authorization.k8s.io"
+        }
+      ]
+    }
+  }
+}

--- a/modules/k8s-rbac-bindings/main.tf
+++ b/modules/k8s-rbac-bindings/main.tf
@@ -1,0 +1,107 @@
+locals {
+  namespaces = {
+    for key, namespace in var.namespaces : key => merge(namespace, {
+      name = try(trimspace(namespace.name), "") != "" ? trimspace(namespace.name) : key
+    })
+  }
+
+  cluster_role_bindings = {
+    for key, binding in var.cluster_role_bindings : key => merge(binding, {
+      name = try(trimspace(binding.name), "") != "" ? trimspace(binding.name) : key
+      subjects = [
+        for subject in binding.subjects : merge(subject, {
+          kind      = trimspace(subject.kind)
+          name      = trimspace(subject.name)
+          api_group = try(trimspace(subject.api_group), "") != "" ? trimspace(subject.api_group) : (subject.kind == "ServiceAccount" ? null : "rbac.authorization.k8s.io")
+          namespace = try(trimspace(subject.namespace), "") != "" ? trimspace(subject.namespace) : (subject.kind == "ServiceAccount" ? null : "")
+        })
+      ]
+    })
+  }
+
+  namespace_role_bindings = {
+    for key, binding in var.namespace_role_bindings : key => merge(binding, {
+      name      = try(trimspace(binding.name), "") != "" ? trimspace(binding.name) : key
+      namespace = trimspace(binding.namespace)
+      role_kind = trimspace(binding.role_kind)
+      role_name = trimspace(binding.role_name)
+      subjects = [
+        for subject in binding.subjects : merge(subject, {
+          kind      = trimspace(subject.kind)
+          name      = trimspace(subject.name)
+          api_group = try(trimspace(subject.api_group), "") != "" ? trimspace(subject.api_group) : (subject.kind == "ServiceAccount" ? null : "rbac.authorization.k8s.io")
+          namespace = try(trimspace(subject.namespace), "") != "" ? trimspace(subject.namespace) : (subject.kind == "ServiceAccount" ? null : "")
+        })
+      ]
+    })
+  }
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  for_each = local.namespaces
+
+  metadata {
+    name        = each.value.name
+    labels      = merge(var.default_labels, each.value.labels)
+    annotations = each.value.annotations
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "this" {
+  for_each = local.cluster_role_bindings
+
+  metadata {
+    name        = each.value.name
+    labels      = merge(var.default_labels, each.value.labels)
+    annotations = each.value.annotations
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = each.value.role_name
+  }
+
+  dynamic "subject" {
+    for_each = each.value.subjects
+
+    content {
+      kind      = subject.value.kind
+      name      = subject.value.name
+      api_group = subject.value.api_group
+      namespace = try(subject.value.namespace, null)
+    }
+  }
+}
+
+resource "kubernetes_role_binding_v1" "this" {
+  for_each = local.namespace_role_bindings
+
+  metadata {
+    name        = each.value.name
+    namespace   = each.value.namespace
+    labels      = merge(var.default_labels, each.value.labels)
+    annotations = each.value.annotations
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = each.value.role_kind
+    name      = each.value.role_name
+  }
+
+  dynamic "subject" {
+    for_each = each.value.subjects
+
+    content {
+      kind      = subject.value.kind
+      name      = subject.value.name
+      api_group = subject.value.api_group
+      namespace = try(subject.value.namespace, null)
+    }
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.this,
+  ]
+}

--- a/modules/k8s-rbac-bindings/outputs.tf
+++ b/modules/k8s-rbac-bindings/outputs.tf
@@ -1,0 +1,33 @@
+output "namespaces" {
+  description = "Namespaces created by this module."
+  value = {
+    for key, namespace in kubernetes_namespace_v1.this : key => {
+      id   = namespace.id
+      name = namespace.metadata[0].name
+    }
+  }
+}
+
+output "cluster_role_bindings" {
+  description = "ClusterRoleBindings created by this module."
+  value = {
+    for key, binding in kubernetes_cluster_role_binding_v1.this : key => {
+      id        = binding.id
+      name      = binding.metadata[0].name
+      role_name = binding.role_ref[0].name
+    }
+  }
+}
+
+output "namespace_role_bindings" {
+  description = "RoleBindings created by this module."
+  value = {
+    for key, binding in kubernetes_role_binding_v1.this : key => {
+      id        = binding.id
+      name      = binding.metadata[0].name
+      namespace = binding.metadata[0].namespace
+      role_kind = binding.role_ref[0].kind
+      role_name = binding.role_ref[0].name
+    }
+  }
+}

--- a/modules/k8s-rbac-bindings/variables.tf
+++ b/modules/k8s-rbac-bindings/variables.tf
@@ -1,0 +1,100 @@
+variable "default_labels" {
+  description = "Labels applied to all Kubernetes resources created by this module."
+  type        = map(string)
+  default     = {}
+}
+
+variable "namespaces" {
+  description = "Optional namespaces to create before namespace-scoped RBAC bindings are applied."
+  type = map(object({
+    name        = optional(string)
+    labels      = optional(map(string), {})
+    annotations = optional(map(string), {})
+  }))
+  default = {}
+}
+
+variable "cluster_role_bindings" {
+  description = "Cluster-wide RBAC bindings keyed by stable Terraform identity. Use for cluster read-only visibility or explicitly approved elevated access."
+  type = map(object({
+    name      = optional(string)
+    role_name = string
+    subjects = list(object({
+      kind      = string
+      name      = string
+      api_group = optional(string)
+      namespace = optional(string)
+    }))
+    labels      = optional(map(string), {})
+    annotations = optional(map(string), {})
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for _, binding in var.cluster_role_bindings :
+      trimspace(binding.role_name) != "" && length(binding.subjects) > 0
+    ])
+    error_message = "Each cluster_role_bindings entry must set role_name and at least one subject."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for _, binding in var.cluster_role_bindings : [
+        for subject in binding.subjects :
+        contains(["User", "Group", "ServiceAccount"], subject.kind) &&
+        trimspace(subject.name) != "" &&
+        (
+          subject.kind != "ServiceAccount" ||
+          try(trimspace(subject.namespace), "") != ""
+        )
+      ]
+    ]))
+    error_message = "Subjects must be User, Group, or ServiceAccount. ServiceAccount subjects must include namespace."
+  }
+}
+
+variable "namespace_role_bindings" {
+  description = "Namespace-scoped RBAC bindings keyed by stable Terraform identity. Use built-in ClusterRoles such as view, edit, or admin for target namespaces."
+  type = map(object({
+    name      = optional(string)
+    namespace = string
+    role_kind = optional(string, "ClusterRole")
+    role_name = string
+    subjects = list(object({
+      kind      = string
+      name      = string
+      api_group = optional(string)
+      namespace = optional(string)
+    }))
+    labels      = optional(map(string), {})
+    annotations = optional(map(string), {})
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for _, binding in var.namespace_role_bindings :
+      trimspace(binding.namespace) != "" &&
+      trimspace(binding.role_name) != "" &&
+      contains(["Role", "ClusterRole"], binding.role_kind) &&
+      length(binding.subjects) > 0
+    ])
+    error_message = "Each namespace_role_bindings entry must set namespace, role_name, a role_kind of Role or ClusterRole, and at least one subject."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for _, binding in var.namespace_role_bindings : [
+        for subject in binding.subjects :
+        contains(["User", "Group", "ServiceAccount"], subject.kind) &&
+        trimspace(subject.name) != "" &&
+        (
+          subject.kind != "ServiceAccount" ||
+          try(trimspace(subject.namespace), "") != ""
+        )
+      ]
+    ]))
+    error_message = "Subjects must be User, Group, or ServiceAccount. ServiceAccount subjects must include namespace."
+  }
+}

--- a/modules/k8s-rbac-bindings/versions.tf
+++ b/modules/k8s-rbac-bindings/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.0.1, < 4.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Adds a reusable Terraform module for managing Kubernetes RBAC bindings:

- `modules/k8s-rbac-bindings`
- Optional namespace creation
- Cluster-wide `ClusterRoleBinding` support
- Namespace-scoped `RoleBinding` support
- Multiple bindings and multiple subjects per binding
- Input validation for common invalid RBAC configurations

Also wires the module into `k8s-training` behind a disabled-by-default `k8s_rbac_bindings` variable, and adds README/tfvars examples for common access patterns.

## Validation

- `terraform fmt -check -recursive k8s-training modules/k8s-rbac-bindings`
- `terraform validate` for `modules/k8s-rbac-bindings`
- `terraform validate` for `modules/k8s-rbac-bindings/examples/basic`
- `terraform validate` for `k8s-training`
- Live smoke-tested on a throwaway CPU-only mk8s cluster:
  - Verified cluster-wide binding creation
  - Verified namespace-scoped access with a synthetic Nebius group
  - Verified access was denied outside the target namespace
  - Destroyed the smoke cluster after testing
