### PR TITLE
Add opt-in GPU NUMA kubelet tuning

### DIFF
--- a/k8s-training/locals.tf
+++ b/k8s-training/locals.tf
@@ -72,6 +72,89 @@ locals {
     var.mig_strategy != null &&
     var.mig_strategy != "none"
   ) ? true : null
+
+  # Known-good kubelet NUMA/topology configs validated during GPU node testing.
+  gpu_kubelet_numa_presets = {
+    "h200-standard" = {
+      cpu_manager_policy      = "static"
+      topology_manager_policy = "restricted"
+      memory_manager_policy   = "Static"
+      kube_reserved_memory    = "1229Mi"
+      reserved_memory = [
+        {
+          numa_node = 0
+          memory    = "1329Mi"
+        }
+      ]
+    }
+    "b200-standard" = {
+      cpu_manager_policy      = "static"
+      topology_manager_policy = "restricted"
+      memory_manager_policy   = "Static"
+      kube_reserved_memory    = "1229Mi"
+      reserved_memory = [
+        {
+          numa_node = 0
+          memory    = "1329Mi"
+        }
+      ]
+    }
+    "b300-standard" = {
+      cpu_manager_policy      = "static"
+      topology_manager_policy = "restricted"
+      memory_manager_policy   = "Static"
+      kube_reserved_memory    = "1229Mi"
+      reserved_memory = [
+        {
+          numa_node = 0
+          memory    = "1329Mi"
+        }
+      ]
+    }
+  }
+
+  gpu_kubelet_numa_platform_presets = {
+    "gpu-h200-sxm"   = "h200-standard"
+    "gpu-b200-sxm"   = "b200-standard"
+    "gpu-b200-sxm-a" = "b200-standard"
+    "gpu-b300-sxm"   = "b300-standard"
+  }
+
+  resolved_gpu_kubelet_numa_preset = var.gpu_kubelet_numa_preset != null ? var.gpu_kubelet_numa_preset : (
+    var.enable_gpu_kubelet_numa ? lookup(
+      local.gpu_kubelet_numa_platform_presets,
+      local.gpu_nodes_platform,
+      null
+    ) : null
+  )
+
+  effective_gpu_kubelet_numa_config = var.gpu_kubelet_numa_config != null ? var.gpu_kubelet_numa_config : (
+    local.resolved_gpu_kubelet_numa_preset == null ? null : local.gpu_kubelet_numa_presets[local.resolved_gpu_kubelet_numa_preset]
+  )
+
+  gpu_kubelet_numa_config_yaml = local.effective_gpu_kubelet_numa_config == null ? "" : yamlencode(
+    merge(
+      {
+        cpuManagerPolicy      = local.effective_gpu_kubelet_numa_config.cpu_manager_policy
+        topologyManagerPolicy = local.effective_gpu_kubelet_numa_config.topology_manager_policy
+        memoryManagerPolicy   = local.effective_gpu_kubelet_numa_config.memory_manager_policy
+        reservedMemory = [
+          for item in local.effective_gpu_kubelet_numa_config.reserved_memory : {
+            numaNode = item.numa_node
+            limits = {
+              memory = item.memory
+            }
+          }
+        ]
+      },
+      local.effective_gpu_kubelet_numa_config.kube_reserved_memory == null ? {} : {
+        kubeReserved = {
+          memory = local.effective_gpu_kubelet_numa_config.kube_reserved_memory
+        }
+      }
+    )
+  )
+
   #List of official MIG configs https://docs.nvidia.com/datacenter/tesla/mig-user-guide/supported-mig-profiles.html
   valid_mig_parted_configs = {
     "gpu-h100-sxm"   = ["all-disabled", "all-enabled", "all-balanced", "all-1g.10gb", "all-1g.10gb.me", "all-1g.20gb", "all-2g.20gb", "all-3g.40gb", "all-4g.40gb", "all-7g.80gb"]

--- a/k8s-training/main.tf
+++ b/k8s-training/main.tf
@@ -102,10 +102,12 @@ resource "nebius_mk8s_v1_node_group" "cpu-only" {
       priority      = 3
     } : null
     cloud_init_user_data = templatefile("${path.module}/../modules/cloud-init/k8s-cloud-init.tftpl", {
-      enable_filestore     = var.enable_filestore ? "true" : "false",
-      filestore_mount_path = local.filestore.mount_path,
-      ssh_user_name        = var.ssh_user_name,
-      ssh_public_key       = local.ssh_public_key
+      enable_filestore         = var.enable_filestore ? "true" : "false",
+      filestore_mount_path     = local.filestore.mount_path,
+      ssh_user_name            = var.ssh_user_name,
+      ssh_public_key           = local.ssh_public_key,
+      kubelet_numa_config      = null,
+      kubelet_numa_config_yaml = ""
     })
   }
 }
