### PR TITLE
SCHED-1574: Schedule login and populate jail pods next to workers on GB300

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -21,11 +21,6 @@ locals {
   default_nodes_per_nodegroup = 100
   gb300_enabled               = anytrue([for nodeset in var.slurm_nodeset_workers : nodeset.resource.platform == local.gb300_platform])
 
-  # slurm_nodeset_login.size always means the desired number of Soperator login
-  # pods, including on GB300. For GB300, those pods run on GB300 worker nodes
-  # instead of a dedicated CPU login node group.
-  login_pod_count = var.slurm_nodeset_login.size
-
   # GB300 keeps slurm_nodeset_login.size non-zero in tfvars so Soperator still
   # creates login pods, while Terraform skips the separate unused CPU login node
   # group. Non-GB300 platforms keep the configured login node group behavior.
@@ -440,7 +435,7 @@ module "slurm" {
   node_count = {
     controller = var.slurm_nodeset_controller.size
     worker     = [for workers in local.slurm_nodeset_workers : workers.size]
-    login      = local.login_pod_count
+    login      = var.slurm_nodeset_login.size
   }
 
   resources = {

--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -19,6 +19,30 @@ locals {
   gb300_platform              = "gpu-gb300"
   gb300_nodes_per_nodegroup   = 18
   default_nodes_per_nodegroup = 100
+  gb300_enabled               = anytrue([for nodeset in var.slurm_nodeset_workers : nodeset.resource.platform == local.gb300_platform])
+
+  # slurm_nodeset_login.size always means the desired number of Soperator login
+  # pods, including on GB300. For GB300, those pods run on GB300 worker nodes
+  # instead of a dedicated CPU login node group.
+  login_pod_count = var.slurm_nodeset_login.size
+
+  # GB300 keeps slurm_nodeset_login.size non-zero in tfvars so Soperator still
+  # creates login pods. Only after deriving login_pod_count do we zero the mk8s
+  # login node group size, preventing Terraform from creating a separate unused
+  # CPU login nodeset for GB300 clusters. Non-GB300 platforms keep the login
+  # node group unchanged and continue to schedule login pods there.
+  login_node_group = local.gb300_enabled ? merge(var.slurm_nodeset_login, {
+    size = 0
+  }) : var.slurm_nodeset_login
+
+  # GB300 is the only platform where login pods share worker nodes. Reserve the
+  # login pod resource budget from every GB300 worker so Slurm jobs cannot
+  # consume the capacity needed to start login pods.
+  gb300_login_pod_worker_reserve = {
+    cpu_cores                   = local.resources.login.cpu_cores
+    memory_gibibytes            = local.resources.login.memory_gibibytes
+    ephemeral_storage_gibibytes = floor(var.slurm_nodeset_login.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient - module.resources.k8s_ephemeral_storage_reserve.gibibytes)
+  }
 
   # Normalize user-facing worker nodesets into the internal nodeset list used
   # by both mk8s node groups and Slurm NodeSets. GB300 is rack-addressed, so one
@@ -280,7 +304,7 @@ module "k8s" {
       nvl_instance_group_id = try(nebius_compute_v1_nvl_instance_group.worker[worker.node_group_name].id, "")
     })
   ]
-  node_group_login = var.slurm_nodeset_login
+  node_group_login = local.login_node_group
   node_group_accounting = {
     enabled = var.accounting_enabled
     spec    = var.slurm_nodeset_accounting
@@ -418,7 +442,7 @@ module "slurm" {
   node_count = {
     controller = var.slurm_nodeset_controller.size
     worker     = [for workers in local.slurm_nodeset_workers : workers.size]
-    login      = var.slurm_nodeset_login.size
+    login      = local.login_pod_count
   }
 
   resources = {
@@ -440,11 +464,16 @@ module "slurm" {
     }
     worker = [for i, worker in local.slurm_nodeset_workers :
       {
-        cpu_cores        = local.resources.workers[i].cpu_cores
-        memory_gibibytes = floor(local.resources.workers[i].memory_gibibytes)
+        cpu_cores = local.resources.workers[i].cpu_cores - (
+          worker.resource.platform == local.gb300_platform ? local.gb300_login_pod_worker_reserve.cpu_cores : 0
+        )
+        memory_gibibytes = floor(local.resources.workers[i].memory_gibibytes) - (
+          worker.resource.platform == local.gb300_platform ? local.gb300_login_pod_worker_reserve.memory_gibibytes : 0
+        )
         ephemeral_storage_gibibytes = floor(
           worker.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
           -module.resources.k8s_ephemeral_storage_reserve.gibibytes
+          -(worker.resource.platform == local.gb300_platform ? local.gb300_login_pod_worker_reserve.ephemeral_storage_gibibytes : 0)
         )
         gpus = local.resources.workers[i].gpus
       }
@@ -541,6 +570,7 @@ module "slurm" {
 
   use_default_apparmor_profile    = var.use_default_apparmor_profile
   worker_sshd_config_map_ref_name = var.slurm_worker_sshd_config_map_ref_name
+  login_on_worker_nodes           = local.gb300_enabled
   shared_memory_size_gibibytes    = var.slurm_shared_memory_size_gibibytes
   slurm_partition_config_type     = var.slurm_partition_config_type
   slurm_partition_raw_config      = var.slurm_partition_raw_config

--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -27,20 +27,18 @@ locals {
   login_pod_count = var.slurm_nodeset_login.size
 
   # GB300 keeps slurm_nodeset_login.size non-zero in tfvars so Soperator still
-  # creates login pods. Only after deriving login_pod_count do we zero the mk8s
-  # login node group size, preventing Terraform from creating a separate unused
-  # CPU login nodeset for GB300 clusters. Non-GB300 platforms keep the login
-  # node group unchanged and continue to schedule login pods there.
-  login_node_group = local.gb300_enabled ? merge(var.slurm_nodeset_login, {
-    size = 0
-  }) : var.slurm_nodeset_login
+  # creates login pods, while Terraform skips the separate unused CPU login node
+  # group. Non-GB300 platforms keep the configured login node group behavior.
+  login_node_group = merge(var.slurm_nodeset_login, {
+    node_group_enabled = local.gb300_enabled ? false : var.slurm_nodeset_login.node_group_enabled
+  })
 
-  # GB300 is the only platform where login pods share worker nodes. Reserve the
-  # login pod resource budget from every GB300 worker so Slurm jobs cannot
-  # consume the capacity needed to start login pods.
+  # RFC 031: GB300 login pods share worker nodes, so reserve an 8vcpu-32gb
+  # login CPU/RAM budget from every GB300 worker instead of the full login node
+  # preset. Keep ephemeral storage tied to the login boot disk configuration.
   gb300_login_pod_worker_reserve = {
-    cpu_cores                   = local.resources.login.cpu_cores
-    memory_gibibytes            = local.resources.login.memory_gibibytes
+    cpu_cores                   = 8
+    memory_gibibytes            = 32
     ephemeral_storage_gibibytes = floor(var.slurm_nodeset_login.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient - module.resources.k8s_ephemeral_storage_reserve.gibibytes)
   }
 
@@ -478,7 +476,7 @@ module "slurm" {
         gpus = local.resources.workers[i].gpus
       }
     ]
-    login = {
+    login = local.gb300_enabled ? local.gb300_login_pod_worker_reserve : {
       cpu_cores        = local.resources.login.cpu_cores
       memory_gibibytes = floor(local.resources.login.memory_gibibytes)
       ephemeral_storage_gibibytes = floor(

--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -28,15 +28,6 @@ locals {
     node_group_enabled = local.gb300_enabled ? false : var.slurm_nodeset_login.node_group_enabled
   })
 
-  # RFC 031: GB300 login pods share worker nodes, so reserve an 8vcpu-32gb
-  # login CPU/RAM budget from every GB300 worker instead of the full login node
-  # preset. Keep ephemeral storage tied to the login boot disk configuration.
-  gb300_login_pod_worker_reserve = {
-    cpu_cores                   = 8
-    memory_gibibytes            = 32
-    ephemeral_storage_gibibytes = floor(var.slurm_nodeset_login.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient - module.resources.k8s_ephemeral_storage_reserve.gibibytes)
-  }
-
   # Normalize user-facing worker nodesets into the internal nodeset list used
   # by both mk8s node groups and Slurm NodeSets. GB300 is rack-addressed, so one
   # input nodeset expands into 18-node rack chunks named <name>-rack<rack>.
@@ -458,20 +449,20 @@ module "slurm" {
     worker = [for i, worker in local.slurm_nodeset_workers :
       {
         cpu_cores = local.resources.workers[i].cpu_cores - (
-          worker.resource.platform == local.gb300_platform ? local.gb300_login_pod_worker_reserve.cpu_cores : 0
+          worker.resource.platform == local.gb300_platform ? var.gb300_login_pod_worker_reserve.cpu_cores : 0
         )
         memory_gibibytes = floor(local.resources.workers[i].memory_gibibytes) - (
-          worker.resource.platform == local.gb300_platform ? local.gb300_login_pod_worker_reserve.memory_gibibytes : 0
+          worker.resource.platform == local.gb300_platform ? var.gb300_login_pod_worker_reserve.memory_gibibytes : 0
         )
         ephemeral_storage_gibibytes = floor(
           worker.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
           -module.resources.k8s_ephemeral_storage_reserve.gibibytes
-          -(worker.resource.platform == local.gb300_platform ? local.gb300_login_pod_worker_reserve.ephemeral_storage_gibibytes : 0)
+          -(worker.resource.platform == local.gb300_platform ? var.gb300_login_pod_worker_reserve.ephemeral_storage_gibibytes : 0)
         )
         gpus = local.resources.workers[i].gpus
       }
     ]
-    login = local.gb300_enabled ? local.gb300_login_pod_worker_reserve : {
+    login = local.gb300_enabled ? var.gb300_login_pod_worker_reserve : {
       cpu_cores        = local.resources.login.cpu_cores
       memory_gibibytes = floor(local.resources.login.memory_gibibytes)
       ephemeral_storage_gibibytes = floor(

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -449,11 +449,13 @@ use_preinstalled_gpu_drivers = true
 
 # Configuration of Slurm Login node set.
 # Keep size as the desired login pod replica count. For GB300, Terraform uses
-# this value for Soperator login pods, then internally sets only the dedicated
-# mk8s login node group to size = 0 so login pods run on worker nodes instead.
+# this value for Soperator login pods, then skips only the dedicated mk8s login
+# node group so login pods run on worker nodes instead.
 # ---
 slurm_nodeset_login = {
   size = 2
+  # Optional. For GB300, this is set to false internally so login pods run on worker nodes.
+  # node_group_enabled = true
   resource = {
     platform = "cpu-d3"
     preset   = "32vcpu-128gb"

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -448,6 +448,9 @@ slurm_nodeset_workers = [
 use_preinstalled_gpu_drivers = true
 
 # Configuration of Slurm Login node set.
+# Keep size as the desired login pod replica count. For GB300, Terraform uses
+# this value for Soperator login pods, then internally sets only the dedicated
+# mk8s login node group to size = 0 so login pods run on worker nodes instead.
 # ---
 slurm_nodeset_login = {
   size = 2

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1099,8 +1099,20 @@ variable "slurm_nodeset_login" {
     error_message = "Boot disks for login nodes must be at least 256 GiB."
   }
   validation {
-    condition     = var.slurm_nodeset_login.size >= 1
-    error_message = "Size of the login node group must be at least 1."
+    # slurm_nodeset_login.size is the login pod replica count on every platform.
+    # GB300 normally keeps this non-zero, then main.tf zeroes only the dedicated
+    # mk8s login node group after the pod count is derived. We still allow
+    # size = 0 for GB300 to support an intentional "no login pods" deployment.
+    # Other platforms keep the historical requirement for at least one login pod
+    # and one dedicated login node.
+    condition = (
+      var.slurm_nodeset_login.size >= 1 ||
+      (
+        var.slurm_nodeset_login.size == 0 &&
+        anytrue([for worker in var.slurm_nodeset_workers : worker.resource.platform == "gpu-gb300"])
+      )
+    )
+    error_message = "Size of the login node group must be at least 1, except GB300 worker clusters may use size = 0."
   }
 }
 
@@ -1202,11 +1214,15 @@ resource "terraform_data" "check_slurm_nodeset" {
           )
         )
         : (
-          try(each.value.size > 0 && floor(each.value.size) == each.value.size, false) ||
-          try(each.value.min_size > 0 && floor(each.value.min_size) == each.value.min_size, false)
+          each.key == "login" && anytrue([for worker in var.slurm_nodeset_workers : worker.resource.platform == "gpu-gb300"])
+          ? try(each.value.size >= 0 && floor(each.value.size) == each.value.size, false)
+          : (
+            try(each.value.size > 0 && floor(each.value.size) == each.value.size, false) ||
+            try(each.value.min_size > 0 && floor(each.value.min_size) == each.value.min_size, false)
+          )
         )
       )
-      error_message = "Node set ${each.key} must have whole-number size/min_size values. Worker node sets may use size = 0 and validate autoscaling.min_size when set; other node sets must have size or min_size greater than 0."
+      error_message = "Node set ${each.key} must have whole-number size/min_size values. Worker node sets may use size = 0 and validate autoscaling.min_size when set; GB300 login node sets may use size = 0; other node sets must have size or min_size greater than 0."
     }
 
     precondition {

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1101,7 +1101,34 @@ variable "slurm_nodeset_login" {
   }
   validation {
     condition     = var.slurm_nodeset_login.size >= 1
-    error_message = "Login pod count must be at least 1."
+    error_message = "Login replica count (slurm_nodeset_login.size) must be at least 1."
+  }
+}
+
+variable "gb300_login_pod_worker_reserve" {
+  description = "Resources requested by each GB300 login pod and reserved from GB300 worker node capacity when login pods run on worker nodes instead of a dedicated CPU login node group."
+  type = object({
+    cpu_cores                   = number
+    memory_gibibytes            = number
+    ephemeral_storage_gibibytes = number
+  })
+  nullable = false
+  default = {
+    cpu_cores                   = 8
+    memory_gibibytes            = 32
+    ephemeral_storage_gibibytes = 128
+  }
+
+  validation {
+    condition = (
+      !anytrue([for worker in var.slurm_nodeset_workers : worker.resource.platform == "gpu-gb300"]) ||
+      (
+        var.gb300_login_pod_worker_reserve.cpu_cores > 0 &&
+        var.gb300_login_pod_worker_reserve.memory_gibibytes > 0 &&
+        var.gb300_login_pod_worker_reserve.ephemeral_storage_gibibytes > 0
+      )
+    )
+    error_message = "GB300 login pod worker reserve values must be greater than zero when GB300 workers are configured."
   }
 }
 

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1070,7 +1070,8 @@ variable "slurm_nodeset_workers" {
 variable "slurm_nodeset_login" {
   description = "Configuration of Slurm Login node set."
   type = object({
-    size = number
+    size               = number
+    node_group_enabled = optional(bool, true)
     resource = object({
       platform = string
       preset   = string
@@ -1099,20 +1100,8 @@ variable "slurm_nodeset_login" {
     error_message = "Boot disks for login nodes must be at least 256 GiB."
   }
   validation {
-    # slurm_nodeset_login.size is the login pod replica count on every platform.
-    # GB300 normally keeps this non-zero, then main.tf zeroes only the dedicated
-    # mk8s login node group after the pod count is derived. We still allow
-    # size = 0 for GB300 to support an intentional "no login pods" deployment.
-    # Other platforms keep the historical requirement for at least one login pod
-    # and one dedicated login node.
-    condition = (
-      var.slurm_nodeset_login.size >= 1 ||
-      (
-        var.slurm_nodeset_login.size == 0 &&
-        anytrue([for worker in var.slurm_nodeset_workers : worker.resource.platform == "gpu-gb300"])
-      )
-    )
-    error_message = "Size of the login node group must be at least 1, except GB300 worker clusters may use size = 0."
+    condition     = var.slurm_nodeset_login.size >= 1
+    error_message = "Login pod count must be at least 1."
   }
 }
 
@@ -1214,15 +1203,11 @@ resource "terraform_data" "check_slurm_nodeset" {
           )
         )
         : (
-          each.key == "login" && anytrue([for worker in var.slurm_nodeset_workers : worker.resource.platform == "gpu-gb300"])
-          ? try(each.value.size >= 0 && floor(each.value.size) == each.value.size, false)
-          : (
-            try(each.value.size > 0 && floor(each.value.size) == each.value.size, false) ||
-            try(each.value.min_size > 0 && floor(each.value.min_size) == each.value.min_size, false)
-          )
+          try(each.value.size > 0 && floor(each.value.size) == each.value.size, false) ||
+          try(each.value.min_size > 0 && floor(each.value.min_size) == each.value.min_size, false)
         )
       )
-      error_message = "Node set ${each.key} must have whole-number size/min_size values. Worker node sets may use size = 0 and validate autoscaling.min_size when set; GB300 login node sets may use size = 0; other node sets must have size or min_size greater than 0."
+      error_message = "Node set ${each.key} must have whole-number size/min_size values. Worker node sets may use size = 0 and validate autoscaling.min_size when set; other node sets must have size or min_size greater than 0."
     }
 
     precondition {

--- a/soperator/modules/k8s/k8s_ng_login.tf
+++ b/soperator/modules/k8s/k8s_ng_login.tf
@@ -1,4 +1,6 @@
 resource "nebius_mk8s_v1_node_group" "login" {
+  count = var.node_group_login.node_group_enabled ? 1 : 0
+
   depends_on = [
     nebius_mk8s_v1_cluster.this,
     terraform_data.check_resource_preset_sufficiency,

--- a/soperator/modules/k8s/sufficiency.tf
+++ b/soperator/modules/k8s/sufficiency.tf
@@ -10,13 +10,15 @@ locals {
         key       = module.labels.name_nodeset_controller
         resource  = var.node_group_controller.resource
         boot_disk = var.node_group_controller.boot_disk
-      },
+      }
+    ],
+    var.node_group_login.node_group_enabled ? [
       {
         key       = module.labels.name_nodeset_login
         resource  = var.node_group_login.resource
         boot_disk = var.node_group_login.boot_disk
       }
-    ],
+    ] : [],
     [
       for worker in var.node_group_workers :
       {

--- a/soperator/modules/k8s/sufficiency.tf
+++ b/soperator/modules/k8s/sufficiency.tf
@@ -12,13 +12,14 @@ locals {
         boot_disk = var.node_group_controller.boot_disk
       }
     ],
-    var.node_group_login.node_group_enabled ? [
-      {
+    [
+      for node_group in [var.node_group_login] : {
         key       = module.labels.name_nodeset_login
-        resource  = var.node_group_login.resource
-        boot_disk = var.node_group_login.boot_disk
+        resource  = node_group.resource
+        boot_disk = node_group.boot_disk
       }
-    ] : [],
+      if node_group.node_group_enabled
+    ],
     [
       for worker in var.node_group_workers :
       {

--- a/soperator/modules/k8s/variables.tf
+++ b/soperator/modules/k8s/variables.tf
@@ -179,9 +179,10 @@ variable "node_group_workers_v2" {
 }
 
 variable "node_group_login" {
-  description = "Controller node group specification."
+  description = "Login node group specification."
   type = object({
-    size = number
+    size               = number
+    node_group_enabled = optional(bool, true)
     resource = object({
       platform = string
       preset   = string

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -64,7 +64,7 @@ locals {
     }
     worker = {
       name        = module.labels.name_nodeset_worker
-      matches     = [for i in range(length(var.node_count.worker)) : join("-", [module.labels.name_nodeset_worker, i])]
+      matches     = [module.labels.name_nodeset_worker]
       gpu_present = length([for i in range(length(var.node_count.worker)) : var.resources.worker[i].gpus]) > 0
     }
     login = {

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -144,6 +144,14 @@ resource "helm_release" "soperator_fluxcd_cm" {
       k8s_node_filters               = local.node_filters
       maintenance_ignore_node_labels = local.maintenance_ignore_node_labels
 
+      # GB300 worker nodes are ARM. The populate-jail job must run on an ARM
+      # node so Kubernetes pulls the ARM image variant and writes ARM binaries
+      # into the jail during first cluster creation. Other platforms keep the
+      # historical system-node placement.
+      populate_jail = {
+        k8s_node_filter_name = var.login_on_worker_nodes ? local.node_filters.worker.name : local.node_filters.system.name
+      }
+
       jail_submounts = [for submount in var.filestores.jail_submounts : {
         name       = submount.name
         mount_path = submount.mount_path
@@ -224,6 +232,7 @@ resource "helm_release" "soperator_fluxcd_cm" {
 
         login = {
           size                     = var.node_count.login
+          k8s_node_filter_name     = var.login_on_worker_nodes ? local.node_filters.worker.name : local.node_filters.login.name
           allocation_id            = var.login_allocation_id
           sshd_config_map_ref_name = var.login_sshd_config_map_ref_name
           root_public_keys         = var.login_ssh_root_public_keys

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -447,7 +447,7 @@ resources:
               %{~ endif ~}
 
             populateJail:
-              k8sNodeFilterName: ${slurm_cluster.k8s_node_filters.system.name}
+              k8sNodeFilterName: ${slurm_cluster.populate_jail.k8s_node_filter_name}
 
             periodicChecks:
               ncclBenchmark:
@@ -550,7 +550,7 @@ resources:
                     %{~ endif ~}
               login:
                 size: ${slurm_cluster.nodes.login.size}
-                k8sNodeFilterName: ${slurm_cluster.k8s_node_filters.login.name}
+                k8sNodeFilterName: ${slurm_cluster.nodes.login.k8s_node_filter_name}
                 sshdServiceType: "LoadBalancer"
                 %{~ if slurm_cluster.nodes.login.allocation_id != null ~}
                 sshdServiceAnnotations:

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -222,6 +222,12 @@ variable "tailscale_enabled" {
   default     = false
 }
 
+variable "login_on_worker_nodes" {
+  description = "Whether login pods and populate-jail should use the worker k8sNodeFilterName instead of dedicated CPU node filters. Used by GB300 installations that do not create dedicated CPU login nodes and need ARM populate-jail."
+  type        = bool
+  default     = false
+}
+
 variable "login_sshd_config_map_ref_name" {
   description = "Name of configmap with SSHD config, which runs in slurmd container."
   type        = string


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Changes to colocate login pods and populate-jail job on worker nodes for GB300 platform.

- Keeps `slurm_nodeset_login.size` as the desired login pod replica count, skips the mk8s login node group for GB300
- Passes a new login_on_worker_nodes flag into the Slurm module, and renders worker-node `k8sNodeFilterName` values for login/populate-jail placement
- Reserves login pod CPU, memory, and ephemeral storage from GB300 worker Slurm resources

Also fixed a bug in worker nodeset naming where a nodest of size 1 would be name `{name}` but referenced in node filters as `{name}-0`.

Addresses SCHED-1575 as well.