### PR TITLE
Disable mem-perf active check  for GB300

### DIFF
--- a/soperator/modules/slurm/locals_active_checks.tf
+++ b/soperator/modules/slurm/locals_active_checks.tf
@@ -1,6 +1,7 @@
 locals {
   gb300_disabled_active_checks = toset([
     "extensive-check",
+    "mem-perf",
   ])
 
   gb300_active_checks_overrides = merge(


### PR DESCRIPTION
mem-perf is currently based on x86 only intel mlc, it won't work as-is for arch based GB platforms

## Release Notes (Mandatory Description)