### PR TITLE
Allow system nodes to be in target group

### DIFF
--- a/soperator/modules/k8s/k8s_ng_system.tf
+++ b/soperator/modules/k8s/k8s_ng_system.tf
@@ -26,7 +26,6 @@ resource "nebius_mk8s_v1_node_group" "system" {
         module.labels.label_nodeset_system,
         module.labels.label_workload_cpu,
         module.labels.label_jail,
-        module.labels.label_exclude_from_external_lb,
       )
     }
 


### PR DESCRIPTION
In GB300 we have no separate CPU login node gorup, so all nodegorups get this label and loadbalancer for login service ends up with an empty target group.
If we allow system nodes to be in target group, it will work for gb300, since cilium will take care of routing traffic to login pods running on worker nodes.

