### PR TITLE
SCHED-1893: Send exporterContainer resources with camelCase key

### DIFF
--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -741,11 +741,10 @@ resources:
                 enabled: ${slurm_cluster.nodes.exporter.enabled}
                 k8sNodeFilterName: ${slurm_cluster.k8s_node_filters.system.name}
                 exporterContainer:
-                  # Rendered into the CR verbatim: k8s resource names (ephemeral-storage).
                   resources:
                     cpu: ${slurm_cluster.nodes.exporter.resources.cpu * 1000}m
                     memory: ${slurm_cluster.nodes.exporter.resources.memory}Gi
-                    ephemeral-storage: ${slurm_cluster.nodes.exporter.resources.ephemeral_storage}Gi
+                    ephemeralStorage: ${slurm_cluster.nodes.exporter.resources.ephemeral_storage}Gi
 
               rest:
                 enabled: ${slurm_cluster.nodes.rest.enabled}


### PR DESCRIPTION
## Problem
The terraform values template passed `ephemeral-storage` under `exporterContainer.resources`, matching the short-lived verbatim rendering in the slurm-cluster chart.

## Solution
- Use the chart's usual `ephemeralStorage` key; the chart now translates it to the k8s resource name in the CR

Companion to nebius/soperator#2746.

## Testing
Covered by the chart-side `helm unittest` in nebius/soperator#2746; template key rename only.

## Release Notes
None