### PR TITLE
[ADD] Use block topology for GB300

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -608,6 +608,11 @@ module "slurm" {
     }
   }]
 
+  topology = {
+    plugin     = local.gb300_enabled ? "topology/block" : "topology/tree"
+    block_size = local.gb300_enabled ? 9 : null
+  }
+
   login_allocation_id              = module.k8s.static_ip_allocation_id
   login_public_ip                  = var.slurm_login_public_ip
   tailscale_enabled                = var.tailscale_enabled

--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -610,7 +610,7 @@ module "slurm" {
 
   topology = {
     plugin     = local.gb300_enabled ? "topology/block" : "topology/tree"
-    block_size = local.gb300_enabled ? 9 : null
+    block_size = local.gb300_enabled ? try(var.slurm_topology_block_size, 9) : null
   }
 
   login_allocation_id              = module.k8s.static_ip_allocation_id

--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -610,7 +610,7 @@ module "slurm" {
 
   topology = {
     plugin     = local.gb300_enabled ? "topology/block" : "topology/tree"
-    block_size = local.gb300_enabled ? try(var.slurm_topology_block_size, 9) : null
+    block_size = local.gb300_enabled ? try(var.slurm_topology_block_size, local.gb300_nodes_per_nodegroup) : null
   }
 
   login_allocation_id              = module.k8s.static_ip_allocation_id

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -579,6 +579,21 @@ active_checks_scope = "prod_quick"
 # ---
 slurm_shared_memory_size_gibibytes = 1024
 
+# Block size for Slurm topology/block topology plugin in number of nodes.
+# This affects how Slurm groups nodes into blocks for scheduling purposes.
+# A smaller block size allows for more flexible scheduling but may increase overhead,
+# while a larger block size may improve scheduling efficiency but reduce flexibility.
+# The optimal value depends on the cluster size and workload characteristics.
+#
+# By default, null (no block topology plugin configuration applied).
+#
+# For GB300,
+# it is recommended to set block size to the rack size (18) or its multiple to optimize for rack-level scheduling.
+# ---
+# slurm_topology_block_size = 9
+# ---
+slurm_topology_block_size = null
+
 # Node groups that Soperator should ignore during maintenance events.
 # These ignored maintenance events will be handled by mk8s control plane instead.
 # Supported values: controller, nfs, system, login, accounting.

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -590,7 +590,7 @@ slurm_shared_memory_size_gibibytes = 1024
 # For GB300,
 # it is recommended to set block size to the rack size (18) or its multiple to optimize for rack-level scheduling.
 # ---
-# slurm_topology_block_size = 9
+# slurm_topology_block_size = 18
 # ---
 slurm_topology_block_size = null
 

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1365,6 +1365,24 @@ variable "slurm_shared_memory_size_gibibytes" {
   }
 }
 
+variable "slurm_topology_block_size" {
+  description = <<EOL
+    Block size for Slurm topology/block topology plugin in number of nodes.
+    This affects how Slurm groups nodes into blocks for scheduling purposes.
+    A smaller block size allows for more flexible scheduling but may increase overhead,
+    while a larger block size may improve scheduling efficiency but reduce flexibility.
+    The optimal value depends on the cluster size and workload characteristics.
+  EOL
+  type        = number
+  default     = 9
+  nullable    = true
+
+  validation {
+    condition     = try(var.slurm_topology_block_size > 0, true)
+    error_message = "slurm_topology_block_size must be greater than 0 if set."
+  }
+}
+
 # endregion Config
 
 # region Telemetry

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1374,7 +1374,7 @@ variable "slurm_topology_block_size" {
     The optimal value depends on the cluster size and workload characteristics.
   EOL
   type        = number
-  default     = 9
+  default     = 18
   nullable    = true
 
   validation {

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -137,6 +137,10 @@ resource "helm_release" "soperator_fluxcd_cm" {
         slurm_raw_config  = var.slurm_partition_raw_config
       }
 
+      topology = {
+        block_size = var.topology.plugin == "topology/block" ? var.topology.block_size : null
+      }
+
       use_preinstalled_gpu_drivers = var.use_preinstalled_gpu_drivers
       cuda_version                 = var.cuda_version
 

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -449,6 +449,15 @@ resources:
             populateJail:
               k8sNodeFilterName: ${slurm_cluster.populate_jail.k8s_node_filter_name}
 
+            %{~ if slurm_cluster.topology.block_size != null ~}
+            slurmConfig:
+              topologyPlugin: "topology/block"
+              topologyParam: "BlockAsNodeRank"
+
+            topology:
+              blockSize: ${slurm_cluster.topology.block_size}
+            %{~ endif ~}
+
             periodicChecks:
               ncclBenchmark:
                 enabled: false

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -49,6 +49,28 @@ variable "slurm_partition_raw_config" {
   default     = []
 }
 
+variable "topology" {
+  description = "Slurm topology configuration. topology/tree leaves the chart default unset; topology/block renders BlockAsNodeRank and requires block_size."
+  type = object({
+    plugin     = string
+    block_size = optional(number)
+  })
+  default = {
+    plugin = "topology/tree"
+  }
+  nullable = false
+
+  validation {
+    condition     = contains(["topology/tree", "topology/block"], var.topology.plugin)
+    error_message = "topology.plugin must be one of 'topology/tree' or 'topology/block'."
+  }
+
+  validation {
+    condition     = var.topology.plugin == "topology/block" ? try(var.topology.block_size > 0, false) : true
+    error_message = "topology.block_size must be a positive number when topology.plugin is 'topology/block'."
+  }
+}
+
 # endregion PartitionConfiguration
 
 # region HealthCheckConfig


### PR DESCRIPTION
## Release Notes

As for GB300, default topology is set to:
```
TopologyPlugin=topology/block
TopologyParam=BlockAsNodeRank
```
with `topology.conf`'s
```
BlockSizes=18
```