### PR TITLE
Add reusable security group module

### DIFF
--- a/bastion/README.md
+++ b/bastion/README.md
@@ -11,6 +11,8 @@ Also installed on the host:
 - kubectl and configured to connect to first mk8s cluster available in project by --internal flag
   (scanned by: `nebius mk8s v1 cluster list`)
 
+The solution creates a managed Nebius security group by default. The security group allows SSH and WireGuard UDP access only from the configured CIDR blocks. The WireGuard UI port is not exposed unless `bastion_allowed_wireguard_ui_cidrs` is set. Outbound traffic is unrestricted by default for package installation, Nebius APIs, and container/object storage access; set `bastion_egress_cidrs = []` to create no default egress rule.
+
 ## How to connect over bastion
 
 ### Edit your local ssh config
@@ -99,6 +101,46 @@ Update the following variables in the `terraform.tfvars` file with your own valu
 
 - `ssh_user_name`
 - `ssh_public_key`
+- `bastion_allowed_ssh_cidrs`
+
+Security group variables:
+
+- `enable_bastion_security_group`: Create and attach the managed security group. Defaults to `true`.
+- `bastion_allowed_ssh_cidrs`: CIDRs allowed to access SSH on TCP 22. Required when `enable_bastion_security_group = true`.
+- `bastion_allowed_wireguard_cidrs`: CIDRs allowed to access WireGuard on UDP 51820. Defaults to `bastion_allowed_ssh_cidrs`.
+- `bastion_allowed_wireguard_ui_cidrs`: CIDRs allowed to access the WireGuard UI on TCP 5000. Defaults to no public UI access. Set this explicitly only for trusted admin CIDRs.
+- `bastion_allow_unrestricted_ingress_rules`: Set to `true` only when intentionally allowing ingress rules from `0.0.0.0/0`, `::/0`, or an empty source.
+- `bastion_security_group_name`: Name of the managed bastion security group. Override this when deploying multiple bastion instances in one project; the default keeps the existing single-bastion naming pattern.
+- `bastion_egress_cidrs`: CIDRs the bastion can reach. Defaults to `["0.0.0.0/0"]`. Set to `[]` to create no default egress rule; add explicit `bastion_extra_egress_rules` for stricter deployments.
+- `bastion_extra_security_group_ids`: Existing security group IDs to attach in addition to the managed security group.
+- `bastion_extra_ingress_rules`: Additional managed ingress rules merged with the SSH, WireGuard, and optional WireGuard UI defaults.
+- `bastion_extra_egress_rules`: Additional managed egress rules merged with the default egress rule when `bastion_egress_cidrs` is not empty.
+
+Example:
+
+```hcl
+bastion_allowed_ssh_cidrs = ["203.0.113.10/32"]
+
+# Optional: expose WireGuard UI only to trusted admin CIDRs.
+bastion_allowed_wireguard_ui_cidrs = ["203.0.113.10/32"]
+```
+
+For a stricter egress posture, disable the default egress rule and add only the explicit destinations your deployment needs:
+
+```hcl
+bastion_egress_cidrs = []
+```
+
+Without egress, first boot may fail to install packages or reach Nebius APIs unless equivalent access is provided through extra egress rules or another attached security group.
+
+For a quick test from a dynamic source IP, you can temporarily use unrestricted ingress:
+
+```hcl
+bastion_allowed_ssh_cidrs          = ["0.0.0.0/0"]
+bastion_allow_unrestricted_ingress_rules = true
+```
+
+Do not use unrestricted ingress for a durable deployment.
 
 ## Creating and using a public IP allocation
 
@@ -132,6 +174,8 @@ public_ip_allocation_id = <public_ip_allocation_id>
    ```
    http://<instance_public_ip>:5000
    ```
+
+   The managed security group allows this only when `bastion_allowed_wireguard_ui_cidrs` is set. If the variable is unset or empty, the UI service may be running on the VM, but TCP 5000 is not opened by the managed security group.
 
 4. Log in with the following credentials:
    - **Username:** `admin`

--- a/bastion/README.md
+++ b/bastion/README.md
@@ -11,7 +11,7 @@ Also installed on the host:
 - kubectl and configured to connect to first mk8s cluster available in project by --internal flag
   (scanned by: `nebius mk8s v1 cluster list`)
 
-The solution creates a managed Nebius security group by default. The security group allows SSH and WireGuard UDP access only from the configured CIDR blocks. The WireGuard UI port is not exposed unless `bastion_allowed_wireguard_ui_cidrs` is set. Outbound traffic is unrestricted by default for package installation, Nebius APIs, and container/object storage access; set `bastion_egress_cidrs = []` to create no default egress rule.
+The solution creates a managed Nebius security group by default. The security group allows SSH and WireGuard UDP access only from the configured CIDR blocks; when no SSH CIDRs are provided, no managed inbound SSH or WireGuard rule is created. The WireGuard UI port is not exposed unless `bastion_allowed_wireguard_ui_cidrs` is set. Outbound traffic is unrestricted by default for package installation, Nebius APIs, and container/object storage access; set `bastion_egress_cidrs = []` to create no default egress rule.
 
 ## How to connect over bastion
 
@@ -101,20 +101,22 @@ Update the following variables in the `terraform.tfvars` file with your own valu
 
 - `ssh_user_name`
 - `ssh_public_key`
-- `bastion_allowed_ssh_cidrs`
+- `bastion_allowed_ssh_cidrs` if you want the managed security group to allow SSH access
 
 Security group variables:
 
 - `enable_bastion_security_group`: Create and attach the managed security group. Defaults to `true`.
