### PR TITLE
SCHED-1900: Use `TF_CLI_ARGS` instead of `TFE_PARALLELISM` for parallel TF execution

### DIFF
--- a/soperator/installations/example/.envrc
+++ b/soperator/installations/example/.envrc
@@ -1,22 +1,53 @@
+# region Styling functions
+fmt_var() {
+  printf '\033[38;5;208m%s\033[0m' "$*"
+}
+fmt_val() {
+  printf '\033[1;33m%s\033[0m' "$*"
+}
+log_info() {
+  printf '\033[1;34m%s\033[0m\n' "$*"
+}
+log_progress() {
+  printf '\033[36m%s...\033[0m\n' "$*"
+}
+log_varval() {
+  local name="$1"
+  local value="$2"
+  local spaces="${3:-1}"
+  printf '%s:' "$(fmt_var "$name")"
+  while (( spaces-- > 0 )); do
+    printf ' '
+  done
+  printf '%s\n' "$(fmt_val "$value")"
+}
+log_success() {
+  printf '\033[32m ✅ %s\033[0m\n' "$*"
+}
+log_error() {
+  printf '\033[31m ❌ %s\033[0m\n' "$*" >&2
+  exit 1
+}
+# endregion Styling functions
+
 NEBIUS_TENANT_ID="$NEBIUS_TENANT_ID" # ='tenant-...'
 NEBIUS_PROJECT_ID="$NEBIUS_PROJECT_ID" # ='project-...'
 NEBIUS_REGION="${NEBIUS_REGION:-eu-north1}"
 
-# O11y setup.
 NEBIUS_OLLY_PROFILE="${NEBIUS_OLLY_PROFILE:-soperator-telemetry}"
 NEBIUS_OLLY_TENANT_ID="${NEBIUS_OLLY_TENANT_ID:-tenant-e00vyb5y1x5vqkzw5e}" # ='tenant-...'
 
 if [ -z "${NEBIUS_TENANT_ID}" ]; then
-  echo "Error: NEBIUS_TENANT_ID is not set"
-  return 1
+  log_error "Variable is not set: $(fmt_var "NEBIUS_TENANT_ID")"
 fi
 
 if [ -z "${NEBIUS_PROJECT_ID}" ]; then
-  echo "Error: NEBIUS_PROJECT_ID is not set"
-  return 1
+  log_error "Variable is not set: $(fmt_var "NEBIUS_PROJECT_ID")"
 fi
 
 # region VPC subnet
