### PR TITLE
fix broken `k8s-training` tests

### DIFF
--- a/modules/k8s-rbac-bindings/versions.tf
+++ b/modules/k8s-rbac-bindings/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.12.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     kubernetes = {


### PR DESCRIPTION
## Summary
- Relax `modules/k8s-rbac-bindings` Terraform Core constraint from `>= 1.12.0` to `>= 1.11.0`
- Restore compatibility with the Terraform workflow, which currently installs Terraform `v1.11.4`

## Validation
- `terraform fmt -check modules/k8s-rbac-bindings/versions.tf`
- `terraform -chdir=modules/k8s-rbac-bindings init -backend=false`
- `terraform -chdir=modules/k8s-rbac-bindings validate`