-- `bastion_allowed_ssh_cidrs`: CIDRs allowed to access SSH on TCP 22. Required when `enable_bastion_security_group = true`.
-- `bastion_allowed_wireguard_cidrs`: CIDRs allowed to access WireGuard on UDP 51820. Defaults to `bastion_allowed_ssh_cidrs`.
+- `bastion_allowed_ssh_cidrs`: CIDRs allowed to access SSH on TCP 22. When unset or empty, no managed SSH ingress rule is created.
+- `bastion_allowed_wireguard_cidrs`: CIDRs allowed to access WireGuard on UDP 51820. Defaults to `bastion_allowed_ssh_cidrs`; set to `[]` to create no managed WireGuard ingress rule.
 - `bastion_allowed_wireguard_ui_cidrs`: CIDRs allowed to access the WireGuard UI on TCP 5000. Defaults to no public UI access. Set this explicitly only for trusted admin CIDRs.
-- `bastion_allow_unrestricted_ingress_rules`: Set to `true` only when intentionally allowing ingress rules from `0.0.0.0/0`, `::/0`, or an empty source.
+- `bastion_allow_unrestricted_ingress_rules`: Set to `true` only when intentionally allowing ingress rules from `0.0.0.0/0` or an empty source.
 - `bastion_security_group_name`: Name of the managed bastion security group. Override this when deploying multiple bastion instances in one project; the default keeps the existing single-bastion naming pattern.
 - `bastion_egress_cidrs`: CIDRs the bastion can reach. Defaults to `["0.0.0.0/0"]`. Set to `[]` to create no default egress rule; add explicit `bastion_extra_egress_rules` for stricter deployments.
 - `bastion_extra_security_group_ids`: Existing security group IDs to attach in addition to the managed security group.
 - `bastion_extra_ingress_rules`: Additional managed ingress rules merged with the SSH, WireGuard, and optional WireGuard UI defaults.
 - `bastion_extra_egress_rules`: Additional managed egress rules merged with the default egress rule when `bastion_egress_cidrs` is not empty.
+
+When `enable_bastion_security_group = true` and no SSH CIDRs are configured, Terraform emits a check warning and `bastion_security_group_access_note` to make the locked-down access posture visible in the plan and outputs.
 
 Example:
 

--- a/bastion/locals.tf
+++ b/bastion/locals.tf
@@ -1,4 +1,47 @@
 locals {
   ssh_public_key = var.ssh_public_key.key != null ? var.ssh_public_key.key : (
   fileexists(var.ssh_public_key.path) ? file(var.ssh_public_key.path) : null)
+
+  bastion_ssh_source_cidrs          = var.bastion_allowed_ssh_cidrs == null ? [] : var.bastion_allowed_ssh_cidrs
+  bastion_wireguard_source_cidrs    = var.bastion_allowed_wireguard_cidrs == null ? local.bastion_ssh_source_cidrs : var.bastion_allowed_wireguard_cidrs
+  bastion_wireguard_ui_source_cidrs = var.bastion_allowed_wireguard_ui_cidrs == null ? [] : var.bastion_allowed_wireguard_ui_cidrs
+
+  bastion_default_ingress_rules = merge(
+    length(local.bastion_ssh_source_cidrs) > 0 ? {
+      ssh = {
+        protocol          = "TCP"
+        destination_ports = [22]
+        source_cidrs      = local.bastion_ssh_source_cidrs
+        priority          = 100
+      }
+    } : {},
+    length(local.bastion_wireguard_source_cidrs) > 0 ? {
+      wireguard = {
+        protocol          = "UDP"
+        destination_ports = [51820]
+        source_cidrs      = local.bastion_wireguard_source_cidrs
+        priority          = 110
+      }
+    } : {},
+    length(local.bastion_wireguard_ui_source_cidrs) > 0 ? {
+      wireguard_ui = {
+        protocol          = "TCP"
+        destination_ports = [5000]
+        source_cidrs      = local.bastion_wireguard_ui_source_cidrs
+        priority          = 120
+      }
+    } : {}
+  )
+
+  bastion_default_egress_rules = length(var.bastion_egress_cidrs) > 0 ? {
+    internet = {
+      protocol          = "ANY"
+      destination_cidrs = var.bastion_egress_cidrs
+      priority          = 900
+    }
+  } : {}
+
+  bastion_managed_security_group_ids = var.enable_bastion_security_group ? [module.bastion_security_group[0].id] : []
+  bastion_security_group_ids         = concat(local.bastion_managed_security_group_ids, var.bastion_extra_security_group_ids)
+  bastion_security_group_refs        = length(local.bastion_security_group_ids) > 0 ? [for id in local.bastion_security_group_ids : { id = id }] : null
 }

--- a/bastion/main.tf
+++ b/bastion/main.tf
@@ -9,9 +9,10 @@ resource "nebius_compute_v1_instance" "bastion_instance" {
 
   network_interfaces = [
     {
-      name       = "eth0"
-      subnet_id  = var.subnet_id
-      ip_address = {}
+      name            = "eth0"
+      subnet_id       = var.subnet_id
+      ip_address      = {}
+      security_groups = local.bastion_security_group_refs
       public_ip_address = {
         allocation_id = var.public_ip_allocation_id
       }

--- a/bastion/main.tf
+++ b/bastion/main.tf
@@ -32,4 +32,8 @@ resource "nebius_compute_v1_instance" "bastion_instance" {
     parent_id          = var.parent_id
     service_account_id = local.service_account_id
   })
+
+  depends_on = [
+    module.bastion_security_group,
+  ]
 }

--- a/bastion/output.tf
+++ b/bastion/output.tf
@@ -17,3 +17,10 @@ output "bastion_security_group_rules" {
     egress  = module.bastion_security_group[0].egress_rule_ids
   } : null
 }