@@ -174,10 +176,12 @@ resource "nebius_mk8s_v1_node_group" "gpu" {
 
     underlay_required = false
     cloud_init_user_data = templatefile("${path.module}/../modules/cloud-init/k8s-cloud-init.tftpl", {
-      enable_filestore     = var.enable_filestore ? "true" : "false",
-      filestore_mount_path = local.filestore.mount_path,
-      ssh_user_name        = var.ssh_user_name,
-      ssh_public_key       = local.ssh_public_key
+      enable_filestore         = var.enable_filestore ? "true" : "false",
+      filestore_mount_path     = local.filestore.mount_path,
+      ssh_user_name            = var.ssh_user_name,
+      ssh_public_key           = local.ssh_public_key,
+      kubelet_numa_config      = local.effective_gpu_kubelet_numa_config,
+      kubelet_numa_config_yaml = local.gpu_kubelet_numa_config_yaml
     })
   }
 }

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -245,7 +245,7 @@ variable "gpu_kubelet_numa_preset" {
   default     = null
 
   validation {
-    condition     = var.gpu_kubelet_numa_preset == null || contains(["h200-standard", "b200-standard", "b300-standard"], var.gpu_kubelet_numa_preset)
+    condition     = var.gpu_kubelet_numa_preset == null ? true : contains(["h200-standard", "b200-standard", "b300-standard"], var.gpu_kubelet_numa_preset)
     error_message = "gpu_kubelet_numa_preset must be null, \"h200-standard\", \"b200-standard\", or \"b300-standard\"."
   }
 }

--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -218,6 +218,38 @@ variable "gpu_nodes_public_ips" {
   default     = false
 }
 
