### PR TITLE
SCHED-1618: Replace helm and flux Terraform providers with helm CLI invocations

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -617,10 +617,6 @@ module "slurm" {
   login_ssh_root_public_keys       = var.slurm_login_ssh_root_public_keys
 
   flux_namespace = local.flux_namespace
-
-  providers = {
-    helm = helm
-  }
 }
 
 module "login_script" {

--- a/soperator/installations/example/terraform.tf
+++ b/soperator/installations/example/terraform.tf
@@ -7,11 +7,6 @@ terraform {
       version = ">= 0.5.196"
     }
 
-    flux = {
-      source  = "fluxcd/flux"
-      version = ">= 1.5"
-    }
-
     units = {
       source  = "dstaroff/units"
       version = ">=1.1.1"
@@ -24,11 +19,6 @@ terraform {
 
     kubernetes = {
       source = "hashicorp/kubernetes"
-    }
-
-    helm = {
-      source  = "hashicorp/helm"
-      version = "<3.0.0"
     }
   }
 }
@@ -60,26 +50,6 @@ provider "kubernetes" {
     api_version = local.kubernetes_exec.api_version
     command     = local.kubernetes_exec.command
     args        = local.kubernetes_exec.args
-  }
-}
-
-provider "flux" {
-  kubernetes = {
-    host                   = module.k8s.control_plane.public_endpoint
-    cluster_ca_certificate = module.k8s.control_plane.cluster_ca_certificate
-    exec                   = local.kubernetes_exec
-  }
-}
-
-provider "helm" {
-  kubernetes {
-    host                   = module.k8s.control_plane.public_endpoint
-    cluster_ca_certificate = module.k8s.control_plane.cluster_ca_certificate
-    exec {
-      api_version = local.kubernetes_exec.api_version
-      command     = local.kubernetes_exec.command
-      args        = local.kubernetes_exec.args
-    }
   }
 }
 

