### PR TITLE
SCHED-1604, SCHED-1267: Retry transient failures in cleanup/destroy scripts

### DIFF
--- a/soperator/modules/backups/scripts/destroy.sh
+++ b/soperator/modules/backups/scripts/destroy.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+retry_script="$(dirname "$0")/../../scripts/retry.sh"
+
 # Set up kubectl context if the cluster ID is available (absent in old Terraform state).
 if [ -n "${K8S_CLUSTER_ID:-}" ]; then
-  nebius mk8s cluster get-credentials \
+  "$retry_script" -- nebius mk8s cluster get-credentials \
     --context-name "$K8S_CLUSTER_CONTEXT" \
     --external \
     --force \
@@ -11,20 +13,20 @@ if [ -n "${K8S_CLUSTER_ID:-}" ]; then
 fi
 
 # Delete all IAM access keys for the service account.
-for AKID in $(nebius iam v2 access-key list-by-account \
-  --account-service-account-id "$SERVICE_ACCOUNT_ID" \
-  --format json | jq -r '.items[].metadata.id'); do
-  nebius iam v2 access-key delete --id "$AKID"
-done
+# Skip the IAM block if the SA was already removed out-of-band (e.g. by force-cleanup).
+if "$retry_script" -- nebius iam v2 service-account get --id "$SERVICE_ACCOUNT_ID" >/dev/null 2>&1; then
+  for AKID in $("$retry_script" -- nebius iam v2 access-key list-by-account \
+    --account-service-account-id "$SERVICE_ACCOUNT_ID" \
+    --format json | jq -r '.items[].metadata.id'); do
+    "$retry_script" -- nebius iam v2 access-key delete --id "$AKID"
+  done
+else
+  echo "Service account $SERVICE_ACCOUNT_ID already gone, skipping access-key cleanup"
+fi
 
 # Delete the k8s secret only if the context is available.
 if kubectl config get-contexts "$K8S_CLUSTER_CONTEXT" &>/dev/null; then
-  kubectl get \
-    --context "$K8S_CLUSTER_CONTEXT" \
-    -n "$NAMESPACE" \
-    secret "$SECRET_NAME" \
-    -oyaml \
-    | kubectl delete --context "$K8S_CLUSTER_CONTEXT" -f -
+  "$retry_script" -- bash -c "kubectl get --context '$K8S_CLUSTER_CONTEXT' -n '$NAMESPACE' secret '$SECRET_NAME' -oyaml | kubectl delete --context '$K8S_CLUSTER_CONTEXT' -f -"
 else
   echo "kubectl context '$K8S_CLUSTER_CONTEXT' not found, skipping secret cleanup"
 fi

--- a/soperator/modules/k8s_cleanup/scripts/k8s_kruise_webhook_cleanup.sh
+++ b/soperator/modules/k8s_cleanup/scripts/k8s_kruise_webhook_cleanup.sh
@@ -1,37 +1,39 @@
 #!/bin/bash
 set -euo pipefail
 
+retry_script="$(dirname "$0")/../../scripts/retry.sh"
+
 context="${K8S_CLUSTER_CONTEXT:?context is required}"
 prefix="${K8S_WEBHOOK_PREFIX:?webhook prefix is required}"
 
 if [ -n "${K8S_CLUSTER_ID:-}" ]; then
-  nebius mk8s cluster get-credentials \
+  "$retry_script" -- nebius mk8s cluster get-credentials \
     --context-name "$context" \
     --external \
     --force \
     --id "$K8S_CLUSTER_ID"
 fi
 
-if ! kubectl version --context "$context" >/dev/null 2>&1; then
+if ! "$retry_script" -- kubectl version --context "$context" >/dev/null 2>&1; then
   echo "Cluster unreachable for context $context; skipping kruise webhook cleanup."
   exit 0
 fi
 
-mutating_configs="$(kubectl get mutatingwebhookconfiguration \
+mutating_raw="$("$retry_script" -- kubectl get mutatingwebhookconfiguration \
   --context "$context" \
-  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .webhooks[*]}{.name}{" "}{end}{"\n"}{end}' \
-  | awk -v target="^" -v prefix="$prefix" '
-      $1 ~ (target prefix) {print $1; next}
-      $0 ~ (target ".*" prefix) {print $1}
-    ' | sort -u)"
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .webhooks[*]}{.name}{" "}{end}{"\n"}{end}')"
+mutating_configs="$(echo "$mutating_raw" | awk -v target="^" -v prefix="$prefix" '
+    $1 ~ (target prefix) {print $1; next}
+    $0 ~ (target ".*" prefix) {print $1}
+  ' | sort -u)"
 