+
+output "bastion_security_group_access_note" {
+  description = "Access note for the managed bastion security group."
+  value = var.enable_bastion_security_group && length(local.bastion_ssh_source_cidrs) == 0 ? (
+    "No default SSH ingress rule was created from bastion_allowed_ssh_cidrs. Set bastion_allowed_ssh_cidrs, bastion_extra_ingress_rules, bastion_extra_security_group_ids, or disable the managed security group if SSH access is required."
+  ) : null
+}

--- a/bastion/output.tf
+++ b/bastion/output.tf
@@ -4,3 +4,16 @@ output "bastion_host_public_ip" {
 output "bastion_service_account" {
   value = nebius_iam_v1_service_account.bastion-sa.id
 }
+
+output "bastion_security_group_id" {
+  description = "Managed bastion security group ID. Null when enable_bastion_security_group is false."
+  value       = var.enable_bastion_security_group ? module.bastion_security_group[0].id : null
+}
+
+output "bastion_security_group_rules" {
+  description = "Managed bastion security group rule IDs. Null when enable_bastion_security_group is false."
+  value = var.enable_bastion_security_group ? {
+    ingress = module.bastion_security_group[0].ingress_rule_ids
+    egress  = module.bastion_security_group[0].egress_rule_ids
+  } : null
+}

--- a/bastion/sa.tf
+++ b/bastion/sa.tf
@@ -27,6 +27,12 @@ resource "nebius_iam_v1_auth_public_key" "bastion-sa-public-key" {
     }
   }
   data = tls_private_key.bastion_sa_key.public_key_pem
