### PR TITLE
SCHED-1893: Scale system component resources with cluster size

### DIFF
--- a/.github/workflows/soperator-terraform.yml
+++ b/.github/workflows/soperator-terraform.yml
@@ -34,20 +34,6 @@ jobs:
         with:
           terraform_version: "v1.12.2"
 
-      # Check that all Terraform configuration files adhere to a canonical format
-      - name: Terraform Format Check
-        run: terraform fmt -check -recursive .
-
-      # Initialize Terraform working directory (without backend for validation)
-      - name: Terraform Init
-        run: terraform init -backend=false
-        working-directory: soperator/installations/example
-
-      # Validate terraform code in example installation
-      - name: Terraform Validate - Example Installation
-        run: terraform validate
-        working-directory: soperator/installations/example
-
-      # Validate terraform modules
+      # fmt check + init/validate of all modules and installations + module tests
       - name: Terraform Check - Modules and Installations
         run: make terraform-check

--- a/soperator/Makefile
+++ b/soperator/Makefile
@@ -1,6 +1,11 @@
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Provider downloads flake on slow networks: the registry client gives up after
+# 10s / 2 attempts by default and `terraform init` fails on the checksum fetch.
+export TF_REGISTRY_DISCOVERY_RETRY ?= 5
+export TF_REGISTRY_CLIENT_TIMEOUT ?= 60
+
 SOPERATOR_VERSION		= $(shell cat VERSION)
 SUBVERSION				= $(shell cat SUBVERSION)
 VERSION					= $(SOPERATOR_VERSION)-$(SUBVERSION)
@@ -62,6 +67,19 @@ terraform-validate-installations:
 		fi; \
 	done
 
