### PR TITLE
SCHED-1987: Disable Mk8s node auto-healing

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -247,11 +247,9 @@ resource "nebius_compute_v1_nvl_instance_group" "worker" {
   }
 
   parent_id = var.iam_project_id
-  # `size` is a private-provider field for non-production partial-rack usage.
-  # Uncomment to use with private provider.
-  # size = each.value.size
-  name = "${local.k8s_cluster_name}-${each.value.node_group_name}"
-  type = each.value.nvlink.type
+  size      = each.value.size
+  name      = "${local.k8s_cluster_name}-${each.value.node_group_name}"
+  type      = each.value.nvlink.type
 }
 
 module "k8s" {

--- a/soperator/modules/k8s/k8s_ng_workers_v2.tf
+++ b/soperator/modules/k8s/k8s_ng_workers_v2.tf
@@ -80,16 +80,42 @@ resource "nebius_mk8s_v1_node_group" "worker_v2" {
 
   auto_repair = {
     conditions = [
+      # Don't recreate the node if it's not ready for 5 minutes
+      # to avoid races with Soperator, since it does the same
       {
-        type     = "NebiusBootDiskIOError"
-        status   = "TRUE"
+        type     = "NodeReady"
+        status   = "FALSE"
         disabled = true
       },
+      # Don't restart nodes with not responding kubelet
+      # to avoid races with Soperator, since it does the same
       {
         type     = "NodeReady"
         status   = "UNKNOWN"
         disabled = true
       },
+      # Don't recreate nodes with broken boot disks
+      # since it's covered by NodeReady=Unknown
+      {
+        type     = "NebiusBootDiskIOError"
+        status   = "TRUE"
+        disabled = true
+      },
+      # Don't set-unhealthy and restart nodes with failed Mk8s health checks
+      # to avoid races with Soperator, since it has its own health checks
+      {
+        type     = "NebiusGPUError"
+        status   = "TRUE"
+        disabled = true
+      },
+      # Don't restart nodes with broken containerd
+      # since it's covered by NodeReady=False
+      {
+        type     = "NebiusContainerRuntimeError"
+        status   = "TRUE"
+        disabled = true
+      },
+      # Set-unhealthy and recreate nodes marked as unhealthy by Soperator
       {
         type    = "HardwareIssuesSuspected"
         status  = "TRUE"


### PR DESCRIPTION
Explicitly disable reactions of the Mk8s control plane to various conditions on K8s nodes, to avoid race conditions with Soperator, which does the same.