+
+  lifecycle {
+    ignore_changes = [
+      expires_at,
+    ]
+  }
 }
 
 locals {

--- a/bastion/security-group.tf
+++ b/bastion/security-group.tf
@@ -1,0 +1,40 @@
+data "nebius_vpc_v1_subnet" "bastion" {
+  count = var.enable_bastion_security_group ? 1 : 0
+
+  id = var.subnet_id
+}
+
+resource "terraform_data" "validate_bastion_security_group_inputs" {
+  count = var.enable_bastion_security_group ? 1 : 0
+
+  input = local.bastion_ssh_source_cidrs
+
+  lifecycle {
+    precondition {
+      condition     = length(local.bastion_ssh_source_cidrs) > 0
+      error_message = "bastion_allowed_ssh_cidrs must contain at least one CIDR when enable_bastion_security_group is true."
+    }
+  }
+}
+
+module "bastion_security_group" {
+  count = var.enable_bastion_security_group ? 1 : 0
+
+  source = "../modules/security-group"
+
+  parent_id  = var.parent_id
+  network_id = data.nebius_vpc_v1_subnet.bastion[0].network_id
+  name       = var.bastion_security_group_name
+
+  labels = {
+    "library-solution" = "bastion"
+  }
+
+  allow_unrestricted_ingress_rules = var.bastion_allow_unrestricted_ingress_rules
+  ingress_rules                    = merge(local.bastion_default_ingress_rules, var.bastion_extra_ingress_rules)
+  egress_rules                     = merge(local.bastion_default_egress_rules, var.bastion_extra_egress_rules)
+
+  depends_on = [
+    terraform_data.validate_bastion_security_group_inputs
+  ]
+}

--- a/bastion/security-group.tf
+++ b/bastion/security-group.tf
@@ -4,19 +4,6 @@ data "nebius_vpc_v1_subnet" "bastion" {
   id = var.subnet_id
 }
 
-resource "terraform_data" "validate_bastion_security_group_inputs" {
-  count = var.enable_bastion_security_group ? 1 : 0
-
-  input = local.bastion_ssh_source_cidrs
-
-  lifecycle {
-    precondition {
-      condition     = length(local.bastion_ssh_source_cidrs) > 0
-      error_message = "bastion_allowed_ssh_cidrs must contain at least one CIDR when enable_bastion_security_group is true."
-    }
-  }
-}
-
 module "bastion_security_group" {
   count = var.enable_bastion_security_group ? 1 : 0
 
@@ -33,8 +20,14 @@ module "bastion_security_group" {
   allow_unrestricted_ingress_rules = var.bastion_allow_unrestricted_ingress_rules
   ingress_rules                    = merge(local.bastion_default_ingress_rules, var.bastion_extra_ingress_rules)
   egress_rules                     = merge(local.bastion_default_egress_rules, var.bastion_extra_egress_rules)
+}
 
-  depends_on = [
-    terraform_data.validate_bastion_security_group_inputs
-  ]
+check "bastion_default_ssh_ingress" {
+  assert {
+    condition = (
+      !var.enable_bastion_security_group ||
+      length(local.bastion_ssh_source_cidrs) > 0
+    )
+    error_message = "No default SSH ingress rule was created from bastion_allowed_ssh_cidrs. Set bastion_allowed_ssh_cidrs, bastion_extra_ingress_rules, bastion_extra_security_group_ids, or disable the managed security group if SSH access is required."
+  }
 }

--- a/bastion/terraform.tfvars
+++ b/bastion/terraform.tfvars
@@ -3,3 +3,13 @@
 #   key  = "put your public ssh key here"
 #   path = "put path to public ssh key here"
 # }
+
+# Required when enable_bastion_security_group = true.
+# bastion_allowed_ssh_cidrs = ["203.0.113.10/32"]
+
+# Optional. Defaults to bastion_allowed_ssh_cidrs when unset.
+# bastion_allowed_wireguard_cidrs = ["203.0.113.10/32"]
+# bastion_allowed_wireguard_ui_cidrs = ["203.0.113.10/32"]
+
+# Set true only for test environments where you intentionally need unrestricted ingress.
+# bastion_allow_unrestricted_ingress_rules = false

--- a/bastion/terraform.tfvars
+++ b/bastion/terraform.tfvars
@@ -4,7 +4,8 @@
 #   path = "put path to public ssh key here"
 # }
 
-# Required when enable_bastion_security_group = true.
+# Set this to allow SSH ingress through the managed security group.
+# When unset or empty, no managed SSH ingress rule is created.
 # bastion_allowed_ssh_cidrs = ["203.0.113.10/32"]
 
 # Optional. Defaults to bastion_allowed_ssh_cidrs when unset.

--- a/bastion/test-resource.tf
+++ b/bastion/test-resource.tf
@@ -6,8 +6,9 @@ resource "null_resource" "check_bastion_instance" {
   count = var.test_mode ? 1 : 0
 
   connection {
-    user = var.ssh_user_name
-    host = local.test_bst_host
+    user        = var.ssh_user_name
+    host        = local.test_bst_host
+    private_key = var.ssh_private_key_path == null ? null : file(var.ssh_private_key_path)
   }
 
   provisioner "remote-exec" {
@@ -16,7 +17,8 @@ resource "null_resource" "check_bastion_instance" {
       "cloud-init status --wait",
       "ip link show wg0",
       "systemctl -q status wg-quick@wg0.service > /dev/null",
-      ".nebius/bin/nebius iam whoami > /dev/null"
+      "systemctl -q status wgui_server.service > /dev/null",
+      "nebius iam whoami > /dev/null"
     ]
   }
 }

--- a/bastion/tests/main.tftest.hcl
+++ b/bastion/tests/main.tftest.hcl
@@ -2,6 +2,10 @@ run "test_mode_bastion_apply" {
   command = apply
 
   variables {
-    test_mode = true
+    test_mode                                = true
+    bastion_allowed_ssh_cidrs                = ["0.0.0.0/0"]
+    bastion_allow_unrestricted_ingress_rules = true
+    bastion_allowed_wireguard_cidrs          = ["0.0.0.0/0"]
+    bastion_allowed_wireguard_ui_cidrs       = ["0.0.0.0/0"]
   }
 }

--- a/bastion/variables.tf
+++ b/bastion/variables.tf
@@ -33,11 +33,130 @@ variable "ssh_public_key" {
   }
 }
 
+variable "ssh_private_key_path" {
+  description = "Optional private SSH key path used by Terraform test_mode remote checks."
+  type        = string
+  default     = null
+}
+
 # Access By IP
 variable "public_ip_allocation_id" {
   description = "Id of a manually created public_ip_allocation."
   type        = string
   default     = null
+}
+
+variable "enable_bastion_security_group" {
+  description = "Create and attach a managed security group for the bastion instance."
+  type        = bool
+  default     = true
+}
+
+variable "bastion_allowed_ssh_cidrs" {
+  description = "CIDR blocks allowed to connect to the bastion over SSH. Required when enable_bastion_security_group is true."
+  type        = list(string)
+  default     = null
+
+  validation {
+    condition = var.bastion_allowed_ssh_cidrs == null || alltrue([
+      for cidr in var.bastion_allowed_ssh_cidrs : can(cidrhost(cidr, 0))
+    ])
+    error_message = "bastion_allowed_ssh_cidrs must contain valid CIDR blocks."
+  }
+}
+
+variable "bastion_allowed_wireguard_cidrs" {
+  description = "CIDR blocks allowed to connect to WireGuard UDP 51820. Defaults to bastion_allowed_ssh_cidrs when null."
+  type        = list(string)
+  default     = null
+
+  validation {
+    condition = var.bastion_allowed_wireguard_cidrs == null || alltrue([
+      for cidr in var.bastion_allowed_wireguard_cidrs : can(cidrhost(cidr, 0))
+    ])
+    error_message = "bastion_allowed_wireguard_cidrs must contain valid CIDR blocks."
+  }
+}
+
+variable "bastion_allowed_wireguard_ui_cidrs" {
+  description = "CIDR blocks allowed to connect to WireGuard UI TCP 5000. Defaults to no public UI access when null."
+  type        = list(string)
+  default     = null
+
+  validation {
+    condition = var.bastion_allowed_wireguard_ui_cidrs == null || alltrue([
+      for cidr in var.bastion_allowed_wireguard_ui_cidrs : can(cidrhost(cidr, 0))
+    ])
+    error_message = "bastion_allowed_wireguard_ui_cidrs must contain valid CIDR blocks."
+  }
+}
+
+variable "bastion_allow_unrestricted_ingress_rules" {
+  description = "Allow 0.0.0.0/0 or empty-source ALLOW ingress rules in the managed bastion security group."
+  type        = bool
+  default     = false
+}
+
+variable "bastion_security_group_name" {
+  description = "Name of the managed bastion security group."
+  type        = string
+  default     = "bastion-security-group"
+
+  validation {
+    condition     = length(trimspace(var.bastion_security_group_name)) > 0
+    error_message = "bastion_security_group_name must not be empty."
+  }
+}
+
+variable "bastion_egress_cidrs" {
+  description = "CIDR blocks the bastion can reach. Defaults to unrestricted egress for package installs and Nebius API access."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+
+  validation {
+    condition = alltrue([
+      for cidr in var.bastion_egress_cidrs : can(cidrhost(cidr, 0))
+    ])
+    error_message = "bastion_egress_cidrs must contain valid CIDR blocks."
+  }
+}
+
+variable "bastion_extra_security_group_ids" {
+  description = "Additional existing security group IDs to attach to the bastion network interface."
+  type        = list(string)
+  default     = []
+}
+
+variable "bastion_extra_ingress_rules" {
+  description = "Additional ingress rules for the managed bastion security group."
+  type = map(object({
+    name                     = optional(string)
+    access                   = optional(string, "ALLOW")
+    protocol                 = optional(string, "TCP")
+    rule_type                = optional(string, "STATEFUL")
+    priority                 = optional(number, 500)
+    source_cidrs             = optional(list(string), [])
+    source_security_group_id = optional(string)
+    destination_ports        = optional(list(number), [])
+    labels                   = optional(map(string), {})
+  }))
+  default = {}
+}
+
+variable "bastion_extra_egress_rules" {
+  description = "Additional egress rules for the managed bastion security group."
+  type = map(object({
+    name                          = optional(string)
+    access                        = optional(string, "ALLOW")
+    protocol                      = optional(string, "ANY")
+    rule_type                     = optional(string, "STATEFUL")
+    priority                      = optional(number, 900)
+    destination_cidrs             = optional(list(string), [])
+    destination_security_group_id = optional(string)
+    destination_ports             = optional(list(number), [])
+    labels                        = optional(map(string), {})
+  }))
+  default = {}
 }
 
 variable "test_mode" {

--- a/bastion/variables.tf
+++ b/bastion/variables.tf
@@ -53,15 +53,16 @@ variable "enable_bastion_security_group" {
 }
 
 variable "bastion_allowed_ssh_cidrs" {
-  description = "CIDR blocks allowed to connect to the bastion over SSH. Required when enable_bastion_security_group is true."
+  description = "CIDR blocks allowed to connect to the bastion over SSH. When null or empty, no managed SSH ingress rule is created."
   type        = list(string)
   default     = null
 
   validation {
-    condition = var.bastion_allowed_ssh_cidrs == null || alltrue([
-      for cidr in var.bastion_allowed_ssh_cidrs : can(cidrhost(cidr, 0))
+    condition = alltrue([
+      for cidr in(var.bastion_allowed_ssh_cidrs != null ? var.bastion_allowed_ssh_cidrs : []) :
+      can(cidrhost(cidr, 0)) && can(regex("^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])/([0-9]|[12][0-9]|3[0-2])$", cidr))
     ])
-    error_message = "bastion_allowed_ssh_cidrs must contain valid CIDR blocks."
+    error_message = "bastion_allowed_ssh_cidrs must contain valid IPv4 CIDR blocks."
   }
 }
 
@@ -71,10 +72,11 @@ variable "bastion_allowed_wireguard_cidrs" {
   default     = null
 
   validation {
-    condition = var.bastion_allowed_wireguard_cidrs == null || alltrue([
-      for cidr in var.bastion_allowed_wireguard_cidrs : can(cidrhost(cidr, 0))
+    condition = alltrue([
+      for cidr in(var.bastion_allowed_wireguard_cidrs != null ? var.bastion_allowed_wireguard_cidrs : []) :
+      can(cidrhost(cidr, 0)) && can(regex("^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])/([0-9]|[12][0-9]|3[0-2])$", cidr))
     ])
-    error_message = "bastion_allowed_wireguard_cidrs must contain valid CIDR blocks."
+    error_message = "bastion_allowed_wireguard_cidrs must contain valid IPv4 CIDR blocks."
   }
 }
 
@@ -84,10 +86,11 @@ variable "bastion_allowed_wireguard_ui_cidrs" {
   default     = null
 
   validation {
-    condition = var.bastion_allowed_wireguard_ui_cidrs == null || alltrue([
-      for cidr in var.bastion_allowed_wireguard_ui_cidrs : can(cidrhost(cidr, 0))
+    condition = alltrue([
+      for cidr in(var.bastion_allowed_wireguard_ui_cidrs != null ? var.bastion_allowed_wireguard_ui_cidrs : []) :
+      can(cidrhost(cidr, 0)) && can(regex("^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])/([0-9]|[12][0-9]|3[0-2])$", cidr))
     ])
-    error_message = "bastion_allowed_wireguard_ui_cidrs must contain valid CIDR blocks."
+    error_message = "bastion_allowed_wireguard_ui_cidrs must contain valid IPv4 CIDR blocks."
   }
 }
 
@@ -115,9 +118,10 @@ variable "bastion_egress_cidrs" {
 
   validation {
     condition = alltrue([
-      for cidr in var.bastion_egress_cidrs : can(cidrhost(cidr, 0))
+      for cidr in var.bastion_egress_cidrs :
+      can(cidrhost(cidr, 0)) && can(regex("^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])/([0-9]|[12][0-9]|3[0-2])$", cidr))
     ])
-    error_message = "bastion_egress_cidrs must contain valid CIDR blocks."
+    error_message = "bastion_egress_cidrs must contain valid IPv4 CIDR blocks."
   }
 }
 

--- a/modules/security-group/README.md
+++ b/modules/security-group/README.md
@@ -1,6 +1,6 @@
 # Nebius security group module
 
-Creates a Nebius VPC security group and managed ingress/egress rules with validation around common misconfigurations: unrestricted ingress, invalid ports, invalid CIDRs, empty security group IDs, mixed source/destination selectors, unsupported protocol/port combinations, and rule priority ranges.
+Creates a Nebius VPC security group and managed ingress/egress rules with validation around common misconfigurations: unrestricted ingress, invalid ports, invalid IPv4 CIDRs, empty security group IDs, mixed source/destination selectors, unsupported protocol/port combinations, and rule priority ranges.
 
 Security groups apply implicit deny after rule evaluation. The module therefore expects callers to model every allowed path deliberately.
 
@@ -48,11 +48,11 @@ network_interfaces = [
 
 ## Notes
 
-- `allow_unrestricted_ingress_rules` defaults to `false`. An `ALLOW` ingress rule with empty `source_cidrs`, `0.0.0.0/0`, `::/0`, or `0::/0` fails validation unless the caller explicitly opts in.
+- `allow_unrestricted_ingress_rules` defaults to `false`. An `ALLOW` ingress rule with empty `source_cidrs` or `0.0.0.0/0` fails validation unless the caller explicitly opts in.
 - `allow_unrestricted_egress_rules` defaults to `true` because most solutions need package repositories, Nebius APIs, container registries, or Object Storage. Set it to `false` for stricter workloads.
 - The module creates only the egress rules passed in `egress_rules`. If `egress_rules = {}`, no egress rules are created, even when `allow_unrestricted_egress_rules = true`; that flag controls validation only.
 - Use either CIDRs or a security group selector per rule, not both. Security group selector IDs must be non-empty when set.
 - Ports are valid only on TCP and UDP rules. Do not set `destination_ports` for `ANY` or `ICMP` rules.
-- Each rule supports up to 8 CIDRs and up to 8 destination ports. Rule priorities must be between 1 and 1000.
+- Each rule supports up to 8 IPv4 CIDRs and up to 8 destination ports. Rule priorities must be between 1 and 1000.
 - Keep rule keys stable. They are used by `for_each`, so renaming a key recreates that rule and may briefly remove the old rule before the replacement is ready.
 - Cross-rule checks run during plan/apply via Terraform preconditions. `terraform validate` confirms syntax and provider schema, but it does not prove every rule passes those preconditions. If rule values are unknown during planning, Terraform may defer a precondition failure until apply.

--- a/modules/security-group/README.md
+++ b/modules/security-group/README.md
@@ -1,0 +1,58 @@
+# Nebius security group module
+
+Creates a Nebius VPC security group and managed ingress/egress rules with validation around common misconfigurations: unrestricted ingress, invalid ports, invalid CIDRs, empty security group IDs, mixed source/destination selectors, unsupported protocol/port combinations, and rule priority ranges.
+
+Security groups apply implicit deny after rule evaluation. The module therefore expects callers to model every allowed path deliberately.
+
+## Example
+
+```hcl
+module "bastion_security_group" {
+  source = "../modules/security-group"
+
+  parent_id  = var.parent_id
+  network_id = data.nebius_vpc_v1_subnet.this.network_id
+  name       = "bastion"
+
+  ingress_rules = {
+    ssh = {
+      protocol          = "TCP"
+      destination_ports = [22]
+      source_cidrs      = ["203.0.113.10/32"]
+      priority          = 100
+    }
+  }
+
+  egress_rules = {
+    internet = {
+      protocol          = "ANY"
+      destination_cidrs = ["0.0.0.0/0"]
+      priority          = 900
+    }
+  }
+}
+```
+
+Attach the group to an instance network interface:
+
+```hcl
+network_interfaces = [
+  {
+    name            = "eth0"
+    subnet_id       = var.subnet_id
+    ip_address      = {}
+    security_groups = [module.bastion_security_group.network_interface_reference]
+  }
+]
+```
+
+## Notes
+
+- `allow_unrestricted_ingress_rules` defaults to `false`. An `ALLOW` ingress rule with empty `source_cidrs`, `0.0.0.0/0`, `::/0`, or `0::/0` fails validation unless the caller explicitly opts in.
+- `allow_unrestricted_egress_rules` defaults to `true` because most solutions need package repositories, Nebius APIs, container registries, or Object Storage. Set it to `false` for stricter workloads.
+- The module creates only the egress rules passed in `egress_rules`. If `egress_rules = {}`, no egress rules are created, even when `allow_unrestricted_egress_rules = true`; that flag controls validation only.
+- Use either CIDRs or a security group selector per rule, not both. Security group selector IDs must be non-empty when set.
+- Ports are valid only on TCP and UDP rules. Do not set `destination_ports` for `ANY` or `ICMP` rules.
+- Each rule supports up to 8 CIDRs and up to 8 destination ports. Rule priorities must be between 1 and 1000.
+- Keep rule keys stable. They are used by `for_each`, so renaming a key recreates that rule and may briefly remove the old rule before the replacement is ready.
+- Cross-rule checks run during plan/apply via Terraform preconditions. `terraform validate` confirms syntax and provider schema, but it does not prove every rule passes those preconditions. If rule values are unknown during planning, Terraform may defer a precondition failure until apply.

--- a/modules/security-group/main.tf
+++ b/modules/security-group/main.tf
@@ -1,0 +1,91 @@
+resource "terraform_data" "validate_rules" {
+  input = {
+    ingress_rules = var.ingress_rules
+    egress_rules  = var.egress_rules
+  }
+
+  lifecycle {
+    precondition {
+      condition = var.allow_unrestricted_ingress_rules || alltrue([
+        for _, rule in var.ingress_rules :
+        rule.access != "ALLOW" ||
+        (
+          rule.source_security_group_id != null ||
+          (
+            length(rule.source_cidrs) > 0 &&
+            !contains(rule.source_cidrs, "0.0.0.0/0") &&
+            !contains(rule.source_cidrs, "::/0") &&
+            !contains(rule.source_cidrs, "0::/0")
+          )
+        )
+      ])
+      error_message = "ALLOW ingress rules must specify restricted source_cidrs or source_security_group_id unless allow_unrestricted_ingress_rules is true."
+    }
+
+    precondition {
+      condition = var.allow_unrestricted_egress_rules || alltrue([
+        for _, rule in var.egress_rules :
+        rule.access != "ALLOW" ||
+        (
+          rule.destination_security_group_id != null ||
+          (
+            length(rule.destination_cidrs) > 0 &&
+            !contains(rule.destination_cidrs, "0.0.0.0/0") &&
+            !contains(rule.destination_cidrs, "::/0") &&
+            !contains(rule.destination_cidrs, "0::/0")
+          )
+        )
+      ])
+      error_message = "ALLOW egress rules must specify restricted destination_cidrs or destination_security_group_id unless allow_unrestricted_egress_rules is true."
+    }
+  }
+}
+
+resource "nebius_vpc_v1_security_group" "this" {
+  parent_id  = var.parent_id
+  network_id = var.network_id
+  name       = var.name
+  labels     = var.labels
+
+  depends_on = [
+    terraform_data.validate_rules
+  ]
+}
+
+resource "nebius_vpc_v1_security_rule" "ingress" {
+  for_each = var.ingress_rules
+
+  parent_id = nebius_vpc_v1_security_group.this.id
+  name      = coalesce(each.value.name, "${var.name}-${each.key}")
+  labels    = merge(var.labels, each.value.labels)
+
+  access   = each.value.access
+  protocol = each.value.protocol
+  type     = each.value.rule_type
+  priority = each.value.priority
+
+  ingress = {
+    source_cidrs             = each.value.source_cidrs
+    source_security_group_id = each.value.source_security_group_id
+    destination_ports        = each.value.destination_ports
+  }
+}
+
+resource "nebius_vpc_v1_security_rule" "egress" {
+  for_each = var.egress_rules
+
+  parent_id = nebius_vpc_v1_security_group.this.id
+  name      = coalesce(each.value.name, "${var.name}-${each.key}")
+  labels    = merge(var.labels, each.value.labels)
+
+  access   = each.value.access
+  protocol = each.value.protocol
+  type     = each.value.rule_type
+  priority = each.value.priority
+
+  egress = {
+    destination_cidrs             = each.value.destination_cidrs
+    destination_security_group_id = each.value.destination_security_group_id
+    destination_ports             = each.value.destination_ports
+  }
+}

--- a/modules/security-group/outputs.tf
+++ b/modules/security-group/outputs.tf
@@ -1,0 +1,31 @@
+output "id" {
+  description = "Security group ID."
+  value       = nebius_vpc_v1_security_group.this.id
+}
+
+output "name" {
+  description = "Security group name."
+  value       = nebius_vpc_v1_security_group.this.name
+}
+
+output "network_id" {
+  description = "VPC network ID."
+  value       = nebius_vpc_v1_security_group.this.network_id
+}
+
+output "ingress_rule_ids" {
+  description = "Ingress rule IDs keyed by input rule key."
+  value       = { for key, rule in nebius_vpc_v1_security_rule.ingress : key => rule.id }
+}
+
+output "egress_rule_ids" {
+  description = "Egress rule IDs keyed by input rule key."
+  value       = { for key, rule in nebius_vpc_v1_security_rule.egress : key => rule.id }
+}
+
+output "network_interface_reference" {
+  description = "Object shape expected by nebius_compute_v1_instance network_interfaces.security_groups."
+  value = {
+    id = nebius_vpc_v1_security_group.this.id
+  }
+}

--- a/modules/security-group/variables.tf
+++ b/modules/security-group/variables.tf
@@ -1,0 +1,231 @@
+variable "parent_id" {
+  description = "Project ID where the security group will be created."
+  type        = string
+}
+
+variable "network_id" {
+  description = "VPC network ID where this security group applies."
+  type        = string
+}
+
+variable "name" {
+  description = "Security group name."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.name)) > 0
+    error_message = "name must not be empty."
+  }
+}
+
+variable "labels" {
+  description = "Labels to apply to the security group and all rules unless overridden per rule."
+  type        = map(string)
+  default     = {}
+}
+
+variable "allow_unrestricted_ingress_rules" {
+  description = "Allow ingress rules that match any source, such as empty source_cidrs or 0.0.0.0/0."
+  type        = bool
+  default     = false
+}
+
+variable "allow_unrestricted_egress_rules" {
+  description = "Allow egress rules that match any destination, such as empty destination_cidrs or 0.0.0.0/0."
+  type        = bool
+  default     = true
+}
+
+variable "ingress_rules" {
+  description = "Ingress security rules keyed by stable rule names."
+  type = map(object({
+    name                     = optional(string)
+    access                   = optional(string, "ALLOW")
+    protocol                 = optional(string, "TCP")
+    rule_type                = optional(string, "STATEFUL")
+    priority                 = optional(number, 500)
+    source_cidrs             = optional(list(string), [])
+    source_security_group_id = optional(string)
+    destination_ports        = optional(list(number), [])
+    labels                   = optional(map(string), {})
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : contains(["ALLOW", "DENY"], rule.access)
+    ])
+    error_message = "Ingress rule access must be ALLOW or DENY."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : contains(["ANY", "TCP", "UDP", "ICMP"], rule.protocol)
+    ])
+    error_message = "Ingress rule protocol must be ANY, TCP, UDP, or ICMP."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : contains(["STATEFUL", "STATELESS"], rule.rule_type)
+    ])
+    error_message = "Ingress rule type must be STATEFUL or STATELESS."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : rule.priority >= 1 && rule.priority <= 1000
+    ])
+    error_message = "Ingress rule priority must be between 1 and 1000."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for _, rule in var.ingress_rules : [
+        for port in rule.destination_ports : port >= 1 && port <= 65535
+      ]
+    ]))
+    error_message = "Ingress destination ports must be between 1 and 65535."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : length(rule.destination_ports) <= 8
+    ])
+    error_message = "Each ingress rule can include at most 8 destination ports."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : length(rule.source_cidrs) <= 8
+    ])
+    error_message = "Each ingress rule can include at most 8 source CIDRs."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : rule.source_security_group_id == null || length(rule.source_cidrs) == 0
+    ])
+    error_message = "Ingress rules cannot set both source_cidrs and source_security_group_id."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : try(length(trimspace(rule.source_security_group_id)) > 0, true)
+    ])
+    error_message = "Ingress source_security_group_id must not be empty when set."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.ingress_rules : contains(["TCP", "UDP"], rule.protocol) || length(rule.destination_ports) == 0
+    ])
+    error_message = "Ingress destination_ports can only be set for TCP or UDP rules."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for _, rule in var.ingress_rules : [
+        for cidr in rule.source_cidrs : can(cidrhost(cidr, 0))
+      ]
+    ]))
+    error_message = "Ingress source_cidrs must contain valid CIDR blocks."
+  }
+}
+
+variable "egress_rules" {
+  description = "Egress security rules keyed by stable rule names."
+  type = map(object({
+    name                          = optional(string)
+    access                        = optional(string, "ALLOW")
+    protocol                      = optional(string, "ANY")
+    rule_type                     = optional(string, "STATEFUL")
+    priority                      = optional(number, 900)
+    destination_cidrs             = optional(list(string), [])
+    destination_security_group_id = optional(string)
+    destination_ports             = optional(list(number), [])
+    labels                        = optional(map(string), {})
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : contains(["ALLOW", "DENY"], rule.access)
+    ])
+    error_message = "Egress rule access must be ALLOW or DENY."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : contains(["ANY", "TCP", "UDP", "ICMP"], rule.protocol)
+    ])
+    error_message = "Egress rule protocol must be ANY, TCP, UDP, or ICMP."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : contains(["STATEFUL", "STATELESS"], rule.rule_type)
+    ])
+    error_message = "Egress rule type must be STATEFUL or STATELESS."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : rule.priority >= 1 && rule.priority <= 1000
+    ])
+    error_message = "Egress rule priority must be between 1 and 1000."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for _, rule in var.egress_rules : [
+        for port in rule.destination_ports : port >= 1 && port <= 65535
+      ]
+    ]))
+    error_message = "Egress destination ports must be between 1 and 65535."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : length(rule.destination_ports) <= 8
+    ])
+    error_message = "Each egress rule can include at most 8 destination ports."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : length(rule.destination_cidrs) <= 8
+    ])
+    error_message = "Each egress rule can include at most 8 destination CIDRs."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : rule.destination_security_group_id == null || length(rule.destination_cidrs) == 0
+    ])
+    error_message = "Egress rules cannot set both destination_cidrs and destination_security_group_id."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : try(length(trimspace(rule.destination_security_group_id)) > 0, true)
+    ])
+    error_message = "Egress destination_security_group_id must not be empty when set."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, rule in var.egress_rules : contains(["TCP", "UDP"], rule.protocol) || length(rule.destination_ports) == 0
+    ])
+    error_message = "Egress destination_ports can only be set for TCP or UDP rules."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for _, rule in var.egress_rules : [
+        for cidr in rule.destination_cidrs : can(cidrhost(cidr, 0))
+      ]
+    ]))
+    error_message = "Egress destination_cidrs must contain valid CIDR blocks."
+  }
+}

