### PR TITLE
chore: add provider version constraints to required_providers

### DIFF
--- a/anyscale/deploy/provider.tf
+++ b/anyscale/deploy/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/anyscale/prepare/provider.tf
+++ b/anyscale/prepare/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/applications/dstack/provider.tf
+++ b/applications/dstack/provider.tf
@@ -1,10 +1,12 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.0.1, < 4.0.0"
     }
   }
 }

--- a/applications/osmo/deploy/example/001-iac/modules/k8s/versions.tf
+++ b/applications/osmo/deploy/example/001-iac/modules/k8s/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/applications/osmo/deploy/example/001-iac/modules/platform/versions.tf
+++ b/applications/osmo/deploy/example/001-iac/modules/platform/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/applications/osmo/deploy/example/001-iac/modules/wireguard/versions.tf
+++ b/applications/osmo/deploy/example/001-iac/modules/wireguard/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/applications/osmo/deploy/example/001-iac/versions.tf
+++ b/applications/osmo/deploy/example/001-iac/versions.tf
@@ -5,7 +5,8 @@ terraform {
 
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/compute-testing/provider.tf
+++ b/compute-testing/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/dsvm/provider.tf
+++ b/dsvm/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/k8s-training/provider.tf
+++ b/k8s-training/provider.tf
@@ -1,10 +1,12 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.0.1, < 4.0.0"
     }
     units = {
       source  = "dstaroff/units"

--- a/modules/cilium-egress-gateway/versions.tf
+++ b/modules/cilium-egress-gateway/versions.tf
@@ -1,10 +1,12 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.19.0, < 2.0.0"
     }
   }
 }

--- a/modules/device-plugin/versions.tf
+++ b/modules/device-plugin/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/modules/gpu-operator/versions.tf
+++ b/modules/gpu-operator/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/modules/kuberay-service/versions.tf
+++ b/modules/kuberay-service/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/modules/kuberay/versions.tf
+++ b/modules/kuberay/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/modules/network-operator/versions.tf
+++ b/modules/network-operator/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/modules/nfs-server/provider.tf
+++ b/modules/nfs-server/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/modules/nims/provider.tf
+++ b/modules/nims/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/modules/o11y/versions.tf
+++ b/modules/o11y/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/nfs-server/provider.tf
+++ b/nfs-server/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }

--- a/skypilot/multiregion/provider.tf
+++ b/skypilot/multiregion/provider.tf
@@ -1,10 +1,12 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = ">= 3.0.1, < 4.0.0"
     }
     units = {
       source  = "dstaroff/units"

--- a/wireguard/provider.tf
+++ b/wireguard/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     nebius = {
-      source = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
+      version = ">= 0.5.196, < 0.6.0"
     }
   }
 }


### PR DESCRIPTION
HashiCorp recommends pinning provider versions; several required_providers entries declared only source with no version, which also triggers tflint's terraform_required_providers warning.

Add lower + major-upper-bound version constraints to the provider entries that were missing them (outside soperator/), anchored to versions already proven in the repo:

nebius >= 0.5.196, < 0.6.0
kubernetes >= 3.0.1, < 4.0.0
kubectl >= 1.19.0, < 2.0.0
units >= 1.1.1, < 2.0.0
local >= 2.5.3, < 3.0.0



soperator/ is intentionally out of scope — its constraint additions and .tflint.hcl enforcement changes are handled in a separate PR (soperator overlaps with in-flight changes elsewhere, so it's isolated to keep this PR clean and mergeable).
No behavior changes beyond the version constraints themselves.
Notes

Existing (already-constrained) entries were left as-is.
The gitignored personal install installations/asabry/ was skipped.
Rebased onto current main; terraform fmt -check is clean.

Summary of what I did

Added version constraints in the approved lower + major-upper-bound style, anchored to versions already in use.
Scoped strictly to non-soperator directories (22 files); soperator constraints + tflint enforcement moved to a separate PR.
Verified zero non-soperator entries remain unconstrained and terraform fmt -check is clean.