### PR TITLE
Fix skypilot multiregion filestore mount path

### DIFF
--- a/skypilot/multiregion/locals.tf
+++ b/skypilot/multiregion/locals.tf
@@ -4,7 +4,8 @@ locals {
   fileexists(var.ssh_public_key.path) ? file(var.ssh_public_key.path) : null)
 
   filestore = {
-    mount_tag = "data"
+    mount_tag  = "data"
+    mount_path = "/mnt/data"
   }
 
   regions_default = {


### PR DESCRIPTION
## Summary
- Define the missing skypilot multiregion filestore mount path local used by k8s cloud-init.
- Keeps the existing mount tag as data and uses the established default path /mnt/data.

## Why
- skypilot/multiregion references local.filestore.mount_path when rendering k8s-cloud-init.tftpl, but locals.tf only defined mount_tag.
- This causes terraform validate to fail with Unsupported attribute once the module is initialized.

## Validation
- terraform fmt -check skypilot/multiregion
- git diff --check
- terraform -chdir=skypilot/multiregion init -backend=false
- terraform plan -out=tfplan