-validating_configs="$(kubectl get validatingwebhookconfiguration \
+validating_raw="$("$retry_script" -- kubectl get validatingwebhookconfiguration \
   --context "$context" \
-  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .webhooks[*]}{.name}{" "}{end}{"\n"}{end}' \
-  | awk -v target="^" -v prefix="$prefix" '
-      $1 ~ (target prefix) {print $1; next}
-      $0 ~ (target ".*" prefix) {print $1}
-    ' | sort -u)"
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .webhooks[*]}{.name}{" "}{end}{"\n"}{end}')"
+validating_configs="$(echo "$validating_raw" | awk -v target="^" -v prefix="$prefix" '
+    $1 ~ (target prefix) {print $1; next}
+    $0 ~ (target ".*" prefix) {print $1}
+  ' | sort -u)"
 
 if [ -z "$mutating_configs" ] && [ -z "$validating_configs" ]; then
   echo "No webhook configurations found with prefix $prefix; nothing to delete."

--- a/soperator/modules/k8s_cleanup/scripts/k8s_login_service_cleanup.sh
+++ b/soperator/modules/k8s_cleanup/scripts/k8s_login_service_cleanup.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+retry_script="$(dirname "$0")/../../scripts/retry.sh"
+
 context="${K8S_CLUSTER_CONTEXT:?context is required}"
 namespace="${SOPERATOR_NAMESPACE:?namespace is required}"
 service="${LOGIN_SERVICE_NAME:?service name is required}"
 
 if [ -n "${K8S_CLUSTER_ID:-}" ]; then
-  nebius mk8s cluster get-credentials \
+  "$retry_script" -- nebius mk8s cluster get-credentials \
     --context-name "$context" \
     --external \
     --force \
@@ -15,25 +17,20 @@ fi
 
 system_namespace="${namespace}-system"
 
-if ! kubectl get namespace "$namespace" --context "$context" >/dev/null 2>&1; then
+if ! "$retry_script" -- kubectl get namespace "$namespace" --context "$context" >/dev/null 2>&1; then
   echo "Namespace $namespace not found or cluster unreachable; skipping login service cleanup."
   exit 0
 fi
 
-if ! kubectl get namespace "$system_namespace" --context "$context" >/dev/null 2>&1; then
+if ! "$retry_script" -- kubectl get namespace "$system_namespace" --context "$context" >/dev/null 2>&1; then
   echo "Namespace $namespace not found or cluster unreachable; skipping login service cleanup."
   exit 0
 fi
 
 echo "Attempting to stop soperator controller to prevent service recreation..."
 if kubectl get deployment soperator-controller-manager -n "$system_namespace" --context "$context" >/dev/null 2>&1; then
-  kubectl scale deployment soperator-controller-manager -n "$system_namespace" --context "$context" --replicas=0
-fi
-
-if ! kubectl get service "$service" -n "$namespace" --context "$context" >/dev/null 2>&1; then
-  echo "Service $namespace/$service not found; nothing to delete."
-  exit 0
+  "$retry_script" -- kubectl scale deployment soperator-controller-manager -n "$system_namespace" --context "$context" --replicas=0
 fi
 
 echo "Deleting service $namespace/$service..."
-kubectl delete service "$service" -n "$namespace" --context "$context" --wait=true --timeout=5m
+"$retry_script" -- kubectl delete service "$service" -n "$namespace" --context "$context" --ignore-not-found --wait=true --timeout=5m

--- a/soperator/modules/k8s_cleanup/scripts/k8s_login_service_cleanup.sh
+++ b/soperator/modules/k8s_cleanup/scripts/k8s_login_service_cleanup.sh
@@ -30,6 +30,9 @@ fi
 echo "Attempting to stop soperator controller to prevent service recreation..."
 if kubectl get deployment soperator-controller-manager -n "$system_namespace" --context "$context" >/dev/null 2>&1; then
   "$retry_script" -- kubectl scale deployment soperator-controller-manager -n "$system_namespace" --context "$context" --replicas=0
+  # kubectl scale returns before pods terminate; wait so the controller can't recreate the Service.
+  echo "Waiting for soperator controller pod to terminate..."
+  kubectl wait --for=delete pod -l control-plane=controller-manager -n "$system_namespace" --context "$context" --timeout=60s || true
 fi
 
 echo "Deleting service $namespace/$service..."


### PR DESCRIPTION
## Problems Solved

- Cleanup and destroy scripts (`destroy.sh`, `k8s_kruise_webhook_cleanup.sh`, `k8s_login_service_cleanup.sh`) failed on transient errors from `nebius` and `kubectl`. Wrapped the affected commands with the existing `retry.sh` helper.
- `destroy.sh` failed when the service account had already been removed out-of-band (e.g. by force-cleanup). Skip the IAM access-key cleanup block when `nebius iam v2 service-account get` reports the SA is gone.
- Login service got recreated by the soperator controller between `kubectl scale` and `kubectl delete service` because `scale` returns before pods actually terminate (SCHED-1604). Added `kubectl wait --for=delete pod` after scaling the controller to zero, and used `--ignore-not-found` on the final `kubectl delete service`.

## Testing

E2E tests

## Release Notes

None