+variable "enable_gpu_kubelet_numa" {
+  description = "Enable platform-aware kubelet NUMA/topology configuration for supported GPU nodes."
+  type        = bool
+  default     = false
+}
+
+variable "gpu_kubelet_numa_config" {
+  description = "Optional custom kubelet NUMA/topology configuration applied to GPU nodes via cloud-init. Overrides gpu_kubelet_numa_preset when set."
+  type = object({
+    cpu_manager_policy      = string
+    topology_manager_policy = string
+    memory_manager_policy   = string
+    kube_reserved_memory    = optional(string)
+    reserved_memory = list(object({
+      numa_node = number
+      memory    = string
+    }))
+  })
+  default = null
+}
+
+variable "gpu_kubelet_numa_preset" {
+  description = "Optional predefined kubelet NUMA/topology configuration for GPU nodes. Supported values: h200-standard, b200-standard, b300-standard. When null and enable_gpu_kubelet_numa is true, Terraform selects a preset from gpu_nodes_platform."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.gpu_kubelet_numa_preset == null || contains(["h200-standard", "b200-standard", "b300-standard"], var.gpu_kubelet_numa_preset)
+    error_message = "gpu_kubelet_numa_preset must be null, \"h200-standard\", \"b200-standard\", or \"b300-standard\"."
+  }
+}
+
 variable "cpu_nodes_public_ips" {
   description = "Assign public IP address to CPU nodes to make them directly accessible from the external internet."
   type        = bool

--- a/modules/cilium-egress-gateway/main.tf
+++ b/modules/cilium-egress-gateway/main.tf
@@ -79,10 +79,12 @@ resource "nebius_mk8s_v1_node_group" "egress-gateway" {
       type           = var.nodes_disk_type
     }
     cloud_init_user_data = templatefile("${path.module}/../cloud-init/k8s-cloud-init.tftpl", {
-      enable_filestore     = "false",
-      filestore_mount_path = "/mnt/data",
-      ssh_user_name        = var.ssh_user_name,
-      ssh_public_key       = var.ssh_public_key
+      enable_filestore         = "false",
+      filestore_mount_path     = "/mnt/data",
+      ssh_user_name            = var.ssh_user_name,
+      ssh_public_key           = var.ssh_public_key,
+      kubelet_numa_config      = null,
+      kubelet_numa_config_yaml = ""
     })
     network_interfaces = [
       {

--- a/modules/cloud-init/k8s-cloud-init.tftpl
+++ b/modules/cloud-init/k8s-cloud-init.tftpl
@@ -1,16 +1,87 @@
 package_update: true
 package_upgrade: false
 
-%{ if enable_filestore != "false" }
-mounts:
-- [ data, ${filestore_mount_path}, virtiofs, "defaults", 0, 2 ]
+%{ if kubelet_numa_config != null ~}
+packages:
+  - python3-yaml
 
+write_files:
+  - path: /etc/systemd/system/kubelet.service.d/config-patch.conf
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Service]
+      ExecStartPre=/usr/local/bin/patch-kubelet-config.sh
+
+  - path: /usr/local/bin/patch-kubelet-config.sh
+    owner: root:root
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+
+      CONFIG=/etc/kubernetes/kubelet/config.yaml
+      BACKUP=/etc/kubernetes/kubelet/config.yaml.pre-cloud-init.$(date +%s)
+      CPU_STATE=/var/lib/kubelet/cpu_manager_state
+      MEMORY_STATE=/var/lib/kubelet/memory_manager_state
+
+      cp "$CONFIG" "$BACKUP"
+
+      PATCH_YAML=$(cat <<'EOF'
+      ${indent(6, kubelet_numa_config_yaml)}
+      EOF
+      )
+
+      export PATCH_YAML
+
+      python3 - <<'PY'
+      import os
+      import yaml
+
+      path = "/etc/kubernetes/kubelet/config.yaml"
+      patch = yaml.safe_load(os.environ["PATCH_YAML"]) or {}
+
+      with open(path) as f:
+          data = yaml.safe_load(f) or {}
+
+      for key, value in patch.items():
+          if isinstance(value, dict) and isinstance(data.get(key), dict):
+              merged = dict(data[key])
+              merged.update(value)
+              data[key] = merged
+          else:
+              data[key] = value
+
+      with open(path, "w") as f:
+          yaml.safe_dump(data, f, sort_keys=False)
+      PY
+
+      rm -f "$CPU_STATE"
+      rm -f "$MEMORY_STATE"
+
+      echo "[PATCHER] kubelet config patched successfully"
+      grep -E '^(cpuManagerPolicy|topologyManagerPolicy|memoryManagerPolicy):' "$CONFIG" || true
+      grep -A5 '^kubeReserved:' "$CONFIG" || true
+      grep -A8 '^reservedMemory:' "$CONFIG" || true
+%{ endif ~}
+
+%{ if enable_filestore != "false" ~}
+mounts:
+  - [ data, ${filestore_mount_path}, virtiofs, "defaults", 0, 2 ]
+%{ endif ~}
+
+%{ if enable_filestore != "false" || kubelet_numa_config != null ~}
 runcmd:
- - [ modprobe, fuse ]
- - [ mkdir, '-p', ${filestore_mount_path} ]
- - [ mount, '-a' ]
- 
-%{ endif }
+%{ if enable_filestore != "false" ~}
+  - [ modprobe, fuse ]
+  - [ mkdir, '-p', ${filestore_mount_path} ]
+  - [ mount, '-a' ]
+%{ endif ~}
+%{ if kubelet_numa_config != null ~}
+  - [ systemctl, daemon-reload ]
+  - [ systemctl, restart, kubelet ]
+%{ endif ~}
+%{ endif ~}
 
 users:
  - name: ${ssh_user_name}

--- a/skypilot/multiregion/main.tf
+++ b/skypilot/multiregion/main.tf
@@ -92,9 +92,12 @@ resource "nebius_mk8s_v1_node_group" "cpu-only" {
     ] : null
     underlay_required = false
     cloud_init_user_data = templatefile("${path.module}/../../modules/cloud-init/k8s-cloud-init.tftpl", {
-      enable_filestore = var.enable_filestore ? "true" : "false",
-      ssh_user_name    = var.ssh_user_name,
-      ssh_public_key   = local.ssh_public_key
+      enable_filestore         = var.enable_filestore ? "true" : "false",
+      filestore_mount_path     = local.filestore.mount_path,
+      ssh_user_name            = var.ssh_user_name,
+      ssh_public_key           = local.ssh_public_key,
+      kubelet_numa_config      = null,
+      kubelet_numa_config_yaml = ""
     })
   }
 }
