### PR TITLE
SCHED-1615 Add support for direct squashfs mode and use it by default

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -560,6 +560,8 @@ module "slurm" {
   slurm_partition_raw_config      = var.slurm_partition_raw_config
   slurm_health_check_config       = var.slurm_health_check_config
 
+  enroot_direct_squashfs_enabled = var.enroot_direct_squashfs_enabled
+
   slurm_nodesets_partitions = [for partition in var.slurm_nodesets_partitions : {
     name         = partition.name
     is_all       = partition.is_all

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -97,7 +97,6 @@ filestore_jail_submounts = [{
   }
 }]
 
-
 # Shared filesystem to be used for accounting DB.
 # By default, null.
 # Required if accounting_enabled is true.
@@ -417,24 +416,23 @@ slurm_nodeset_workers = [
       disk_type       = "NETWORK_SSD"
       filesystem_type = "ext4"
     }]
-    # Whether to create extra NRD disks for storing Docker/Enroot images and container filesystems on each worker node.
-    # It will create compute disks with provided spec for each node via CSI.
-    # NOTE: In case you're not going to use Docker/Enroot in your workloads, it's worth disabling this feature.
+    # Whether to create extra node-local disks for storing Docker/Enroot images and container filesystems on each worker node.
+    # Disabled by default. Enable this only when you want dedicated image-storage disks instead of direct SquashFS startup.
     # NOTE: `size` must be divisible by 93Gi - https://docs.nebius.com/compute/storage/types#disks-types.
     # ---
-    # node_local_image_disk = {
-    #   enabled = false
-    # }
-    # ---
     node_local_image_disk = {
-      enabled = true
-      spec = {
-        size_gibibytes  = 930
-        filesystem_type = "ext4"
-        # Could be changed to `NETWORK_SSD_NON_REPLICATED`
-        disk_type = "NETWORK_SSD_IO_M3"
-      }
+      enabled = false
     }
+    # ---
+    # node_local_image_disk = {
+    #   enabled = true
+    #   spec = {
+    #     size_gibibytes  = 930
+    #     filesystem_type = "ext4"
+    #     # Could be changed to `NETWORK_SSD_NON_REPLICATED`
+    #     disk_type = "NETWORK_SSD_IO_M3"
+    #   }
+    # }
   },
 ]
 

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -240,6 +240,12 @@ variable "filestore_jail_submounts" {
   }
 }
 
+variable "enroot_direct_squashfs_enabled" {
+  description = "Enable Pyxis/Enroot direct SquashFS startup through squashfuse. Node-local image-storage disk creation remains controlled by node_local_image_disk.enabled."
+  type        = bool
+  default     = true
+}
+
 variable "filestore_accounting" {
   description = "Shared filesystem to be used for accounting DB"
   type = object({

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -77,7 +77,8 @@ resource "helm_release" "soperator_fluxcd_cm" {
     soperator_image_repo     = local.image.repository
     soperator_image_repo_nfs = var.nfs_in_k8s.use_stable_repo ? local.image.repository_stable : local.image.repository
 
-    dcgm_job_mapping_enabled = var.dcgm_job_mapping_enabled
+    dcgm_job_mapping_enabled       = var.dcgm_job_mapping_enabled
+    enroot_direct_squashfs_enabled = var.enroot_direct_squashfs_enabled
 
     tailscale_enabled       = var.tailscale_enabled
     apparmor_enabled        = var.use_default_apparmor_profile

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -15,6 +15,12 @@ resources:
             url: ${soperator_helm_repo_nfs}
           soperator:
             url: ${soperator_helm_repo}
+        %{~ if enroot_direct_squashfs_enabled ~}
+        customConfigmaps:
+          overrideValues:
+            enroot:
+              useDedicatedImageStorage: false
+        %{~ endif ~}
         certManager:
           enabled: true
           interval: 5m
@@ -256,6 +262,9 @@ resources:
             cudaVersion: ${slurm_cluster.cuda_version}
             useDefaultAppArmorProfile: ${apparmor_enabled}
             maintenance: ${slurm_cluster.maintenance}
+            plugStackConfig:
+              pyxis:
+                useSquashfuse: ${enroot_direct_squashfs_enabled}
 
             %{~ if has_local_nvme ~}
             slurmScripts:

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -348,6 +348,12 @@ variable "controller_state_on_filestore" {
   default     = false
 }
 
+variable "enroot_direct_squashfs_enabled" {
+  description = "Enable Pyxis/Enroot direct SquashFS startup through squashfuse. Node-local image-storage disk creation remains controlled by node_local_image_disk.enabled."
+  type        = bool
+  default     = true
+}
+
 # endregion Disks
 
 # region nfs-server


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Enables direct Enroot startup from cached SquashFS images by default.

Main changes:
  - Add support for enroot direct squashfs (https://github.com/nebius/soperator/pull/2562) defaulting to true.
  - Disable dedicated Enroot node-local image disks by default.