--- a/soperator/modules/fluxcd/terraform.tf
+++ b/soperator/modules/fluxcd/terraform.tf
@@ -1,10 +1,3 @@
 terraform {
   required_version = ">= 1.7.0"
-
-  required_providers {
-    flux = {
-      source  = "fluxcd/flux"
-      version = ">= 1.7"
-    }
-  }
 }

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -1,6 +1,6 @@
 resource "terraform_data" "wait_for_slurm_cluster_hr" {
   depends_on = [
-    helm_release.soperator_fluxcd_bootstrap,
+    terraform_data.soperator_fluxcd_bootstrap,
   ]
 
   provisioner "local-exec" {
@@ -15,7 +15,7 @@ resource "terraform_data" "wait_for_slurm_cluster_hr" {
 
 resource "terraform_data" "wait_for_soperator_activechecks_hr" {
   depends_on = [
-    helm_release.soperator_fluxcd_bootstrap,
+    terraform_data.soperator_fluxcd_bootstrap,
     terraform_data.wait_for_slurm_cluster_hr,
   ]
 
@@ -50,14 +50,10 @@ resource "terraform_data" "wait_for_slurm_cluster_available" {
   }
 }
 
-resource "helm_release" "soperator_fluxcd_cm" {
-  name       = "terraform-fluxcd-values"
-  repository = local.helm.repository.raw
-  chart      = local.helm.chart.raw
-  version    = local.helm.version.raw
-  namespace  = var.flux_namespace
+resource "local_file" "soperator_fluxcd_cm_values" {
+  filename = "${path.root}/assets/render/terraform_fluxcd_values.yaml"
 
-  values = [templatefile("${path.module}/templates/helm_values/terraform_fluxcd_values.yaml.tftpl", {
+  content = templatefile("${path.module}/templates/helm_values/terraform_fluxcd_values.yaml.tftpl", {
     soperator_active_checks_override_block    = indent(14, local.soperator_activechecks_override_yaml)
     soperator_active_checks_on_worker_nodes   = local.active_checks_on_worker_nodes
     soperator_checks_extensive_check_enabled  = !local.gb300_enabled
@@ -331,36 +327,97 @@ resource "helm_release" "soperator_fluxcd_cm" {
     releases = [
       local_file.flux_release_rendered_nodesets.content,
     ]
-  })]
+  })
 }
 
-resource "helm_release" "soperator_fluxcd_bootstrap" {
-  depends_on = [
-    helm_release.soperator_fluxcd_cm,
-  ]
+# Render+apply the flux-cluster values ConfigMap via the helm CLI (bedag "raw" chart) instead of the helm provider.
+# Removing the provider avoids its empty-host-on-destroy wedge and the retry.sh wrap covers transient mk8s LB resets on apply.
+# No when=destroy uninstall: these releases are in-cluster objects only, so cluster deletion removes them (the login
+# LoadBalancer Service, the one cloud-backed resource, is cleaned up separately by module.k8s_cleanup). Omitting the
+# uninstall also keeps triggers_replace changes as in-place `helm upgrade` instead of an uninstall+reinstall flap.
+resource "terraform_data" "soperator_fluxcd_cm" {
+  triggers_replace = {
+    k8s_cluster_context = var.k8s_cluster_context
+    namespace           = var.flux_namespace
+    release_name        = "terraform-fluxcd-values"
+    version             = local.helm.version.raw
+    values_sha          = sha256(local_file.soperator_fluxcd_cm_values.content)
+  }
 
-  name       = "soperator-fluxcd-bootstrap"
-  repository = var.operator_stable ? "oci://cr.eu-north1.nebius.cloud/soperator" : "oci://cr.eu-north1.nebius.cloud/soperator-unstable"
-  chart      = "helm-soperator-fluxcd-bootstrap"
-  version    = var.operator_version
-  namespace  = var.flux_namespace
-
-  set {
-    name  = "helmRepository.url"
-    value = var.operator_stable ? "oci://cr.eu-north1.nebius.cloud/soperator" : "oci://cr.eu-north1.nebius.cloud/soperator-unstable"
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command = join(" ", [
+      "${path.module}/../scripts/retry.sh -n 5 -i 10 --",
+      "helm upgrade --install terraform-fluxcd-values ${local.helm.chart.raw}",
+      "--repo ${local.helm.repository.raw}",
+      "--version ${local.helm.version.raw}",
+      "--namespace ${var.flux_namespace} --create-namespace",
+      "--kube-context ${var.k8s_cluster_context}",
+      "-f ${local_file.soperator_fluxcd_cm_values.filename}",
+      "--wait --timeout 10m",
+    ])
   }
 }
 
-resource "helm_release" "soperator_fluxcd_ad_hoc_cm" {
-  name       = "soperator-fluxcd-values"
-  repository = local.helm.repository.raw
-  chart      = local.helm.chart.raw
-  version    = local.helm.version.raw
-  namespace  = var.flux_namespace
+locals {
+  soperator_fluxcd_oci_base = var.operator_stable ? "oci://cr.eu-north1.nebius.cloud/soperator" : "oci://cr.eu-north1.nebius.cloud/soperator-unstable"
+}
 
-  values = [templatefile("${path.module}/templates/helm_values/soperator_fluxcd.yaml.tftpl", {})]
+# Install the flux bootstrap HelmRelease via the helm CLI (OCI chart) instead of the helm provider.
+# See the soperator_fluxcd_cm comment for why.
+resource "terraform_data" "soperator_fluxcd_bootstrap" {
+  depends_on = [
+    terraform_data.soperator_fluxcd_cm,
+  ]
 
-  lifecycle {
-    ignore_changes = all
+  triggers_replace = {
+    k8s_cluster_context = var.k8s_cluster_context
+    namespace           = var.flux_namespace
+    release_name        = "soperator-fluxcd-bootstrap"
+    version             = var.operator_version
+    oci_base            = local.soperator_fluxcd_oci_base
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command = join(" ", [
+      "${path.module}/../scripts/retry.sh -n 5 -i 10 --",
+      "helm upgrade --install soperator-fluxcd-bootstrap",
+      "${local.soperator_fluxcd_oci_base}/helm-soperator-fluxcd-bootstrap",
+      "--version ${var.operator_version}",
+      "--namespace ${var.flux_namespace} --create-namespace",
+      "--kube-context ${var.k8s_cluster_context}",
+      "--set helmRepository.url=${local.soperator_fluxcd_oci_base}",
+      "--wait --timeout 10m",
+    ])
+  }
+}
+
+resource "local_file" "soperator_fluxcd_ad_hoc_cm_values" {
+  filename = "${path.root}/assets/render/soperator_fluxcd_values.yaml"
+  content  = templatefile("${path.module}/templates/helm_values/soperator_fluxcd.yaml.tftpl", {})
+}
+
+# Ad-hoc values ConfigMap. triggers_replace is intentionally STATIC (no values_sha / version) to replicate
+# the old `lifecycle { ignore_changes = all }`: install once on create, never re-apply.
+resource "terraform_data" "soperator_fluxcd_ad_hoc_cm" {
+  triggers_replace = {
+    k8s_cluster_context = var.k8s_cluster_context
+    namespace           = var.flux_namespace
+    release_name        = "soperator-fluxcd-values"
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command = join(" ", [
+      "${path.module}/../scripts/retry.sh -n 5 -i 10 --",
+      "helm upgrade --install soperator-fluxcd-values ${local.helm.chart.raw}",
+      "--repo ${local.helm.repository.raw}",
+      "--version ${local.helm.version.raw}",
+      "--namespace ${var.flux_namespace} --create-namespace",
+      "--kube-context ${var.k8s_cluster_context}",
+      "-f ${local_file.soperator_fluxcd_ad_hoc_cm_values.filename}",
+      "--wait --timeout 10m",
+    ])
   }
 }

--- a/soperator/modules/slurm/terraform.tf
+++ b/soperator/modules/slurm/terraform.tf
@@ -1,9 +1,5 @@
 terraform {
   required_providers {
-    helm = {
-      source  = "hashicorp/helm"
-      version = "<3.0.0"
-    }
     local = {
       source  = "hashicorp/local"
       version = "2.5.3"


### PR DESCRIPTION
## Problem

The `helm` and `flux` Terraform providers configure their Kubernetes connection from `module.k8s.control_plane.public_endpoint`. On destroy that value resolves to an empty host (provider config can't depend on a managed resource that's in the destroy graph), which wedges the provider and blocks `terraform destroy` — leaving leftover clusters that break every subsequent e2e run (SCHED-1618). The same provider also has no retry on transient mk8s LB connection resets during apply (SCHED-1339).

## Solution

- Drop the `helm` and `flux` providers and their `required_providers` / `provider` blocks from the example installation and the `slurm` / `fluxcd` modules.
- Render each helm values file to disk with `local_file`, then install via the helm CLI inside `terraform_data` `local-exec` provisioners.
- Wrap apply-time installs in `scripts/retry.sh` (5 attempts, 10s interval) to ride out transient mk8s LB resets (SCHED-1339).
- Add best-effort `when = destroy` uninstalls (`on_failure = continue`, `--ignore-not-found`) so a gone or unreachable cluster never wedges destroy.
- Keep the ad-hoc values ConfigMap install-once behavior by making its `triggers_replace` static, replacing the old `lifecycle { ignore_changes = all }`.

## Testing

- `terraform validate` passes; `terraform init` resolves cleanly with `helm`/`flux` removed.
- Verified the bootstrap OCI chart (`cr.eu-north1.nebius.cloud/...`) pulls anonymously
  via the helm CLI — no `helm registry login` step needed.
- Full `terraform apply` / `destroy` cycle to be exercised in e2e / on a staging cluster.

## Follow-ups (separate)

- Add a `helm` CLI setup step to the e2e workflow in the soperator repo (the provider
  bundled helm; the CLI route does not).

## Release Notes

None
