### PR TITLE
SCHED-1898: Provide a knob for tuning max in-flight collections per Slurm Exporter's sub-collector

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -549,13 +549,14 @@ module "slurm" {
   }
   nfs_node_group_enabled = local.slurm_nodeset_nfs != null
 
-  exporter_enabled         = var.slurm_exporter_enabled
-  rest_enabled             = var.slurm_rest_enabled
-  accounting_enabled       = var.accounting_enabled
-  telemetry_enabled        = var.telemetry_enabled
-  public_o11y_enabled      = var.public_o11y_enabled
-  soperator_notifier       = var.soperator_notifier
-  nccl_inspector_profiling = var.nccl_inspector_profiling
+  exporter_enabled                = var.slurm_exporter_enabled
+  exporter_max_collector_inflight = var.slurm_exporter_max_collector_inflight
+  rest_enabled                    = var.slurm_rest_enabled
+  accounting_enabled              = var.accounting_enabled
+  telemetry_enabled               = var.telemetry_enabled
+  public_o11y_enabled             = var.public_o11y_enabled
+  soperator_notifier              = var.soperator_notifier
+  nccl_inspector_profiling        = var.nccl_inspector_profiling
 
   backups_enabled = local.backups_enabled
   backups_config = {

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -506,6 +506,9 @@ slurm_exporter_enabled = true
 # Maximum number of concurrent collections per collector in Slurm exporter.
 # By default, 1.
 # ---
+# WARNING: Increasing this value may cause OOM issues on the REST component.
+# It is recommended to increase REST node resources if you increase this value.
+# ---
 # slurm_exporter_max_collector_inflight = 1
 
 # endregion Exporter

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -503,6 +503,11 @@ slurm_login_ssh_root_public_keys = [
 # ---
 slurm_exporter_enabled = true
 
+# Maximum number of concurrent collections per collector in Slurm exporter.
+# By default, 1.
+# ---
+# slurm_exporter_max_collector_inflight = 1
+
 # endregion Exporter
 
 #----------------------------------------------------------------------------------------------------------------------#

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1330,6 +1330,17 @@ variable "slurm_exporter_enabled" {
   default     = true
 }
 
+variable "slurm_exporter_max_collector_inflight" {
+  description = "Maximum number of concurrent collections per collector in Slurm exporter."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.slurm_exporter_max_collector_inflight >= 1
+    error_message = "slurm_exporter_max_collector_inflight must be greater than or equal to 1."
+  }
+}
+
 # endregion Exporter
 
 # region REST API

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -283,8 +283,9 @@ resource "helm_release" "soperator_fluxcd_cm" {
         }
 
         exporter = {
-          enabled   = var.exporter_enabled
-          resources = local.resources.exporter
+          enabled                = var.exporter_enabled
+          resources              = local.resources.exporter
+          max_collector_inflight = var.exporter_max_collector_inflight
         }
 
         munge = {

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -740,6 +740,7 @@ resources:
               exporter:
                 enabled: ${slurm_cluster.nodes.exporter.enabled}
                 k8sNodeFilterName: ${slurm_cluster.k8s_node_filters.system.name}
+                maxCollectorInflight: ${slurm_cluster.nodes.exporter.max_collector_inflight}
                 exporterContainer:
                   resources:
                     cpu: ${slurm_cluster.nodes.exporter.resources.cpu * 1000}m

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -299,6 +299,17 @@ variable "exporter_enabled" {
   default     = false
 }
 
+variable "exporter_max_collector_inflight" {
+  description = "Maximum number of concurrent collections per collector in Slurm exporter."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.exporter_max_collector_inflight >= 1
+    error_message = "exporter_max_collector_inflight must be greater than or equal to 1."
+  }
+}
+
 # endregion Exporter
 
 # region REST API


### PR DESCRIPTION
## Release Notes

Max in-flight collections per Slurm Exporter's sub-collector can now be tuned to enable overlapping collections.