### PR TITLE
Fix the path for the slurm scripts

### DIFF
--- a/soperator/modules/slurm/templates/helm_values/flux_release_nodesets.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/flux_release_nodesets.yaml.tftpl
@@ -145,14 +145,14 @@ nodesets:
                 mountPath: /opt/slurm_scripts/
                 volumeSource:
                   configMap:
-                    name: slurm-scripts
+                    name: soperator-slurm-scripts
                     defaultMode: 0755
 
               - name: slurm-scripts-jail
                 mountPath: /mnt/jail.upper/opt/slurm_scripts/
                 volumeSource:
                   configMap:
-                    name: slurm-scripts
+                    name: soperator-slurm-scripts
                     defaultMode: 0755
 
               - name: sys-host


### PR DESCRIPTION
## Release Notes

### Fix

Updated the worker NodeSet Flux values to mount Slurm scripts from the ConfigMap created by the main Slurm release.

Previously, worker pods referenced `slurm-scripts`, but the deployed ConfigMap is named `soperator-slurm-scripts`. This caused worker pods to fail during volume setup with `configmap "slurm-scripts" not found`.

The NodeSet template now points both script mounts to `soperator-slurm-scripts`:

- `/opt/slurm_scripts/`
- `/mnt/jail.upper/opt/slurm_scripts/`

This allows worker pods to mount the Slurm scripts correctly and start successfully.