+
+log_progress 'Fetching VPC subnet ID'
 
 NEBIUS_VPC_SUBNET_ID=$(nebius vpc subnet list \
   --parent-id "${NEBIUS_PROJECT_ID}" \
@@ -24,11 +55,16 @@ NEBIUS_VPC_SUBNET_ID=$(nebius vpc subnet list \
   | jq -r '.items[0].metadata.id')
 export NEBIUS_VPC_SUBNET_ID
 
+log_success "Using VPC subnet ID: $(fmt_val "${NEBIUS_VPC_SUBNET_ID}")"
+printf '\n'
+
 # endregion VPC subnet
 
 # region Remote state
 
 # region Service account
+
+log_progress 'Ensuring service account'
 
 NEBIUS_SA_TERRAFORM_ID=$(nebius iam service-account list \
   --page-size 999 \
@@ -43,14 +79,18 @@ if [ -z "$NEBIUS_SA_TERRAFORM_ID" ]; then
     --name 'slurm-terraform-sa' \
     --format json \
     | jq -r '.metadata.id')
-  echo "Created new service account with ID: $NEBIUS_SA_TERRAFORM_ID"
+  log_success "Created new service account with ID: $(fmt_val "${NEBIUS_SA_TERRAFORM_ID}")"
 else
-  echo "Found existing service account with ID: $NEBIUS_SA_TERRAFORM_ID"
+  log_info "Found existing service account with ID: $(fmt_val "${NEBIUS_SA_TERRAFORM_ID}")"
 fi
+
+printf '\n'
 
 # endregion Service account
 
 # region `editors` group
+
+log_progress 'Ensuring service account is a member of editors group'
 
 NEBIUS_GROUP_EDITORS_ID=$(nebius iam group get-by-name \
   --parent-id "${NEBIUS_TENANT_ID}" \
@@ -64,22 +104,24 @@ IS_MEMBER=$(nebius iam group-membership list-members \
   --format json \
   | jq -r --arg SAID "${NEBIUS_SA_TERRAFORM_ID}" '.memberships[] | select(.spec.member_id == $SAID) | .spec.member_id')
 
-
 # Add service account to group editors only if not already a member
 if [ -z "${IS_MEMBER}" ]; then
   nebius iam group-membership create \
     --parent-id "${NEBIUS_GROUP_EDITORS_ID}" \
     --member-id "${NEBIUS_SA_TERRAFORM_ID}"
-  echo "Added service account to editors group"
+  log_success "Added service account to editors group: $(fmt_val "${NEBIUS_SA_TERRAFORM_ID}") -> $(fmt_val "${NEBIUS_GROUP_EDITORS_ID}")"
 else
-  echo "Service account is already a member of editors group"
+  log_info "Service account is already a member of editors group: $(fmt_val "${NEBIUS_SA_TERRAFORM_ID}") -> $(fmt_val "${NEBIUS_GROUP_EDITORS_ID}")"
 fi
+
+printf '\n'
 
 # endregion `editors` group
 
 # region Access key
 
-echo 'Cleaning up expired access keys for service account'
+log_progress 'Cleaning up expired access keys for service account'
+
 EXPIRED_KEYS=$(nebius iam v2 access-key list-by-account \
   --account-service-account-id "${NEBIUS_SA_TERRAFORM_ID}" \
   --format json \
@@ -88,10 +130,13 @@ EXPIRED_KEYS=$(nebius iam v2 access-key list-by-account \
 
 echo "$EXPIRED_KEYS" | while read -r KEY_ID; do
   if [ -n "$KEY_ID" ]; then
-    echo "Deleting expired key: ${KEY_ID}"
+    log_progress "Deleting expired key: $(fmt_val "${KEY_ID}")"
     nebius iam v2 access-key delete --id "${KEY_ID}" --async || true
   fi
 done
+
+log_success ''
+printf '\n'
 
 DATE_FORMAT='+%Y-%m-%dT%H:%M:%SZ'
 
@@ -103,7 +148,8 @@ else
   EXPIRATION_DATE=$(date -d '+1 day' "${DATE_FORMAT}")
 fi
 
-echo 'Creating new access key for Object Storage'
+log_progress 'Creating new access key for Object Storage'
+
 NEBIUS_SA_ACCESS_KEY_ID=$(nebius iam v2 access-key create \
   --parent-id "${NEBIUS_PROJECT_ID}" \
   --name "slurm-tf-ak-$(date +%s)" \
@@ -111,8 +157,11 @@ NEBIUS_SA_ACCESS_KEY_ID=$(nebius iam v2 access-key create \
   --description 'Temporary S3 Access' \
   --expires-at "${EXPIRATION_DATE}" \
   --format json \
+  2>/dev/null \
   | jq -r '.metadata.id')
-echo "Created new access key: ${NEBIUS_SA_ACCESS_KEY_ID}"
+
+log_success "Created new access key: $(fmt_val "${NEBIUS_SA_ACCESS_KEY_ID}")"
+printf '\n'
 
 # endregion Access key
 
@@ -123,12 +172,13 @@ AWS_ACCESS_KEY_ID=$(nebius iam v2 access-key get \
   --format json | jq -r '.status.aws_access_key_id')
 export AWS_ACCESS_KEY_ID
 
-echo "Generating new AWS_SECRET_ACCESS_KEY"
+log_progress "Generating new $(fmt_var AWS_SECRET_ACCESS_KEY)"
 AWS_SECRET_ACCESS_KEY="$(nebius iam v2 access-key get \
   --id "${NEBIUS_SA_ACCESS_KEY_ID}" \
   --format json \
   | jq -r '.status.secret')"
 export AWS_SECRET_ACCESS_KEY
+log_success ''
 
 AWS_REGION=$NEBIUS_REGION
 export AWS_REGION
@@ -136,9 +186,13 @@ export AWS_REGION
 AWS_ENDPOINT_URL="https://storage.$AWS_REGION.nebius.cloud:443"
 export AWS_ENDPOINT_URL
 
+printf '\n'
+
 # endregion AWS access key
 
 # region Bucket
+
+log_progress 'Ensuring bucket exists for Terraform state'
 
 NEBIUS_BUCKET_NAME="tfstate-slurm-k8s-$(echo -n "${NEBIUS_TENANT_ID}-${NEBIUS_PROJECT_ID}" | md5sum | awk '$0=$1')"
 export NEBIUS_BUCKET_NAME
@@ -153,14 +207,18 @@ if [ -z "${EXISTING_BUCKET}" ]; then
     --name "${NEBIUS_BUCKET_NAME}" \
     --parent-id "${NEBIUS_PROJECT_ID}" \
     --versioning-policy 'enabled'
-  echo "Created bucket: ${NEBIUS_BUCKET_NAME}"
+  log_success "Created bucket: $(fmt_val "${NEBIUS_BUCKET_NAME}")"
 else
-  echo "Using existing bucket: ${NEBIUS_BUCKET_NAME}"
+  log_info "Using existing bucket: $(fmt_val "${NEBIUS_BUCKET_NAME}")"
 fi
+
+printf '\n'
 
 # endregion Bucket
 
 # region Backend override
+
+log_progress 'Creating Terraform backend override file'
 
 cat > terraform_backend_override.tf << EOF
 terraform {
@@ -181,6 +239,9 @@ terraform {
 }
 EOF
 
+log_success ''
+printf '\n'
+
 # endregion Backend override
 
 # endregion Remote state
@@ -195,21 +256,23 @@ export TF_VAR_o11y_profile="${NEBIUS_OLLY_PROFILE}"
 export TF_VAR_vpc_subnet_id="${NEBIUS_VPC_SUBNET_ID}"
 export TF_VAR_aws_access_key_id="${AWS_ACCESS_KEY_ID}"
 export TF_VAR_aws_secret_access_key="${AWS_SECRET_ACCESS_KEY}"
+
 : "${TF_PARALLELISM:=20}"
 export TF_CLI_ARGS_plan="-parallelism=${TF_PARALLELISM}"
 export TF_CLI_ARGS_apply="-parallelism=${TF_PARALLELISM}"
 export TF_CLI_ARGS_destroy="-parallelism=${TF_PARALLELISM}"
 
-echo "Exported variables:"
-echo "TF_VAR_region: ${TF_VAR_region}"
-echo "TF_VAR_iam_tenant_id: ${TF_VAR_iam_tenant_id}"
-echo "TF_VAR_iam_project_id: ${TF_VAR_iam_project_id}"
-echo "TF_VAR_o11y_iam_tenant_id: ${TF_VAR_o11y_iam_tenant_id}"
-echo "TF_VAR_o11y_profile: ${TF_VAR_o11y_profile}"
-echo "TF_VAR_vpc_subnet_id: ${TF_VAR_vpc_subnet_id}"
-echo "TF_VAR_aws_access_key_id: ${TF_VAR_aws_access_key_id}"
-echo "TF_CLI_ARGS_plan: ${TF_CLI_ARGS_plan}"
-echo "TF_CLI_ARGS_apply: ${TF_CLI_ARGS_apply}"
-echo "TF_CLI_ARGS_destroy: ${TF_CLI_ARGS_destroy}"
+log_info "Exported variables:"
+log_varval 'TF_VAR_region' "${TF_VAR_region}" 13
+log_varval 'TF_VAR_iam_tenant_id' "${TF_VAR_iam_tenant_id}" 6
+log_varval 'TF_VAR_iam_project_id' "${TF_VAR_iam_project_id}" 5
+log_varval 'TF_VAR_o11y_iam_tenant_id' "${TF_VAR_o11y_iam_tenant_id}" 1
+log_varval 'TF_VAR_o11y_profile' "${TF_VAR_o11y_profile}" 7
+log_varval 'TF_VAR_vpc_subnet_id' "${TF_VAR_vpc_subnet_id}" 6
+log_varval 'TF_VAR_aws_access_key_id' "${TF_VAR_aws_access_key_id}" 2
+log_varval 'TF_CLI_ARGS_plan' "${TF_CLI_ARGS_plan}" 10
+log_varval 'TF_CLI_ARGS_apply' "${TF_CLI_ARGS_apply}" 9
+log_varval 'TF_CLI_ARGS_destroy' "${TF_CLI_ARGS_destroy}" 7
+printf '\n'
 
 # endregion TF variables

--- a/soperator/installations/example/.envrc
+++ b/soperator/installations/example/.envrc
@@ -195,7 +195,10 @@ export TF_VAR_o11y_profile="${NEBIUS_OLLY_PROFILE}"
 export TF_VAR_vpc_subnet_id="${NEBIUS_VPC_SUBNET_ID}"
 export TF_VAR_aws_access_key_id="${AWS_ACCESS_KEY_ID}"
 export TF_VAR_aws_secret_access_key="${AWS_SECRET_ACCESS_KEY}"
-export TFE_PARALLELISM=20
+: "${TF_PARALLELISM:=20}"
+export TF_CLI_ARGS_plan="-parallelism=${TF_PARALLELISM}"
+export TF_CLI_ARGS_apply="-parallelism=${TF_PARALLELISM}"
+export TF_CLI_ARGS_destroy="-parallelism=${TF_PARALLELISM}"
 
 echo "Exported variables:"
 echo "TF_VAR_region: ${TF_VAR_region}"
@@ -205,6 +208,8 @@ echo "TF_VAR_o11y_iam_tenant_id: ${TF_VAR_o11y_iam_tenant_id}"
 echo "TF_VAR_o11y_profile: ${TF_VAR_o11y_profile}"
 echo "TF_VAR_vpc_subnet_id: ${TF_VAR_vpc_subnet_id}"
 echo "TF_VAR_aws_access_key_id: ${TF_VAR_aws_access_key_id}"
-echo "TFE_PARALLELISM: ${TFE_PARALLELISM}"
+echo "TF_CLI_ARGS_plan: ${TF_CLI_ARGS_plan}"
+echo "TF_CLI_ARGS_apply: ${TF_CLI_ARGS_apply}"
+echo "TF_CLI_ARGS_destroy: ${TF_CLI_ARGS_destroy}"
 
 # endregion TF variables


### PR DESCRIPTION
## Release Notes

`TFE_PARALLELISM` is not recognized by the Terraform CLI, as this option is meant for Terraform Enterprise.
Instead, `TF_CLI_ARGS` per `plan`, `apply`, and `destroy` commands are used.

`.envrc` sourcing now logs more info with clear visual separation.