--- a/modules/security-group/variables.tf
+++ b/modules/security-group/variables.tf
@@ -126,10 +126,11 @@ variable "ingress_rules" {
   validation {
     condition = alltrue(flatten([
       for _, rule in var.ingress_rules : [
-        for cidr in rule.source_cidrs : can(cidrhost(cidr, 0))
+        for cidr in rule.source_cidrs :
+        can(cidrhost(cidr, 0)) && can(regex("^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])/([0-9]|[12][0-9]|3[0-2])$", cidr))
       ]
     ]))
-    error_message = "Ingress source_cidrs must contain valid CIDR blocks."
+    error_message = "Ingress source_cidrs must contain valid IPv4 CIDR blocks."
   }
 }
 
@@ -223,9 +224,10 @@ variable "egress_rules" {
   validation {
     condition = alltrue(flatten([
       for _, rule in var.egress_rules : [
-        for cidr in rule.destination_cidrs : can(cidrhost(cidr, 0))
+        for cidr in rule.destination_cidrs :
+        can(cidrhost(cidr, 0)) && can(regex("^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])/([0-9]|[12][0-9]|3[0-2])$", cidr))
       ]
     ]))
-    error_message = "Egress destination_cidrs must contain valid CIDR blocks."
+    error_message = "Egress destination_cidrs must contain valid IPv4 CIDR blocks."
   }
 }