@@ -153,9 +156,12 @@ resource "nebius_mk8s_v1_node_group" "gpu" {
 
     underlay_required = false
     cloud_init_user_data = templatefile("${path.module}/../../modules/cloud-init/k8s-cloud-init.tftpl", {
-      enable_filestore = var.enable_filestore ? "true" : "false",
-      ssh_user_name    = var.ssh_user_name,
-      ssh_public_key   = local.ssh_public_key
+      enable_filestore         = var.enable_filestore ? "true" : "false",
+      filestore_mount_path     = local.filestore.mount_path,
+      ssh_user_name            = var.ssh_user_name,
+      ssh_public_key           = local.ssh_public_key,
+      kubelet_numa_config      = null,
+      kubelet_numa_config_yaml = ""
     })
   }
 }


### PR DESCRIPTION
## Summary

Adds opt-in kubelet NUMA/topology tuning for GPU node groups in `k8s-training`.
NUMA tuning remains disabled by default. When enabled, Terraform selects a standard preset based on the GPU platform:

- `gpu-h200-sxm` -> `h200-standard`
- `gpu-b200-sxm` -> `b200-standard`
- `gpu-b200-sxm-a` -> `b200-standard`
- `gpu-b300-sxm` -> `b300-standard`

The presets configure:

- `cpuManagerPolicy: static`
- `topologyManagerPolicy: restricted`
- `memoryManagerPolicy: Static`
- `kubeReserved.memory: 1229Mi`
- `reservedMemory` on NUMA node 0 with `1329Mi`

A custom `gpu_kubelet_numa_config` can still override the preset values.

## Implementation

- Adds `enable_gpu_kubelet_numa`, `gpu_kubelet_numa_preset`, and `gpu_kubelet_numa_config`.
- Applies NUMA tuning only to GPU node groups.
- Updates the shared cloud-init template to patch kubelet config via `ExecStartPre` before kubelet starts.
- Preserves existing `kubeReserved` keys by merging the memory override instead of replacing the whole map.
- Updates other shared cloud-init callers to pass `null` NUMA config, preserving existing behavior.

## Validation

- `terraform fmt`
- `terraform validate` in `k8s-training`
- Ran deployment over B300 Nodes:  GPUs allocatable, kubelet NUMA config verified on-node
- Ran deployment over B200 Nodes:  GPUs allocatable, kubelet NUMA config verified on-node
- Ran deployment over H200 Nodes:  GPUs allocatable, kubelet NUMA config verified on-node