### PR TITLE
More effective resource usage

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -273,8 +273,6 @@ module "k8s" {
   platform_driver_presets      = var.platform_driver_presets
   use_preinstalled_gpu_drivers = var.use_preinstalled_gpu_drivers
 
-  etcd_cluster_size = var.etcd_cluster_size
-
   node_group_system     = var.slurm_nodeset_system
   node_group_controller = var.slurm_nodeset_controller
   node_group_workers    = local.node_group_workers

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -357,7 +357,7 @@ slurm_nodeset_workers = [
     }
     boot_disk = {
       type                 = "NETWORK_SSD"
-      size_gibibytes       = 512
+      size_gibibytes       = 128
       block_size_kibibytes = 4
     }
     gpu_cluster = {

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -316,7 +316,7 @@ slurm_nodeset_controller = {
   size = 1
   resource = {
     platform = "cpu-d3"
-    preset   = "64vcpu-256gb"
+    preset   = "16vcpu-64gb"
   }
   boot_disk = {
     type                 = "NETWORK_SSD"

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -513,17 +513,6 @@ variable "k8s_cluster_node_ssh_access_public_ip" {
   default     = false
 }
 
-variable "etcd_cluster_size" {
-  description = "Size of the etcd cluster. Must be a positive odd number (1, 3, 5…) to maintain quorum."
-  type        = number
-  default     = 3
-
-  validation {
-    condition     = var.etcd_cluster_size >= 1 && var.etcd_cluster_size % 2 == 1
-    error_message = "etcd_cluster_size must be a positive odd number (1, 3, 5…) to maintain quorum."
-  }
-}
-
 # endregion k8s
 
 # endregion Infrastructure

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -835,7 +835,7 @@ variable "slurm_nodeset_workers" {
     }
     boot_disk = {
       type                 = "NETWORK_SSD"
-      size_gibibytes       = 512
+      size_gibibytes       = 128
       block_size_kibibytes = 4
     }
     node_local_image_disk = {
@@ -939,9 +939,9 @@ variable "slurm_nodeset_workers" {
   validation {
     condition = alltrue([
       for worker in var.slurm_nodeset_workers :
-      (worker.boot_disk.size_gibibytes >= 512)
+      (worker.boot_disk.size_gibibytes >= 128)
     ])
-    error_message = "Boot disks for worker nodes must be at least 512 GiB."
+    error_message = "Boot disks for worker nodes must be at least 128 GiB."
   }
 
   validation {

--- a/soperator/modules/k8s/k8s_cluster.tf
+++ b/soperator/modules/k8s/k8s_cluster.tf
@@ -11,8 +11,6 @@ resource "nebius_mk8s_v1_cluster" "this" {
       public_endpoint = {}
     }
 
-    etcd_cluster_size = var.etcd_cluster_size
-
     audit_logs = {}
   }
 

--- a/soperator/modules/k8s/variables.tf
+++ b/soperator/modules/k8s/variables.tf
@@ -28,12 +28,6 @@ variable "name" {
   type        = string
 }
 
-variable "etcd_cluster_size" {
-  description = "Size of the etcd cluster."
-  type        = number
-  default     = 3
-}
-
 variable "company_name" {
   description = "Name of the company. It is used for context name of the cluster in .kubeconfig file."
   type        = string

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -634,8 +634,8 @@ resources:
                         - ReadWriteOnce
                       resources:
                         requests:
-                          storage: 50Gi
-                      storageClassName: "compute-csi-network-ssd-ext4"
+                          storage: ${93*3}Gi
+                      storageClassName: "compute-csi-network-ssd-io-m3-ext4"
                     %{~ endif ~}
               login:
                 size: ${slurm_cluster.nodes.login.size}


### PR DESCRIPTION
## Release Notes

- Decreased default controller VM preset
- Decreased default worker boot disk size
- Switched `controller-spool` disks to `IO_M3` to reduce latency
- Excluded configuration of `etcd` cluster size to auto-scale it on MK8s side to speed up cluster creation