--- a/modules/security-group/versions.tf
+++ b/modules/security-group/versions.tf
@@ -8,7 +8,3 @@ terraform {
     }
   }
 }
-
-provider "nebius" {
-  domain = "api.eu.nebius.cloud:443"
-}


### PR DESCRIPTION
## Purpose

Adds a reusable Nebius security group module and uses it in the bastion solution. This gives solutions a safer, consistent way to create security groups without repeating low-level rule wiring in each solution. It also moves common mistakes into Terraform validation, such as unrestricted ingress, invalid ports, empty security group selectors, mixed CIDR/security-group selectors, and ports on ANY/ICMP rules.  The intent is to incorporate this module into additional solutions in later PRs to keep this concise.

For bastion specifically, this makes network exposure explicit: SSH and WireGuard are CIDR-scoped, WireGuard UI is closed by default, and egress can be left open for bootstrap convenience or disabled entirely with `bastion_egress_cidrs = []`.

## What Changed

- Added `modules/security-group`.
- Integrated managed security groups into `bastion`.
- Added CIDR-scoped SSH and WireGuard ingress.
- Made WireGuard UI TCP 5000 opt-in.
- Allowed strict deployments to create no default egress rule.
- Updated README, outputs, and test hooks.

## Validation

- `terraform fmt -check -recursive modules/security-group bastion`
- `terraform validate` for bastion and security-group module
- Guardrail tests for empty SG IDs and ICMP/ANY ports
- Plan-only checks for omitted WireGuard UI and empty egress
- Live module create/destroy in arch-sandbox
- Final live bastion no-op plan