+.PHONY: terraform-test-modules
+terraform-test-modules:
+	@echo 'Running Terraform module tests...'
+	@for module_dir in modules/*/; do \
+		if [ -d "$$module_dir/tests" ]; then \
+			echo "Testing module: $$module_dir"; \
+			cd "$$module_dir"; \
+			terraform init -upgrade -backend=false; \
+			terraform test; \
+			cd - > /dev/null; \
+		fi; \
+	done
+
 .PHONY: terraform-check
-terraform-check: terraform-fmt-check terraform-validate-modules terraform-validate-installations
+terraform-check: terraform-fmt-check terraform-validate-modules terraform-validate-installations terraform-test-modules
 	@echo 'All Terraform checks passed successfully!'

--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -1,12 +1,36 @@
 locals {
   resources = {
-    system     = module.resources.by_platform[var.slurm_nodeset_system.resource.platform][var.slurm_nodeset_system.resource.preset]
-    controller = module.resources.by_platform[var.slurm_nodeset_controller.resource.platform][var.slurm_nodeset_controller.resource.preset]
+    system     = module.resources.by_platform[local.slurm_nodeset_system.resource.platform][local.slurm_nodeset_system.resource.preset]
+    controller = module.resources.by_platform[local.slurm_nodeset_controller.resource.platform][local.slurm_nodeset_controller.resource.preset]
     workers    = [for worker in local.slurm_nodeset_workers : module.resources.by_platform[worker.resource.platform][worker.resource.preset]]
     login      = module.resources.by_platform[var.slurm_nodeset_login.resource.platform][var.slurm_nodeset_login.resource.preset]
-    accounting = var.slurm_nodeset_accounting != null ? module.resources.by_platform[var.slurm_nodeset_accounting.resource.platform][var.slurm_nodeset_accounting.resource.preset] : null
-    nfs        = var.slurm_nodeset_nfs != null ? module.resources.by_platform[var.slurm_nodeset_nfs.resource.platform][var.slurm_nodeset_nfs.resource.preset] : null
+    accounting = local.slurm_nodeset_accounting != null ? module.resources.by_platform[local.slurm_nodeset_accounting.resource.platform][local.slurm_nodeset_accounting.resource.preset] : null
+    nfs        = local.slurm_nodeset_nfs != null ? module.resources.by_platform[local.slurm_nodeset_nfs.resource.platform][local.slurm_nodeset_nfs.resource.preset] : null
   }
+
+  # Resolve CPU nodeset presets from the sizing tier when a preset is not set explicitly,
+  # so a smaller cluster gets smaller controller/accounting/nfs/ system nodes instead of the fixed big-cluster presets.
+  # An explicitly set preset always wins.
+  slurm_nodeset_system = merge(var.slurm_nodeset_system, {
+    resource = merge(var.slurm_nodeset_system.resource, {
+      preset = coalesce(var.slurm_nodeset_system.resource.preset, module.sizing.node_preset.system)
+    })
+  })
+  slurm_nodeset_controller = merge(var.slurm_nodeset_controller, {
+    resource = merge(var.slurm_nodeset_controller.resource, {
+      preset = coalesce(var.slurm_nodeset_controller.resource.preset, module.sizing.node_preset.controller)
+    })
+  })
+  slurm_nodeset_accounting = var.slurm_nodeset_accounting == null ? null : merge(var.slurm_nodeset_accounting, {
+    resource = merge(var.slurm_nodeset_accounting.resource, {
+      preset = coalesce(var.slurm_nodeset_accounting.resource.preset, module.sizing.node_preset.accounting)
+    })
+  })
+  slurm_nodeset_nfs = var.slurm_nodeset_nfs == null ? null : merge(var.slurm_nodeset_nfs, {
+    resource = merge(var.slurm_nodeset_nfs.resource, {
+      preset = coalesce(var.slurm_nodeset_nfs.resource.preset, module.sizing.node_preset.nfs)
+    })
+  })
 
   # keep in sync with helm chart
   # https://github.com/nebius/soperator/blob/main/helm/storageclasses/templates/storageclasses.yaml#L4
@@ -130,6 +154,15 @@ resource "terraform_data" "check_variables" {
     terraform_data.check_jail_submount_paths,
     terraform_data.check_local_nvme,
   ]
+}
+
+# Resolve the sizing tier used to default the CPU nodeset presets above
+# (see modules/sizing_tier).
+module "sizing" {
+  source = "../../modules/sizing_tier"
+
+  worker_count         = length(local.slurm_nodeset_workers) > 0 ? sum([for w in local.slurm_nodeset_workers : w.size]) : 0
+  sizing_tier_override = var.sizing_tier_override
 }
 
 module "filestore" {
@@ -274,8 +307,8 @@ module "k8s" {
   platform_driver_presets      = var.platform_driver_presets
   use_preinstalled_gpu_drivers = var.use_preinstalled_gpu_drivers
 
-  node_group_system     = var.slurm_nodeset_system
-  node_group_controller = var.slurm_nodeset_controller
+  node_group_system     = local.slurm_nodeset_system
+  node_group_controller = local.slurm_nodeset_controller
   node_group_workers    = local.node_group_workers
   node_group_workers_v2 = [
     for worker in local.node_group_workers_v2 : merge(worker, {
@@ -285,11 +318,11 @@ module "k8s" {
   node_group_login = local.login_node_group
   node_group_accounting = {
     enabled = var.accounting_enabled
-    spec    = var.slurm_nodeset_accounting
+    spec    = local.slurm_nodeset_accounting
   }
   node_group_nfs = {
-    enabled = var.slurm_nodeset_nfs != null
-    spec    = var.slurm_nodeset_nfs
+    enabled = local.slurm_nodeset_nfs != null
+    spec    = local.slurm_nodeset_nfs
   }
 
   filestores = {
@@ -414,17 +447,23 @@ module "slurm" {
   controller_state_on_filestore = var.controller_state_on_filestore
 
   node_count = {
-    controller = var.slurm_nodeset_controller.size
+    controller = local.slurm_nodeset_controller.size
     worker     = [for workers in local.slurm_nodeset_workers : workers.size]
     login      = var.slurm_nodeset_login.size
   }
 
-  resources = {
+  # Resolved tier (auto-derived from the worker count unless var.sizing_tier_override forces it).
+  sizing_tier_override = module.sizing.sizing_tier
+  # Per-component overrides on top of the tier (merged inside the module's size dispatch).
+  component_overrides = var.component_overrides
+
+  # Available capacity of the node VMs backing each Slurm nodeset (preset minus k8s reserves).
+  node_capacity = {
     system = {
       cpu_cores        = local.resources.system.cpu_cores
       memory_gibibytes = local.resources.system.memory_gibibytes
       ephemeral_storage_gibibytes = floor(
-        var.slurm_nodeset_system.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
+        local.slurm_nodeset_system.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
         -module.resources.k8s_ephemeral_storage_reserve.gibibytes
       )
     }
@@ -432,7 +471,7 @@ module "slurm" {
       cpu_cores        = local.resources.controller.cpu_cores
       memory_gibibytes = floor(local.resources.controller.memory_gibibytes)
       ephemeral_storage_gibibytes = floor(
-        var.slurm_nodeset_controller.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
+        local.slurm_nodeset_controller.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
         -module.resources.k8s_ephemeral_storage_reserve.gibibytes
       )
     }
@@ -464,19 +503,11 @@ module "slurm" {
       cpu_cores        = local.resources.accounting.cpu_cores
       memory_gibibytes = floor(local.resources.accounting.memory_gibibytes)
       ephemeral_storage_gibibytes = floor(
-        var.slurm_nodeset_accounting.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
+        local.slurm_nodeset_accounting.boot_disk.size_gibibytes * module.resources.k8s_ephemeral_storage_coefficient
         -module.resources.k8s_ephemeral_storage_reserve.gibibytes
       )
     } : null
-    rest              = try(var.system_resources.rest, null)
-    exporter          = try(var.system_resources.exporter, null)
-    mariadb           = try(var.system_resources.mariadb, null)
-    node_configurator = try(var.system_resources.node_configurator, null)
-    slurm_operator    = try(var.system_resources.slurm_operator, null)
-    slurm_checks      = try(var.system_resources.slurm_checks, null)
-    kruise_daemon     = try(var.system_resources.kruise_daemon, null)
-    dcgm_exporter     = try(var.system_resources.dcgm_exporter, null)
-    nfs = var.slurm_nodeset_nfs != null ? {
+    nfs = local.slurm_nodeset_nfs != null ? {
       cpu_cores        = local.resources.nfs.cpu_cores
       memory_gibibytes = floor(local.resources.nfs.memory_gibibytes)
     } : null
@@ -516,7 +547,7 @@ module "slurm" {
     storage_class  = replace("compute-csi-${lower(var.nfs_in_k8s.disk_type)}-${lower(var.nfs_in_k8s.filesystem_type)}", "_", "-")
     threads        = var.nfs_in_k8s.threads
   }
-  nfs_node_group_enabled = var.slurm_nodeset_nfs != null
+  nfs_node_group_enabled = local.slurm_nodeset_nfs != null
 
   exporter_enabled         = var.slurm_exporter_enabled
   rest_enabled             = var.slurm_rest_enabled

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -245,7 +245,7 @@ slurm_nodeset_system = {
   max_size = 24
   resource = {
     platform = "cpu-d3"
-    preset   = "32vcpu-128gb"
+    # preset omitted -> driven by sizing_tier. Set a preset to override.
   }
   boot_disk = {
     type                 = "NETWORK_SSD"
@@ -254,61 +254,20 @@ slurm_nodeset_system = {
   }
 }
 
-# Components that will be deployed on system node groups.
-# Their resources should fit the slurm_nodeset_system.
-# Defaults are for big clusters.
-system_resources = {
-  rest = {
-    cpu_cores                   = 20
-    memory_gibibytes            = 120
-    ephemeral_storage_gibibytes = 5
-  }
-  exporter = {
-    cpu_cores                   = 4
-    memory_gibibytes            = 4
-    ephemeral_storage_gibibytes = 2
-  }
-  mariadb = {
-    cpu_cores                   = 8
-    memory_gibibytes            = 48
-    ephemeral_storage_gibibytes = 32
-  }
-  node_configurator = {
-    requests = {
-      cpu_cores        = 0.5
-      memory_gibibytes = 0.25
-    }
-    limits = {
-      memory_gibibytes = 0.25
-    }
-  }
-  slurm_operator = {
-    requests = {
-      cpu_cores        = 1
-      memory_gibibytes = 4
-    }
-    limits = {
-      memory_gibibytes = 4
-    }
-  }
-  slurm_checks = {
-    requests = {
-      cpu_cores        = 1
-      memory_gibibytes = 4
-    }
-    limits = {
-      memory_gibibytes = 4
-    }
-  }
-  kruise_daemon = {
-    cpu_cores        = 1
-    memory_gibibytes = 4
-  }
-  dcgm_exporter = {
-    cpu_cores        = 0.05
-    memory_gibibytes = 0.5
-  }
-}
+# Sizing tier override. The sizing tier is a single knob that scales all system/observability
+# component resources (kruise, VM stack, SPO, collectors, REST, mariadb, ...) and CPU node
+# presets by cluster size. null (default) auto-derives the tier from the worker node count;
+# set "XS".."XL" to force it.
+# Tier boundaries and per-tier values: soperator/modules/sizing_tier/main.tf.
+sizing_tier_override = null
+
+# Optional per-component overrides ON TOP of the sizing tier (an entry replaces that
+# component's tier value wholesale; unset components keep their tier values). Same shape
+# as the component_presets table referenced above. Example:
+# component_overrides = {
+#   rest      = { cpu = 20, memory = 120, ephemeral_storage = 5 }
+#   vm_single = { cpu = "25000m", memory = "24Gi", size = "512Gi", gomaxprocs = 25 }
+# }
 
 # Configuration of Slurm Controller node set.
 # ---
@@ -316,7 +275,7 @@ slurm_nodeset_controller = {
   size = 1
   resource = {
     platform = "cpu-d3"
-    preset   = "16vcpu-64gb"
+    # preset omitted -> driven by sizing_tier. Set a preset to override.
   }
   boot_disk = {
     type                 = "NETWORK_SSD"
@@ -472,7 +431,7 @@ slurm_nodeset_login = {
 slurm_nodeset_accounting = {
   resource = {
     platform = "cpu-d3"
-    preset   = "32vcpu-128gb"
+    # preset omitted -> driven by sizing_tier. Set a preset to override.
   }
   boot_disk = {
     type                 = "NETWORK_SSD"
@@ -487,7 +446,7 @@ slurm_nodeset_nfs = {
   size = 1
   resource = {
     platform = "cpu-d3"
-    preset   = "128vcpu-512gb"
+    # preset omitted -> driven by sizing_tier. Set a preset to override.
   }
   boot_disk = {
     type                 = "NETWORK_SSD"

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -641,7 +641,7 @@ variable "slurm_nodeset_system" {
     max_size = number
     resource = object({
       platform = string
-      preset   = string
+      preset   = optional(string)
     })
     boot_disk = object({
       type                 = string
@@ -655,7 +655,7 @@ variable "slurm_nodeset_system" {
     max_size = 9
     resource = {
       platform = "cpu-d3"
-      preset   = "16vcpu-64gb"
+      # preset defaults to the sizing tier's node preset (see local.slurm_nodeset_system).
     }
     boot_disk = {
       type                 = "NETWORK_SSD"
@@ -677,60 +677,51 @@ variable "slurm_nodeset_system" {
   }
 }
 
-variable "system_resources" {
-  description = "Resources of system components."
+variable "sizing_tier_override" {
+  description = <<-EOT
+    Force the sizing tier that dispatches system/observability component resources and CPU node presets by scale.
+    One of XS, S, M, L, XL; null (default) auto-derives the tier from the total worker node count.
+    Tier boundaries and per-tier values: soperator/modules/sizing_tier/main.tf.
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.sizing_tier_override == null ? true : contains(["XS", "S", "M", "L", "XL"], var.sizing_tier_override)
+    error_message = "sizing_tier_override must be one of: XS, S, M, L, XL."
+  }
+}
+
+variable "component_overrides" {
+  description = <<-EOT
+    Optional per-component resource overrides applied on top of the sizing tier
+    (an entry replaces that component's tier value wholesale; unset components
+    keep their tier values). Same shape as the component_presets table in
+    soperator/modules/sizing_tier/main.tf. Leave empty to let
+    the sizing tier drive everything.
+  EOT
   type = object({
-    rest = optional(object({
-      cpu_cores                   = number
-      memory_gibibytes            = number
-      ephemeral_storage_gibibytes = number
-    }))
-    exporter = optional(object({
-      cpu_cores                   = number
-      memory_gibibytes            = number
-      ephemeral_storage_gibibytes = number
-    }))
-    mariadb = optional(object({
-      cpu_cores                   = number
-      memory_gibibytes            = number
-      ephemeral_storage_gibibytes = number
-    }))
-    node_configurator = optional(object({
-      requests = object({
-        cpu_cores        = number
-        memory_gibibytes = number
-      })
-      limits = object({
-        memory_gibibytes = number
-      })
-    }))
-    slurm_operator = optional(object({
-      requests = object({
-        cpu_cores        = number
-        memory_gibibytes = number
-      })
-      limits = object({
-        memory_gibibytes = number
-      })
-    }))
-    slurm_checks = optional(object({
-      requests = object({
-        cpu_cores        = number
-        memory_gibibytes = number
-      })
-      limits = object({
-        memory_gibibytes = number
-      })
-    }))
-    kruise_daemon = optional(object({
-      cpu_cores        = number
-      memory_gibibytes = number
-    }))
-    dcgm_exporter = optional(object({
-      cpu_cores        = number
-      memory_gibibytes = number
-    }))
+    exporter                = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    rest                    = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    mariadb                 = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    node_configurator       = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    slurm_operator          = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    slurm_checks            = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    kruise_daemon           = optional(object({ cpu = number, memory = number }))
+    dcgm_exporter           = optional(object({ cpu = number, memory = number }))
+    nfs_server              = optional(object({ cpu = number, memory = number }))
+    spo                     = optional(object({ daemon = object({ cpu = string, memory = string }), controller = object({ cpu = string, memory = string }) }))
+    kruise_manager          = optional(object({ cpu = string, memory = string }))
+    vm_single               = optional(object({ memory = string, cpu = string, size = string, gomaxprocs = number }))
+    vm_agent                = optional(object({ memory = string, cpu = string }))
+    vm_logs                 = optional(object({ memory = string, cpu = string, size = string }))
+    events_collector        = optional(object({ memory = string, cpu = string }))
+    logs_collector          = optional(object({ memory = string, cpu = string }))
+    jail_logs_collector     = optional(object({ memory = string, cpu = string }))
+    nccl_profiles_collector = optional(object({ memory = string, cpu = string }))
   })
+  default  = {}
+  nullable = false
 }
 
 variable "slurm_nodeset_controller" {
@@ -739,7 +730,7 @@ variable "slurm_nodeset_controller" {
     size = number
     resource = object({
       platform = string
-      preset   = string
+      preset   = optional(string)
     })
     boot_disk = object({
       type                 = string
@@ -752,7 +743,7 @@ variable "slurm_nodeset_controller" {
     size = 1
     resource = {
       platform = "cpu-d3"
-      preset   = "16vcpu-64gb"
+      # preset defaults to the sizing tier's node preset (see local.slurm_nodeset_controller).
     }
     boot_disk = {
       type                 = "NETWORK_SSD"
@@ -1138,7 +1129,7 @@ variable "slurm_nodeset_accounting" {
   type = object({
     resource = object({
       platform = string
-      preset   = string
+      preset   = optional(string)
     })
     boot_disk = object({
       type                 = string
@@ -1149,7 +1140,7 @@ variable "slurm_nodeset_accounting" {
   default = {
     resource = {
       platform = "cpu-d3"
-      preset   = "8vcpu-32gb"
+      # preset defaults to the sizing tier's node preset (see local.slurm_nodeset_accounting).
     }
     boot_disk = {
       type                 = "NETWORK_SSD"
@@ -1181,7 +1172,7 @@ variable "slurm_nodeset_nfs" {
     size = number
     resource = object({
       platform = string
-      preset   = string
+      preset   = optional(string)
     })
     boot_disk = object({
       type                 = string
@@ -1203,14 +1194,14 @@ variable "slurm_nodeset_nfs" {
 
 resource "terraform_data" "check_slurm_nodeset" {
   for_each = merge({
-    "system"     = var.slurm_nodeset_system
-    "controller" = var.slurm_nodeset_controller
+    "system"     = local.slurm_nodeset_system
+    "controller" = local.slurm_nodeset_controller
     "login"      = var.slurm_nodeset_login
     }, { for i, worker in var.slurm_nodeset_workers :
     "worker_${i}" => worker
     },
-    var.slurm_nodeset_nfs != null ? {
-      "nfs" = var.slurm_nodeset_nfs
+    local.slurm_nodeset_nfs != null ? {
+      "nfs" = local.slurm_nodeset_nfs
     } : {}
   )
 

--- a/soperator/modules/sizing_tier/main.tf
+++ b/soperator/modules/sizing_tier/main.tf
@@ -1,0 +1,374 @@
+locals {
+  # Sizing tier. Auto-derived from worker_count unless forced via sizing_tier_override.
+  # The bucket boundaries below are the single source of truth for the worker-count -> tier mapping.
+  sizing_tier = coalesce(
+    var.sizing_tier_override,
+    var.worker_count < 10 ? "XS" :
+    var.worker_count < 100 ? "S" :
+    var.worker_count < 500 ? "M" :
+    var.worker_count < 2000 ? "L" : "XL"
+  )
+
+  # Per-component pod resources for the system/observability components that fall over on big clusters.
+  # Keyed component-major (component -> tier -> value) so each component's ramp across tiers is easy to read and tune.
+  # Numeric entries (cpu cores / GiB) feed the SlurmCluster CR; string entries (e.g. "24Gi", "6000m") feed the
+  # soperator-fluxcd Helm values.
+  # Each row states which nodes (nodesets, label slurm.nebius.ai/nodeset) its pods run on; the capacity
+  # invariants against the node presets are computed in the capacity locals below and enforced at plan
+  # time by the precondition on output.capacity_violations.
+  component_presets = {
+    # Runs on: system nodes.
+    exporter = {
+      XS = { cpu = 0.25, memory = 0.25, ephemeral_storage = 0.5 }
+      S  = { cpu = 0.5, memory = 0.5, ephemeral_storage = 0.5 }
+      M  = { cpu = 1, memory = 1, ephemeral_storage = 1 }
+      L  = { cpu = 1, memory = 1, ephemeral_storage = 1 }
+      XL = { cpu = 2, memory = 2, ephemeral_storage = 2 }
+    }
+    # Runs on: system nodes.
+    rest = {
+      XS = { cpu = 2, memory = 8, ephemeral_storage = 0.5 }
+      S  = { cpu = 3, memory = 12, ephemeral_storage = 0.5 }
+      M  = { cpu = 6, memory = 24, ephemeral_storage = 2 }
+      L  = { cpu = 12, memory = 64, ephemeral_storage = 5 }
+      XL = { cpu = 20, memory = 120, ephemeral_storage = 5 }
+    }
+    # Runs on: the accounting node, next to the slurmdbd pod, which is sized from whatever
+    # this preset leaves free (see modules/slurm/main.tf) - keep headroom.
+    mariadb = {
+      # In practice, it uses up to 4GB memory, and almost no CPU, maybe we overprovision here.
+      XS = { cpu = 2, memory = 12, ephemeral_storage = 16 }
+      S  = { cpu = 2, memory = 12, ephemeral_storage = 16 }
+      M  = { cpu = 2, memory = 12, ephemeral_storage = 16 }
+      L  = { cpu = 4, memory = 24, ephemeral_storage = 32 }
+      XL = { cpu = 8, memory = 48, ephemeral_storage = 32 }
+    }
+    # Runs on: every node (DaemonSet).
+    node_configurator = {
+      XS = { requests = { cpu = 0.5, memory = 0.25 }, limits = { memory = 0.25 } }
+      S  = { requests = { cpu = 0.5, memory = 0.25 }, limits = { memory = 0.25 } }
+      M  = { requests = { cpu = 0.5, memory = 0.25 }, limits = { memory = 0.25 } }
+      L  = { requests = { cpu = 0.5, memory = 0.5 }, limits = { memory = 0.5 } }
+      XL = { requests = { cpu = 0.5, memory = 0.5 }, limits = { memory = 0.5 } }
+    }
+    # Runs on: system nodes.
+    slurm_operator = {
+      XS = { requests = { cpu = 1, memory = 2 }, limits = { memory = 2 } }
+      S  = { requests = { cpu = 1, memory = 2 }, limits = { memory = 2 } }
+      M  = { requests = { cpu = 1, memory = 2 }, limits = { memory = 2 } }
+      L  = { requests = { cpu = 1, memory = 3 }, limits = { memory = 3 } }
+      XL = { requests = { cpu = 1, memory = 4 }, limits = { memory = 4 } }
+    }
+    # Runs on: system nodes.
+    slurm_checks = {
+      XS = { requests = { cpu = 0.5, memory = 2 }, limits = { memory = 2 } }
+      S  = { requests = { cpu = 0.5, memory = 2 }, limits = { memory = 2 } }
+      M  = { requests = { cpu = 1, memory = 2 }, limits = { memory = 2 } }
+      L  = { requests = { cpu = 1, memory = 3 }, limits = { memory = 3 } }
+      XL = { requests = { cpu = 1, memory = 4 }, limits = { memory = 4 } }
+    }
+    # Runs on: every node (DaemonSet); subtracted from the worker/login pod sizing in modules/slurm.
+    kruise_daemon = {
+      XS = { cpu = 0.05, memory = 0.128 }
+      S  = { cpu = 0.1, memory = 0.25 }
+      M  = { cpu = 0.25, memory = 0.5 }
+      L  = { cpu = 0.5, memory = 1 }
+      XL = { cpu = 1, memory = 4 }
+    }
+    # Runs on: GPU worker nodes (DaemonSet).
+    dcgm_exporter = {
+      XS = { cpu = 0.05, memory = 0.5 }
+      S  = { cpu = 0.05, memory = 0.5 }
+      M  = { cpu = 0.05, memory = 0.5 }
+      L  = { cpu = 0.05, memory = 0.5 }
+      XL = { cpu = 0.05, memory = 0.5 }
+    }
+    # Runs on: system nodes, and only for in-k8s NFS without a dedicated nfs nodeset
+    # (with a nodeset, the pod is sized from that node's capacity instead).
+    nfs_server = {
+      XS = { cpu = 1, memory = 1 }
+      S  = { cpu = 1, memory = 1 }
+      M  = { cpu = 1, memory = 2 }
+      L  = { cpu = 2, memory = 4 }
+      XL = { cpu = 2, memory = 4 }
+    }
+    # Runs on: daemon on every node (DaemonSet), controller on system nodes.
+    spo = {
+      XS = { daemon = { cpu = "100m", memory = "128Mi" }, controller = { cpu = "500m", memory = "3Gi" } }
+      S  = { daemon = { cpu = "100m", memory = "128Mi" }, controller = { cpu = "500m", memory = "3Gi" } }
+      M  = { daemon = { cpu = "100m", memory = "128Mi" }, controller = { cpu = "500m", memory = "3Gi" } }
+      L  = { daemon = { cpu = "150m", memory = "256Mi" }, controller = { cpu = "750m", memory = "4Gi" } }
+      XL = { daemon = { cpu = "200m", memory = "512Mi" }, controller = { cpu = "1000m", memory = "6Gi" } }
+    }
+    # Runs on: system nodes.
+    kruise_manager = {
+      XS = { cpu = "1", memory = "2Gi" }
+      S  = { cpu = "1", memory = "2Gi" }
+      M  = { cpu = "2", memory = "4Gi" }
+      L  = { cpu = "3", memory = "8Gi" }
+      XL = { cpu = "8", memory = "16Gi" }
+    }
+    # Runs on: system nodes.
+    vm_single = {
+      XS = { memory = "24Gi", cpu = "6000m", size = "512Gi", gomaxprocs = 6 }
+      S  = { memory = "24Gi", cpu = "6000m", size = "512Gi", gomaxprocs = 6 }
+      M  = { memory = "24Gi", cpu = "8000m", size = "512Gi", gomaxprocs = 8 }
+      L  = { memory = "24Gi", cpu = "12000m", size = "512Gi", gomaxprocs = 12 }
+      XL = { memory = "24Gi", cpu = "25000m", size = "512Gi", gomaxprocs = 25 }
+    }
+    # Runs on: system nodes.
+    vm_agent = {
+      XS = { memory = "10Gi", cpu = "5000m" }
+      S  = { memory = "10Gi", cpu = "5000m" }
+      M  = { memory = "12Gi", cpu = "6000m" }
+      L  = { memory = "16Gi", cpu = "8000m" }
+      XL = { memory = "25Gi", cpu = "12000m" }
+    }
+    # Runs on: system nodes.
+    vm_logs = {
+      XS = { memory = "2Gi", cpu = "1000m", size = "256Gi" }
+      S  = { memory = "2Gi", cpu = "1000m", size = "256Gi" }
+      M  = { memory = "4Gi", cpu = "1000m", size = "256Gi" }
+      L  = { memory = "4Gi", cpu = "2000m", size = "512Gi" }
+      XL = { memory = "8Gi", cpu = "4000m", size = "512Gi" }
+    }
+    # Runs on: system nodes.
+    events_collector = {
+      XS = { memory = "128Mi", cpu = "100m" }
+      S  = { memory = "128Mi", cpu = "100m" }
+      M  = { memory = "256Mi", cpu = "150m" }
+      L  = { memory = "256Mi", cpu = "250m" }
+      XL = { memory = "512Mi", cpu = "500m" }
+    }
+    # Runs on: every node (DaemonSet).
+    logs_collector = {
+      XS = { memory = "200Mi", cpu = "200m" }
+      S  = { memory = "200Mi", cpu = "200m" }
+      M  = { memory = "256Mi", cpu = "250m" }
+      L  = { memory = "384Mi", cpu = "400m" }
+      XL = { memory = "512Mi", cpu = "750m" }
+    }
+    # Runs on: system nodes.
+    jail_logs_collector = {
+      XS = { memory = "1Gi", cpu = "1000m" }
+      S  = { memory = "1Gi", cpu = "1000m" }
+      M  = { memory = "1Gi", cpu = "1000m" }
+      L  = { memory = "2Gi", cpu = "2000m" }
+      XL = { memory = "4Gi", cpu = "4000m" }
+    }
+    # Runs on: system nodes.
+    nccl_profiles_collector = {
+      XS = { memory = "200Mi", cpu = "500m" }
+      S  = { memory = "200Mi", cpu = "500m" }
+      M  = { memory = "200Mi", cpu = "500m" }
+      L  = { memory = "256Mi", cpu = "500m" }
+      XL = { memory = "512Mi", cpu = "1000m" }
+    }
+  }
+
+  # Node VM presets (cpu-d3) for the single-pod-per-node CPU nodesets, whose pod size == node size.
+  # Values must be valid cpu-d3 presets from modules/available_resources.
+  node_presets = {
+    controller = {
+      XS = "16vcpu-64gb"
+      S  = "16vcpu-64gb"
+      M  = "16vcpu-64gb"
+      L  = "16vcpu-64gb"
+      XL = "16vcpu-64gb"
+    }
+    accounting = {
+      XS = "8vcpu-32gb"
+      S  = "8vcpu-32gb"
+      M  = "8vcpu-32gb"
+      L  = "16vcpu-64gb"
+      XL = "32vcpu-128gb"
+    }
+    nfs = {
+      XS = "32vcpu-128gb"
+      S  = "32vcpu-128gb"
+      M  = "32vcpu-128gb"
+      L  = "64vcpu-256gb"
+      XL = "128vcpu-512gb"
+    }
+    system = {
+      XS = "16vcpu-64gb"
+      S  = "16vcpu-64gb"
+      M  = "16vcpu-64gb"
+      L  = "32vcpu-128gb"
+      XL = "64vcpu-256gb"
+    }
+  }
+
+  # Effective per-component resources: an explicit component_overrides entry replaces the tier value wholesale;
+  # everything else takes the resolved tier's column.
+  preset = {
+    exporter                = coalesce(var.component_overrides.exporter, local.component_presets.exporter[local.sizing_tier])
+    rest                    = coalesce(var.component_overrides.rest, local.component_presets.rest[local.sizing_tier])
+    mariadb                 = coalesce(var.component_overrides.mariadb, local.component_presets.mariadb[local.sizing_tier])
+    node_configurator       = coalesce(var.component_overrides.node_configurator, local.component_presets.node_configurator[local.sizing_tier])
+    slurm_operator          = coalesce(var.component_overrides.slurm_operator, local.component_presets.slurm_operator[local.sizing_tier])
+    slurm_checks            = coalesce(var.component_overrides.slurm_checks, local.component_presets.slurm_checks[local.sizing_tier])
+    kruise_daemon           = coalesce(var.component_overrides.kruise_daemon, local.component_presets.kruise_daemon[local.sizing_tier])
+    dcgm_exporter           = coalesce(var.component_overrides.dcgm_exporter, local.component_presets.dcgm_exporter[local.sizing_tier])
+    nfs_server              = coalesce(var.component_overrides.nfs_server, local.component_presets.nfs_server[local.sizing_tier])
+    spo                     = coalesce(var.component_overrides.spo, local.component_presets.spo[local.sizing_tier])
+    kruise_manager          = coalesce(var.component_overrides.kruise_manager, local.component_presets.kruise_manager[local.sizing_tier])
+    vm_single               = coalesce(var.component_overrides.vm_single, local.component_presets.vm_single[local.sizing_tier])
+    vm_agent                = coalesce(var.component_overrides.vm_agent, local.component_presets.vm_agent[local.sizing_tier])
+    vm_logs                 = coalesce(var.component_overrides.vm_logs, local.component_presets.vm_logs[local.sizing_tier])
+    events_collector        = coalesce(var.component_overrides.events_collector, local.component_presets.events_collector[local.sizing_tier])
+    logs_collector          = coalesce(var.component_overrides.logs_collector, local.component_presets.logs_collector[local.sizing_tier])
+    jail_logs_collector     = coalesce(var.component_overrides.jail_logs_collector, local.component_presets.jail_logs_collector[local.sizing_tier])
+    nccl_profiles_collector = coalesce(var.component_overrides.nccl_profiles_collector, local.component_presets.nccl_profiles_collector[local.sizing_tier])
+  }
+
+  # Node VM preset per CPU nodeset for the resolved tier
+  # (overridden per nodeset by the caller via the nodeset's own `preset` field).
+  node_preset = {
+    system     = local.node_presets.system[local.sizing_tier]
+    controller = local.node_presets.controller[local.sizing_tier]
+    accounting = local.node_presets.accounting[local.sizing_tier]
+    nfs        = local.node_presets.nfs[local.sizing_tier]
+  }
+}
+
+# Capacity guard: the tier presets must fit the nodes they are placed on.
+# All of this is static table math, so a plan of any installation fails (via the precondition on output.capacity_violations)
+# as soon as a table edit breaks an invariant in any tier.
+
+# Preset -> allocatable capacity facts. The same source the installations use to size nodeset pods,
+# so the guard sees what the scheduler will actually see.
+module "node_resources" {
+  source = "../available_resources"
+}
+
+locals {
+  tiers = keys(local.node_presets.system)
+
+  # Allocatable capacity (cores / GiB) of each tier's node presets: the preset size minus
+  # the k8s/system reserves, per modules/available_resources. A preset string that does not
+  # exist for the cpu-d3 platform fails the lookup at plan time.
+  node_capacity_of = {
+    for nodeset, by_tier in local.node_presets : nodeset => {
+      for tier, preset in by_tier : tier => {
+        cpu    = module.node_resources.by_platform["cpu-d3"][preset].cpu_cores
+        memory = module.node_resources.by_platform["cpu-d3"][preset].memory_gibibytes
+      }
+    }
+  }
+
+  # Requests of the system-bound singletons, normalized to cores / GiB.
+  # (Flux, cert-manager and the operators also live on system nodes but are small,
+  # constant and not tier-driven, so they are not modeled here.)
+  system_pod_requests = {
+    for tier in local.tiers : tier => {
+      exporter = {
+        cpu    = local.component_presets.exporter[tier].cpu
+        memory = local.component_presets.exporter[tier].memory
+      }
+      rest = {
+        cpu    = local.component_presets.rest[tier].cpu
+        memory = local.component_presets.rest[tier].memory
+      }
+      slurm_operator = {
+        cpu    = local.component_presets.slurm_operator[tier].requests.cpu
+        memory = local.component_presets.slurm_operator[tier].requests.memory
+      }
+      slurm_checks = {
+        cpu    = local.component_presets.slurm_checks[tier].requests.cpu
+        memory = local.component_presets.slurm_checks[tier].requests.memory
+      }
+      nfs_server = {
+        cpu    = local.component_presets.nfs_server[tier].cpu
+        memory = local.component_presets.nfs_server[tier].memory
+      }
+      spo_controller = {
+        cpu    = tonumber(trimsuffix(local.component_presets.spo[tier].controller.cpu, "m")) / 1000
+        memory = tonumber(trimsuffix(local.component_presets.spo[tier].controller.memory, "Gi"))
+      }
+      kruise_manager = {
+        cpu    = tonumber(local.component_presets.kruise_manager[tier].cpu)
+        memory = tonumber(trimsuffix(local.component_presets.kruise_manager[tier].memory, "Gi"))
+      }
+      vm_single = {
+        cpu    = tonumber(trimsuffix(local.component_presets.vm_single[tier].cpu, "m")) / 1000
+        memory = tonumber(trimsuffix(local.component_presets.vm_single[tier].memory, "Gi"))
+      }
+      vm_agent = {
+        cpu    = tonumber(trimsuffix(local.component_presets.vm_agent[tier].cpu, "m")) / 1000
+        memory = tonumber(trimsuffix(local.component_presets.vm_agent[tier].memory, "Gi"))
+      }
+      vm_logs = {
+        cpu    = tonumber(trimsuffix(local.component_presets.vm_logs[tier].cpu, "m")) / 1000
+        memory = tonumber(trimsuffix(local.component_presets.vm_logs[tier].memory, "Gi"))
+      }
+      events_collector = {
+        cpu    = tonumber(trimsuffix(local.component_presets.events_collector[tier].cpu, "m")) / 1000
+        memory = tonumber(trimsuffix(local.component_presets.events_collector[tier].memory, "Mi")) / 1024
+      }
+      jail_logs_collector = {
+        cpu    = tonumber(trimsuffix(local.component_presets.jail_logs_collector[tier].cpu, "m")) / 1000
+        memory = tonumber(trimsuffix(local.component_presets.jail_logs_collector[tier].memory, "Gi"))
+      }
+      nccl_profiles_collector = {
+        cpu    = tonumber(trimsuffix(local.component_presets.nccl_profiles_collector[tier].cpu, "m")) / 1000
+        memory = tonumber(trimsuffix(local.component_presets.nccl_profiles_collector[tier].memory, "Mi")) / 1024
+      }
+    }
+  }
+
+  # Per-node DaemonSet agents: they occupy every node, including each system node.
+  daemonset_requests = {
+    for tier in local.tiers : tier => {
+      cpu = (
+        local.component_presets.node_configurator[tier].requests.cpu
+        + local.component_presets.kruise_daemon[tier].cpu
+        + tonumber(trimsuffix(local.component_presets.spo[tier].daemon.cpu, "m")) / 1000
+        + tonumber(trimsuffix(local.component_presets.logs_collector[tier].cpu, "m")) / 1000
+      )
+      memory = (
+        local.component_presets.node_configurator[tier].requests.memory
+        + local.component_presets.kruise_daemon[tier].memory
+        + tonumber(trimsuffix(local.component_presets.spo[tier].daemon.memory, "Mi")) / 1024
+        + tonumber(trimsuffix(local.component_presets.logs_collector[tier].memory, "Mi")) / 1024
+      )
+    }
+  }
+
+  # Broken capacity invariants. Each produces a self-explaining message (tier, component, numbers, node),
+  # surfaced by the precondition on output.capacity_violations and by the module tests.
+  capacity_violations = flatten([
+    for tier in local.tiers : concat(
+      # Every system-bound singleton must fit on one system node next to the DaemonSet
+      # agents: a pod larger than the node can never schedule - autoscaling cannot help.
+      [
+        for name, req in local.system_pod_requests[tier] :
+        "${tier}/${name}: ${req.cpu} cpu + ${format("%.4g", local.daemonset_requests[tier].cpu)} DaemonSet cpu > ${local.node_capacity_of.system[tier].cpu} allocatable cores on a ${local.node_presets.system[tier]} system node"
+        if req.cpu + local.daemonset_requests[tier].cpu > local.node_capacity_of.system[tier].cpu
+      ],
+      [
+        for name, req in local.system_pod_requests[tier] :
+        "${tier}/${name}: ${req.memory}Gi + ${format("%.4g", local.daemonset_requests[tier].memory)}Gi DaemonSet memory > ${format("%.4g", local.node_capacity_of.system[tier].memory)}Gi allocatable on a ${local.node_presets.system[tier]} system node"
+        if req.memory + local.daemonset_requests[tier].memory > local.node_capacity_of.system[tier].memory
+      ],
+      # mariadb must leave the accounting node room for munge (1 cpu / 1 GiB) and a useful
+      # slurmdbd pod, which is sized from the remainder - hence 2 cores / 4 GiB of headroom.
+      local.component_presets.mariadb[tier].cpu + 2 <= local.node_capacity_of.accounting[tier].cpu ? [] : [
+        "${tier}/mariadb: ${local.component_presets.mariadb[tier].cpu} cpu + 2 headroom (munge+slurmdbd) > ${local.node_capacity_of.accounting[tier].cpu} allocatable cores on a ${local.node_presets.accounting[tier]} accounting node"
+      ],
+      local.component_presets.mariadb[tier].memory + 4 <= local.node_capacity_of.accounting[tier].memory ? [] : [
+        "${tier}/mariadb: ${local.component_presets.mariadb[tier].memory}Gi + 4Gi headroom (munge+slurmdbd) > ${local.node_capacity_of.accounting[tier].memory}Gi allocatable on a ${local.node_presets.accounting[tier]} accounting node"
+      ],
+    )
+  ])
+
+  # Minimum system node count for the resolved tier (informative: compare with the system
+  # nodeset's min_size). Approximation: bin-packing slack and the non-tier-driven residents
+  # (flux, cert-manager, operators) are not modeled.
+  system_nodes_needed = ceil(max(
+    sum([for req in values(local.system_pod_requests[local.sizing_tier]) : req.cpu])
+    / (local.node_capacity_of.system[local.sizing_tier].cpu - local.daemonset_requests[local.sizing_tier].cpu),
+    sum([for req in values(local.system_pod_requests[local.sizing_tier]) : req.memory])
+    / (local.node_capacity_of.system[local.sizing_tier].memory - local.daemonset_requests[local.sizing_tier].memory),
+  ))
+}

--- a/soperator/modules/sizing_tier/outputs.tf
+++ b/soperator/modules/sizing_tier/outputs.tf
@@ -1,0 +1,46 @@
+output "sizing_tier" {
+  description = "The resolved sizing tier (XS..XL)."
+  value       = local.sizing_tier
+}
+
+output "preset" {
+  description = "Effective per-component pod resources: the resolved tier's column with component_overrides applied."
+  value       = local.preset
+}
+
+output "node_preset" {
+  description = "Node VM preset per CPU nodeset for the resolved tier (controller/accounting/nfs/system -> preset string)."
+  value       = local.node_preset
+}
+
+output "all_component_presets" {
+  description = "The full component-major pod-resource table (component -> tier -> resources)."
+  value       = local.component_presets
+}
+
+output "all_node_presets" {
+  description = "The full component-major node-preset table (nodeset -> tier -> preset string)."
+  value       = local.node_presets
+}
+
+output "capacity_violations" {
+  description = <<-EOT
+    Broken capacity invariants, one self-explaining message each (see the capacity locals in main.tf).
+    Empty when every tier's component presets fit their nodes; the precondition makes any table edit
+    that breaks an invariant a plan-time error.
+  EOT
+  value       = local.capacity_violations
+
+  precondition {
+    condition     = length(local.capacity_violations) == 0
+    error_message = "Sizing-tier presets no longer fit their nodes. Fix the tables in modules/sizing_tier/main.tf:\n  - ${join("\n  - ", local.capacity_violations)}"
+  }
+}
+
+output "system_nodes_needed" {
+  description = <<-EOT
+    Minimum system node count needed to hold the resolved tier's system-bound components
+    (approximate; compare with the system nodeset's min_size).
+  EOT
+  value       = local.system_nodes_needed
+}

--- a/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
+++ b/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
@@ -1,0 +1,247 @@
+# Unit tests for the cluster-size dispatch.
+# Pure module, no providers: run with `terraform test` from this module dir:
+#   cd soperator/modules/sizing_tier && terraform init && terraform test
+
+# Derivation boundaries.
+
+run "zero_workers_is_xs" {
+  command = apply
+  variables { worker_count = 0 }
+  assert {
+    condition     = output.sizing_tier == "XS"
+    error_message = "0 workers must derive XS, got ${output.sizing_tier}"
+  }
+}
+
+run "one_worker_is_xs" {
+  command = apply
+  variables { worker_count = 1 }
+  assert {
+    condition     = output.sizing_tier == "XS"
+    error_message = "1 worker must derive XS, got ${output.sizing_tier}"
+  }
+}
+
+run "nine_workers_is_xs" {
+  command = apply
+  variables { worker_count = 9 }
+  assert {
+    condition     = output.sizing_tier == "XS"
+    error_message = "9 workers must derive XS, got ${output.sizing_tier}"
+  }
+}
+
+run "ten_workers_is_s" {
+  command = apply
+  variables { worker_count = 10 }
+  assert {
+    condition     = output.sizing_tier == "S"
+    error_message = "10 workers must derive S, got ${output.sizing_tier}"
+  }
+}
+
+run "ninety_nine_workers_is_s" {
+  command = apply
+  variables { worker_count = 99 }
+  assert {
+    condition     = output.sizing_tier == "S"
+    error_message = "99 workers must derive S, got ${output.sizing_tier}"
+  }
+}
+
+run "hundred_workers_is_m" {
+  command = apply
+  variables { worker_count = 100 }
+  assert {
+    condition     = output.sizing_tier == "M"
+    error_message = "100 workers must derive M, got ${output.sizing_tier}"
+  }
+  assert {
+    condition     = output.node_preset.controller == "16vcpu-64gb" && output.node_preset.accounting == "8vcpu-32gb" && output.node_preset.nfs == "32vcpu-128gb"
+    error_message = "M node presets must be the mid-size presets"
+  }
+}
+
+run "four_ninety_nine_workers_is_m" {
+  command = apply
+  variables { worker_count = 499 }
+  assert {
+    condition     = output.sizing_tier == "M"
+    error_message = "499 workers must derive M, got ${output.sizing_tier}"
+  }
+}
+
+run "five_hundred_workers_is_l" {
+  command = apply
+  variables { worker_count = 500 }
+  assert {
+    condition     = output.sizing_tier == "L"
+    error_message = "500 workers must derive L, got ${output.sizing_tier}"
+  }
+}
+
+run "nineteen_ninety_nine_workers_is_l" {
+  command = apply
+  variables { worker_count = 1999 }
+  assert {
+    condition     = output.sizing_tier == "L"
+    error_message = "1999 workers must derive L, got ${output.sizing_tier}"
+  }
+}
+
+run "two_thousand_workers_is_xl" {
+  command = apply
+  variables { worker_count = 2000 }
+  assert {
+    condition     = output.sizing_tier == "XL"
+    error_message = "2000 workers must derive XL, got ${output.sizing_tier}"
+  }
+}
+
+run "xl_is_open_ended" {
+  command = apply
+  variables { worker_count = 5000 }
+  assert {
+    condition     = output.sizing_tier == "XL"
+    error_message = "5000 workers must derive XL (top tier, no upper bound), got ${output.sizing_tier}"
+  }
+}
+
+# Override precedence.
+
+run "override_forces_tier" {
+  command = apply
+  variables {
+    worker_count         = 6 # would derive XS
+    sizing_tier_override = "XL"
+  }
+  assert {
+    condition     = output.sizing_tier == "XL"
+    error_message = "sizing_tier_override must win over the derived tier"
+  }
+  assert {
+    condition     = output.preset.rest.cpu == 20
+    error_message = "forced XL must expose the XL rest preset"
+  }
+  assert {
+    condition     = output.node_preset.system == "64vcpu-256gb" && output.node_preset.nfs == "128vcpu-512gb"
+    error_message = "forced XL must expose the XL node presets"
+  }
+}
+
+run "component_override_wins_over_tier" {
+  command = apply
+  variables {
+    worker_count = 5 # derives XS
+    component_overrides = {
+      rest      = { cpu = 20, memory = 120, ephemeral_storage = 5 }
+      vm_single = { cpu = "25000m", memory = "24Gi", size = "512Gi", gomaxprocs = 25 }
+    }
+  }
+  assert {
+    condition     = output.preset.rest.cpu == 20 && output.preset.rest.memory == 120
+    error_message = "component_overrides.rest must replace the XS tier value"
+  }
+  assert {
+    condition     = output.preset.vm_single.cpu == "25000m" && output.preset.vm_single.gomaxprocs == 25
+    error_message = "component_overrides.vm_single must replace the XS tier value"
+  }
+  assert {
+    condition     = output.preset.mariadb.memory == 12
+    error_message = "components without an override must keep their tier (XS) values"
+  }
+}
+
+# Back-compat: XS == legacy defaults.
+
+run "xs_matches_legacy_defaults" {
+  command = apply
+  variables { worker_count = 5 }
+  assert {
+    condition     = output.sizing_tier == "XS"
+    error_message = "5 workers must derive XS"
+  }
+  assert {
+    condition     = output.preset.rest.cpu == 2 && output.preset.rest.memory == 8
+    error_message = "XS rest must equal the legacy default 2cpu/8Gi"
+  }
+  assert {
+    condition     = output.preset.mariadb.memory == 12
+    error_message = "XS mariadb memory must equal the legacy default 12Gi"
+  }
+  assert {
+    condition     = output.preset.vm_single.cpu == "6000m" && output.preset.vm_single.gomaxprocs == 6
+    error_message = "XS vm_single must equal the legacy default 6000m / gomaxprocs 6"
+  }
+  assert {
+    condition     = output.preset.vm_agent.memory == "10Gi" && output.preset.vm_agent.cpu == "5000m"
+    error_message = "XS vm_agent must equal the legacy default 10Gi / 5000m"
+  }
+  assert {
+    condition     = output.preset.events_collector.memory == "128Mi"
+    error_message = "XS events_collector must equal the legacy default 128Mi"
+  }
+  assert {
+    condition     = output.preset.spo.controller.memory == "3Gi" && output.preset.spo.daemon.memory == "128Mi"
+    error_message = "XS SPO must equal the legacy default 3Gi controller / 128Mi daemon"
+  }
+  assert {
+    condition     = output.node_preset.controller == "16vcpu-64gb" && output.node_preset.accounting == "8vcpu-32gb"
+    error_message = "XS node presets must be the small-cluster presets"
+  }
+}
+
+# Capacity: presets must fit the nodes they are placed on, in every tier.
+
+run "capacity_fits_all_tiers" {
+  command = apply
+  variables { worker_count = 5 }
+  assert {
+    condition     = length(output.capacity_violations) == 0
+    error_message = "presets no longer fit their nodes: ${join("; ", output.capacity_violations)}"
+  }
+  assert {
+    condition     = output.system_nodes_needed >= 1
+    error_message = "system_nodes_needed must be at least 1"
+  }
+}
+
+run "xl_system_pods_need_few_nodes" {
+  command = apply
+  variables { worker_count = 6000 }
+  assert {
+    # The XL column is the fattest: its system-bound singletons must still pack
+    # into a handful of system nodes (the example ships min_size = 3).
+    condition     = output.system_nodes_needed <= 3
+    error_message = "XL system-bound components need ${output.system_nodes_needed} system nodes; expected <= 3 - retune the table or the system node preset"
+  }
+}
+
+# Top-end PoC anchors.
+
+run "xl_matches_poc_numbers" {
+  command = apply
+  variables { worker_count = 6000 }
+  assert {
+    condition     = output.preset.rest.cpu == 20 && output.preset.rest.memory == 120
+    error_message = "XL rest must be the 20cpu/120Gi PoC value"
+  }
+  assert {
+    condition     = output.preset.vm_single.cpu == "25000m" && output.preset.vm_single.gomaxprocs == 25
+    error_message = "XL vm_single must be 25000m / gomaxprocs 25"
+  }
+  assert {
+    condition     = output.preset.vm_agent.memory == "25Gi" && output.preset.vm_agent.cpu == "12000m"
+    error_message = "XL vm_agent must be 25Gi / 12000m"
+  }
+  assert {
+    condition     = output.preset.mariadb.memory == 48
+    error_message = "XL mariadb memory must be 48Gi"
+  }
+  assert {
+    # The controller intentionally does NOT grow with the tier: the PoC showed
+    # no benefit from larger controller presets even at 5k workers.
+    condition     = output.node_preset.controller == "16vcpu-64gb" && output.node_preset.accounting == "32vcpu-128gb" && output.node_preset.nfs == "128vcpu-512gb"
+    error_message = "XL node presets must be the big-cluster presets (controller stays 16vcpu-64gb)"
+  }
+}

--- a/soperator/modules/sizing_tier/variables.tf
+++ b/soperator/modules/sizing_tier/variables.tf
@@ -1,0 +1,54 @@
+# Pure (provider-free) cluster-size dispatch for soperator.
+# Derives an XS..XL tier from the worker node count and returns the per-component resource preset for that tier.
+
+variable "worker_count" {
+  description = "Total declared worker node count across all worker nodesets."
+  type        = number
+  nullable    = false
+
+  validation {
+    condition     = var.worker_count >= 0
+    error_message = "worker_count must be >= 0."
+  }
+}
+
+variable "sizing_tier_override" {
+  description = "Force a specific tier (XS..XL); null auto-derives from worker_count."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.sizing_tier_override == null ? true : contains(["XS", "S", "M", "L", "XL"], var.sizing_tier_override)
+    error_message = "sizing_tier_override must be one of: XS, S, M, L, XL."
+  }
+}
+
+variable "component_overrides" {
+  description = <<-EOT
+    Optional per-component resource overrides. Each entry replaces the resolved tier's value
+    for that component wholesale and uses exactly the same shape as the component_presets table in main.tf.
+    Components left unset keep their tier values.
+  EOT
+  type = object({
+    exporter                = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    rest                    = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    mariadb                 = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    node_configurator       = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    slurm_operator          = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    slurm_checks            = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    kruise_daemon           = optional(object({ cpu = number, memory = number }))
+    dcgm_exporter           = optional(object({ cpu = number, memory = number }))
+    nfs_server              = optional(object({ cpu = number, memory = number }))
+    spo                     = optional(object({ daemon = object({ cpu = string, memory = string }), controller = object({ cpu = string, memory = string }) }))
+    kruise_manager          = optional(object({ cpu = string, memory = string }))
+    vm_single               = optional(object({ memory = string, cpu = string, size = string, gomaxprocs = number }))
+    vm_agent                = optional(object({ memory = string, cpu = string }))
+    vm_logs                 = optional(object({ memory = string, cpu = string, size = string }))
+    events_collector        = optional(object({ memory = string, cpu = string }))
+    logs_collector          = optional(object({ memory = string, cpu = string }))
+    jail_logs_collector     = optional(object({ memory = string, cpu = string }))
+    nccl_profiles_collector = optional(object({ memory = string, cpu = string }))
+  })
+  default  = {}
+  nullable = false
+}

--- a/soperator/modules/slurm/flux_release_nodesets.tf
+++ b/soperator/modules/slurm/flux_release_nodesets.tf
@@ -8,7 +8,7 @@ resource "local_file" "flux_release_rendered_nodesets" {
     cluster_name = var.name
 
     nodesets = var.worker_nodesets
-    resources = [for res in var.resources.worker : {
+    resources = [for res in var.node_capacity.worker : {
       cpu_cores = floor(
         res.cpu_cores
         -local.resources.munge.cpu

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -49,7 +49,7 @@ locals {
 
   active_checks_on_worker_nodes = local.gb300_enabled
 
-  soperator_active_checks_gpu_counts = distinct([for worker in var.resources.worker : worker.gpus if worker.gpus > 0])
+  soperator_active_checks_gpu_counts = distinct([for worker in var.node_capacity.worker : worker.gpus if worker.gpus > 0])
   // We don't support heterogenous clusters with mixed number of GPUs (or basically GB series mixed with the rest) yet.
   // So taking the first GPU count is fine for now.
   soperator_active_checks_gpus_per_node = length(local.soperator_active_checks_gpu_counts) == 1 ? tostring(local.soperator_active_checks_gpu_counts[0]) : null
@@ -78,7 +78,7 @@ locals {
     worker = {
       name        = module.labels.name_nodeset_worker
       matches     = [module.labels.name_nodeset_worker]
-      gpu_present = length([for i in range(length(var.node_count.worker)) : var.resources.worker[i].gpus]) > 0
+      gpu_present = length([for i in range(length(var.node_count.worker)) : var.node_capacity.worker[i].gpus]) > 0
     }
     login = {
       name  = module.labels.name_nodeset_login
@@ -115,63 +115,27 @@ locals {
       memory            = 0.5
       ephemeral_storage = 5
     }
-    exporter = {
-      cpu               = var.resources.exporter != null ? var.resources.exporter.cpu_cores : 0.25
-      memory            = var.resources.exporter != null ? var.resources.exporter.memory_gibibytes : 0.25
-      ephemeral_storage = var.resources.exporter != null ? var.resources.exporter.ephemeral_storage_gibibytes : 0.5
-    }
-    rest = {
-      cpu               = var.resources.rest != null ? var.resources.rest.cpu_cores : 2
-      memory            = var.resources.rest != null ? var.resources.rest.memory_gibibytes : 8
-      ephemeral_storage = var.resources.rest != null ? var.resources.rest.ephemeral_storage_gibibytes : 0.5
-    }
-    mariadb = {
-      cpu               = var.resources.mariadb != null ? var.resources.mariadb.cpu_cores : 2
-      memory            = var.resources.mariadb != null ? var.resources.mariadb.memory_gibibytes : 12
-      ephemeral_storage = var.resources.mariadb != null ? var.resources.mariadb.ephemeral_storage_gibibytes : 16
-    }
-    node_configurator = {
-      limits = {
-        memory = var.resources.node_configurator != null ? var.resources.node_configurator.limits.memory_gibibytes : 0.25
-      }
-      requests = {
-        memory = var.resources.node_configurator != null ? var.resources.node_configurator.requests.memory_gibibytes : 0.25
-        cpu    = var.resources.node_configurator != null ? var.resources.node_configurator.requests.cpu_cores : 0.5
-      }
-    }
-    slurm_operator = {
-      limits = {
-        memory = var.resources.slurm_operator != null ? var.resources.slurm_operator.limits.memory_gibibytes : 2
-      }
-      requests = {
-        memory = var.resources.slurm_operator != null ? var.resources.slurm_operator.requests.memory_gibibytes : 2
-        cpu    = var.resources.slurm_operator != null ? var.resources.slurm_operator.requests.cpu_cores : 1
-      }
-    }
-    slurm_checks = {
-      limits = {
-        memory = var.resources.slurm_checks != null ? var.resources.slurm_checks.limits.memory_gibibytes : 2
-      }
-      requests = {
-        memory = var.resources.slurm_checks != null ? var.resources.slurm_checks.requests.memory_gibibytes : 2
-        cpu    = var.resources.slurm_checks != null ? var.resources.slurm_checks.requests.cpu_cores : 0.5
-      }
-    }
-    kruise_daemon = {
-      cpu    = var.resources.kruise_daemon != null ? var.resources.kruise_daemon.cpu_cores : 0.05
-      memory = var.resources.kruise_daemon != null ? var.resources.kruise_daemon.memory_gibibytes : 0.128
-    }
-    dcgm_exporter = {
-      cpu    = var.resources.dcgm_exporter != null ? var.resources.dcgm_exporter.cpu_cores : 0.05
-      memory = var.resources.dcgm_exporter != null ? var.resources.dcgm_exporter.memory_gibibytes : 0.5
-    }
+    # System/observability components are sized by the sizing tier,
+    # with per-component overrides merged inside ../sizing_tier (see var.component_overrides).
+    # local.selected_preset is the post-merge result.
+    exporter          = local.selected_preset.exporter
+    rest              = local.selected_preset.rest
+    mariadb           = local.selected_preset.mariadb
+    node_configurator = local.selected_preset.node_configurator
+    slurm_operator    = local.selected_preset.slurm_operator
+    slurm_checks      = local.selected_preset.slurm_checks
+    kruise_daemon     = local.selected_preset.kruise_daemon
+    dcgm_exporter     = local.selected_preset.dcgm_exporter
+    spo               = local.selected_preset.spo
+    # The NFS server pod fills its dedicated node, so when an NFS nodeset exists
+    # its node capacity (var.node_capacity.nfs) wins over the tier value.
     nfs_server = {
       limits = {
-        memory = var.resources.nfs != null ? var.resources.nfs.memory_gibibytes : 1
+        memory = var.node_capacity.nfs != null ? var.node_capacity.nfs.memory_gibibytes : local.selected_preset.nfs_server.memory
       }
       requests = {
-        memory = var.resources.nfs != null ? var.resources.nfs.memory_gibibytes : 1
-        cpu    = var.resources.nfs != null ? var.resources.nfs.cpu_cores : 1
+        memory = var.node_capacity.nfs != null ? var.node_capacity.nfs.memory_gibibytes : local.selected_preset.nfs_server.memory
+        cpu    = var.node_capacity.nfs != null ? var.node_capacity.nfs.cpu_cores : local.selected_preset.nfs_server.cpu
       }
     }
   }
@@ -194,6 +158,13 @@ locals {
       : null
     )
   )
+
+  # Total declared worker nodes across all worker nodesets. Drives the sizing tier.
+  worker_count = length(var.node_count.worker) > 0 ? sum(var.node_count.worker) : 0
+
+  # Sizing tier + effective per-component preset (tier column with var.component_overrides already merged).
+  sizing_tier     = module.sizing.sizing_tier
+  selected_preset = module.sizing.preset
 
   opentelemetry_batch_enabled = (
     var.opentelemetry_batch != null

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -200,9 +200,9 @@ resource "helm_release" "soperator_fluxcd_cm" {
           slurmdbd_config = var.slurmdbd_config
           slurm_config    = var.slurm_accounting_config
           resources = var.accounting_enabled ? {
-            cpu               = var.resources.accounting.cpu_cores - local.resources.munge.cpu - local.resources.mariadb.cpu
-            memory            = var.resources.accounting.memory_gibibytes - local.resources.munge.memory - local.resources.mariadb.memory
-            ephemeral_storage = var.resources.accounting.ephemeral_storage_gibibytes - local.resources.munge.ephemeral_storage - local.resources.mariadb.ephemeral_storage
+            cpu               = var.node_capacity.accounting.cpu_cores - local.resources.munge.cpu - local.resources.mariadb.cpu
+            memory            = var.node_capacity.accounting.memory_gibibytes - local.resources.munge.memory - local.resources.mariadb.memory
+            ephemeral_storage = var.node_capacity.accounting.ephemeral_storage_gibibytes - local.resources.munge.ephemeral_storage - local.resources.mariadb.ephemeral_storage
           } : null
         }
 
@@ -210,19 +210,19 @@ resource "helm_release" "soperator_fluxcd_cm" {
           size = var.node_count.controller
           resources = {
             cpu = floor(
-              var.resources.controller.cpu_cores
+              var.node_capacity.controller.cpu_cores
               -local.resources.munge.cpu
               -(var.sssd_enabled ? local.resources.sssd.cpu : 0)
               -local.resources.kruise_daemon.cpu
             )
             memory = floor(
-              var.resources.controller.memory_gibibytes
+              var.node_capacity.controller.memory_gibibytes
               -local.resources.munge.memory
               -(var.sssd_enabled ? local.resources.sssd.memory : 0)
               -local.resources.kruise_daemon.memory
             )
             ephemeral_storage = floor(
-              var.resources.controller.ephemeral_storage_gibibytes
+              var.node_capacity.controller.ephemeral_storage_gibibytes
               -local.resources.munge.ephemeral_storage
               -(var.sssd_enabled ? local.resources.sssd.ephemeral_storage : 0)
             )
@@ -233,21 +233,21 @@ resource "helm_release" "soperator_fluxcd_cm" {
           size = 0
           resources = {
             cpu = floor(
-              var.resources.worker[0].cpu_cores
+              var.node_capacity.worker[0].cpu_cores
               -local.resources.munge.cpu
               -(var.sssd_enabled ? local.resources.sssd.cpu : 0)
             ) - local.resources.kruise_daemon.cpu
             memory = floor(
-              var.resources.worker[0].memory_gibibytes
+              var.node_capacity.worker[0].memory_gibibytes
               -local.resources.munge.memory
               -(var.sssd_enabled ? local.resources.sssd.memory : 0)
             ) - local.resources.kruise_daemon.memory
             ephemeral_storage = floor(
-              var.resources.worker[0].ephemeral_storage_gibibytes
+              var.node_capacity.worker[0].ephemeral_storage_gibibytes
               -local.resources.munge.ephemeral_storage
               -(var.sssd_enabled ? local.resources.sssd.ephemeral_storage : 0)
             )
-            gpus = var.resources.worker[0].gpus
+            gpus = var.node_capacity.worker[0].gpus
           }
           shared_memory            = var.shared_memory_size_gibibytes
           slurm_node_extra         = local.slurm_node_extra
@@ -263,19 +263,19 @@ resource "helm_release" "soperator_fluxcd_cm" {
           public_ip                = var.login_public_ip
           resources = {
             cpu = floor(
-              var.resources.login.cpu_cores
+              var.node_capacity.login.cpu_cores
               -local.resources.munge.cpu
               -(var.sssd_enabled ? local.resources.sssd.cpu : 0)
               -local.resources.kruise_daemon.cpu
             )
             memory = floor(
-              var.resources.login.memory_gibibytes
+              var.node_capacity.login.memory_gibibytes
               -local.resources.munge.memory
               -(var.sssd_enabled ? local.resources.sssd.memory : 0)
               -local.resources.kruise_daemon.memory
             )
             ephemeral_storage = floor(
-              var.resources.login.ephemeral_storage_gibibytes
+              var.node_capacity.login.ephemeral_storage_gibibytes
               -local.resources.munge.ephemeral_storage
               -(var.sssd_enabled ? local.resources.sssd.ephemeral_storage : 0)
             )
@@ -322,18 +322,20 @@ resource "helm_release" "soperator_fluxcd_cm" {
     }
 
     resources = {
-      vm_single               = var.resources_vm_single
-      vm_agent                = var.resources_vm_agent
-      vm_logs                 = var.resources_vm_logs_server
-      logs_collector          = var.resources_logs_collector
-      jail_logs_collector     = var.resources_jail_logs_collector
-      events_collector        = var.resources_events_collector
-      nccl_profiles_collector = var.resources_nccl_profiles_collector
+      vm_single               = local.selected_preset.vm_single
+      vm_agent                = local.selected_preset.vm_agent
+      vm_logs                 = local.selected_preset.vm_logs
+      logs_collector          = local.selected_preset.logs_collector
+      jail_logs_collector     = local.selected_preset.jail_logs_collector
+      events_collector        = local.selected_preset.events_collector
+      nccl_profiles_collector = local.selected_preset.nccl_profiles_collector
       node_configurator       = local.resources.node_configurator
       slurm_operator          = local.resources.slurm_operator
       slurm_checks            = local.resources.slurm_checks
       dcgm_exporter           = local.resources.dcgm_exporter
       nfs_server              = local.resources.nfs_server
+      spo                     = local.resources.spo
+      kruise_manager          = local.selected_preset.kruise_manager
     }
 
     vm_agent_queue_count = local.vm_agent_queue_count

--- a/soperator/modules/slurm/outputs.tf
+++ b/soperator/modules/slurm/outputs.tf
@@ -12,3 +12,16 @@ output "debug_resources" {
 
   value = local.resources
 }
+
+output "sizing_tier" {
+  description = "Sizing tier (XS..XL) derived from the worker count or forced via var.sizing_tier_override."
+  value       = local.sizing_tier
+}
+
+output "debug_size_resources" {
+  description = "Effective size-driven component resources (tier column with component_overrides merged), for tests/inspection."
+  value = merge(local.selected_preset, {
+    sizing_tier  = local.sizing_tier
+    worker_count = local.worker_count
+  })
+}

--- a/soperator/modules/slurm/sizing.tf
+++ b/soperator/modules/slurm/sizing.tf
@@ -1,0 +1,10 @@
+# Cluster-size dispatch. Resolves the XS..XL tier from the worker count (or
+# the forced var.sizing_tier_override) and exposes the per-component resource preset
+# consumed in locals.tf.
+module "sizing" {
+  source = "../sizing_tier"
+
+  worker_count         = local.worker_count
+  sizing_tier_override = var.sizing_tier_override
+  component_overrides  = var.component_overrides
+}

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -170,6 +170,8 @@ resources:
               vmagent:
                 spec:
                   extraArgs:
+                    # TODO(SCHED-2105): scale with cluster size; 32MiB is too small
+                    # for kube-state-metrics past ~3.5k workers.
                     promscrape.maxScrapeSize: "33554432"
                   externalLabels:
                     iam_tenant_id: ${iam_tenant_id}
@@ -305,20 +307,22 @@ resources:
           version: ${security_profiles_operator_version}
           %{~ endif ~}
           values:
+            # SecurityProfilesOperator resources scale with cluster size; it OOM-ed on big clusters.
+            # Driven by local.resources.spo.
             daemon:
               resources:
                 limits:
-                  memory: 128Mi
+                  memory: ${resources.spo.daemon.memory}
                 requests:
-                  cpu: 100m
-                  memory: 128Mi
+                  cpu: ${resources.spo.daemon.cpu}
+                  memory: ${resources.spo.daemon.memory}
             resources:
               limits:
-                cpu: 500m
-                memory: 3Gi
+                cpu: ${resources.spo.controller.cpu}
+                memory: ${resources.spo.controller.memory}
               requests:
-                cpu: 500m
-                memory: 3Gi
+                cpu: ${resources.spo.controller.cpu}
+                memory: ${resources.spo.controller.memory}
         slurmCluster:
           enabled: true
           interval: 5m
@@ -737,10 +741,11 @@ resources:
                 enabled: ${slurm_cluster.nodes.exporter.enabled}
                 k8sNodeFilterName: ${slurm_cluster.k8s_node_filters.system.name}
                 exporterContainer:
+                  # Rendered into the CR verbatim: k8s resource names (ephemeral-storage).
                   resources:
                     cpu: ${slurm_cluster.nodes.exporter.resources.cpu * 1000}m
                     memory: ${slurm_cluster.nodes.exporter.resources.memory}Gi
-                    ephemeralStorage: ${slurm_cluster.nodes.exporter.resources.ephemeral_storage}Gi
+                    ephemeral-storage: ${slurm_cluster.nodes.exporter.resources.ephemeral_storage}Gi
 
               rest:
                 enabled: ${slurm_cluster.nodes.rest.enabled}
@@ -909,6 +914,15 @@ resources:
                 image:
                   repository: cr.eu-north1.nebius.cloud/soperator/kruise-manager
                   tag: v1.8.3
+                # Scales with the sizing tier; the kruise manager OOM-ed on big
+                # clusters with the chart-default 1 cpu / 2Gi.
+                resources:
+                  requests:
+                    cpu: ${resources.kruise_manager.cpu}
+                    memory: ${resources.kruise_manager.memory}
+                  limits:
+                    cpu: ${resources.kruise_manager.cpu}
+                    memory: ${resources.kruise_manager.memory}
               helmHooks:
                 image:
                   repository: cr.eu-north1.nebius.cloud/soperator/kruise-helm-hook

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -110,8 +110,58 @@ variable "node_count" {
 
 # region Resources
 
-variable "resources" {
-  description = "Resources of Slurm nodes."
+variable "sizing_tier_override" {
+  description = <<-EOT
+    Force the sizing tier that dispatches system/observability component resources.
+    One of XS, S, M, L, XL; null (default) auto-derives the tier from the total worker node count.
+    Tier boundaries and per-tier values: ../sizing_tier/main.tf.
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.sizing_tier_override == null ? true : contains(["XS", "S", "M", "L", "XL"], var.sizing_tier_override)
+    error_message = "sizing_tier_override must be one of: XS, S, M, L, XL."
+  }
+}
+
+variable "component_overrides" {
+  description = <<-EOT
+    Optional per-component resource overrides applied on top of the sizing tier
+    (an entry replaces that component's tier value wholesale). Same shape as the
+    component_presets table in ../sizing_tier/main.tf. Leave empty to let
+    the sizing tier drive everything.
+  EOT
+  type = object({
+    exporter                = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    rest                    = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    mariadb                 = optional(object({ cpu = number, memory = number, ephemeral_storage = number }))
+    node_configurator       = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    slurm_operator          = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    slurm_checks            = optional(object({ requests = object({ cpu = number, memory = number }), limits = object({ memory = number }) }))
+    kruise_daemon           = optional(object({ cpu = number, memory = number }))
+    dcgm_exporter           = optional(object({ cpu = number, memory = number }))
+    nfs_server              = optional(object({ cpu = number, memory = number }))
+    spo                     = optional(object({ daemon = object({ cpu = string, memory = string }), controller = object({ cpu = string, memory = string }) }))
+    kruise_manager          = optional(object({ cpu = string, memory = string }))
+    vm_single               = optional(object({ memory = string, cpu = string, size = string, gomaxprocs = number }))
+    vm_agent                = optional(object({ memory = string, cpu = string }))
+    vm_logs                 = optional(object({ memory = string, cpu = string, size = string }))
+    events_collector        = optional(object({ memory = string, cpu = string }))
+    logs_collector          = optional(object({ memory = string, cpu = string }))
+    jail_logs_collector     = optional(object({ memory = string, cpu = string }))
+    nccl_profiles_collector = optional(object({ memory = string, cpu = string }))
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "node_capacity" {
+  description = <<-EOT
+    Available capacity of the node VMs backing each Slurm nodeset (computed by the caller from the chosen VM presets,
+    minus k8s reserves). Not an override surface: Slurm node pods are sized to fill these nodes (capacity minus sidecars).
+    For per-component pod sizing on top of the sizing tier, use component_overrides.
+  EOT
   type = object({
     system = object({
       cpu_cores                   = number
@@ -139,56 +189,6 @@ variable "resources" {
       memory_gibibytes            = number
       ephemeral_storage_gibibytes = number
     }))
-    rest = optional(object({
-      cpu_cores                   = number
-      memory_gibibytes            = number
-      ephemeral_storage_gibibytes = number
-    }))
-    exporter = optional(object({
-      cpu_cores                   = number
-      memory_gibibytes            = number
-      ephemeral_storage_gibibytes = number
-    }))
-    mariadb = optional(object({
-      cpu_cores                   = number
-      memory_gibibytes            = number
-      ephemeral_storage_gibibytes = number
-    }))
-    node_configurator = optional(object({
-      requests = object({
-        cpu_cores        = number
-        memory_gibibytes = number
-      })
-      limits = object({
-        memory_gibibytes = number
-      })
-    }))
-    slurm_operator = optional(object({
-      requests = object({
-        cpu_cores        = number
-        memory_gibibytes = number
-      })
-      limits = object({
-        memory_gibibytes = number
-      })
-    }))
-    slurm_checks = optional(object({
-      requests = object({
-        cpu_cores        = number
-        memory_gibibytes = number
-      })
-      limits = object({
-        memory_gibibytes = number
-      })
-    }))
-    kruise_daemon = optional(object({
-      cpu_cores        = number
-      memory_gibibytes = number
-    }))
-    dcgm_exporter = optional(object({
-      cpu_cores        = number
-      memory_gibibytes = number
-    }))
     nfs = optional(object({
       cpu_cores        = number
       memory_gibibytes = number
@@ -196,7 +196,7 @@ variable "resources" {
   })
 
   validation {
-    condition     = length(var.resources.worker) > 0
+    condition     = length(var.node_capacity.worker) > 0
     error_message = "At least one worker node must be provided."
   }
 
@@ -205,7 +205,7 @@ variable "resources" {
 resource "terraform_data" "check_worker_nodesets" {
   lifecycle {
     precondition {
-      condition     = length(var.node_count.worker) == length(var.resources.worker)
+      condition     = length(var.node_count.worker) == length(var.node_capacity.worker)
       error_message = "Worker node set resources must accord to the worker node count."
     }
   }
@@ -701,89 +701,8 @@ variable "resources_vm_operator" {
   }
 }
 
-variable "resources_vm_logs_server" {
-  type = object({
-    memory = string
-    cpu    = string
-    size   = string
-  })
-  default = {
-    memory = "2Gi"
-    cpu    = "1000m"
-    size   = "256Gi"
-  }
-}
-
-variable "resources_vm_single" {
-  type = object({
-    memory     = string
-    cpu        = string
-    size       = string
-    gomaxprocs = number
-  })
-  default = {
-    memory     = "24Gi"
-    cpu        = "6000m"
-    size       = "512Gi"
-    gomaxprocs = 6
-  }
-}
-
-variable "resources_vm_agent" {
-  type = object({
-    memory = string
-    cpu    = string
-  })
-  default = {
-    memory = "10Gi"
-    cpu    = "5000m"
-  }
-}
-
-variable "resources_events_collector" {
-  type = object({
-    memory = string
-    cpu    = string
-  })
-  default = {
-    memory = "128Mi"
-    cpu    = "100m"
-  }
-}
-
-
-variable "resources_logs_collector" {
-  type = object({
-    memory = string
-    cpu    = string
-  })
-  default = {
-    memory = "200Mi"
-    cpu    = "200m"
-  }
-}
-
-variable "resources_jail_logs_collector" {
-  type = object({
-    memory = string
-    cpu    = string
-  })
-  default = {
-    memory = "1Gi"
-    cpu    = "1000m"
-  }
-}
-
-variable "resources_nccl_profiles_collector" {
-  type = object({
-    memory = string
-    cpu    = string
-  })
-  default = {
-    memory = "200Mi"
-    cpu    = "500m"
-  }
-}
+# VM stack / collector resources are driven by the sizing tier
+# (../sizing_tier/main.tf); override via var.component_overrides.
 
 # endregion Monitoring
 


### PR DESCRIPTION
Considered together with nebius/soperator#2735: the slurm-cluster chart dropped `exporterContainer.resources` until that PR, so the exporter tier row only takes effect with it.

## Problem

System/observability component resources are hardcoded for big clusters. Small clusters waste money on oversized CPU nodes and pods, while some components (SPO controller, kruise) OOM on really big ones.

## Solution

- New `modules/sizing_tier`: derives an XS..XL tier from the total worker count and returns per-component pod resources plus CPU node presets for that tier. `sizing_tier_override` forces a tier.
- `modules/slurm` sizes exporter, REST, mariadb, node_configurator, slurm_operator, slurm_checks, kruise (manager + daemon), dcgm_exporter, nfs_server, SPO and the VM/collector stack from the tier. SPO and kruise-manager resources in the fluxcd values are templated instead of hardcoded.
- The example installation defaults controller/accounting/nfs/system node presets from the tier when `resource.preset` is omitted; an explicit preset wins.
- `system_resources` and the `resources_vm_*`/collector variables are replaced by one `component_overrides` object; an entry replaces that component's tier value wholesale. `modules/slurm` input `resources` is renamed to `node_capacity` to separate node capacity from pod sizing.
- Each component row documents which nodes its pods run on, and a capacity guard verifies the presets fit those nodes in every tier (allocatable capacity from `modules/available_resources`; mariadb must leave the accounting node room for slurmdbd). A broken table fails any plan with a message naming the component, the numbers and the node.

## Testing

`terraform test` for `modules/sizing_tier` (17 cases: tier boundaries, overrides, legacy-default and big-cluster parity, capacity invariants) passes; `make terraform-check` now runs module tests, so they also run in CI. Example installation plan checked manually.

## Release Notes

Feature: system component resources and CPU node presets now scale with cluster size via an auto-derived sizing tier; override with `sizing_tier_override` or per-component `component_overrides`. Breaking (Terraform): `system_resources` and `resources_vm_*` variables are replaced by `component_overrides`.
