### PR TITLE
SCHED-2105: Scale kube-state-metrics scrape cap and resources with the sizing tier

### DIFF
--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -586,7 +586,7 @@ dcgm_job_mapping_enabled = true
 # Optional kube-state-metrics scrape size override in bytes.
 # By default, it is raised automatically for large clusters.
 # ---
-# kube_state_metrics_max_scrape_size = 150554432
+# kube_state_metrics_max_scrape_size = 268435456
 
 # Optional OpenTelemetry sending_queue batch overrides for logs, jail logs, events, and nccl-profiles collectors.
 # By default, chart values are used.

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1416,7 +1416,7 @@ variable "dcgm_job_mapping_enabled" {
 }
 
 variable "kube_state_metrics_max_scrape_size" {
-  description = "Maximum kube-state-metrics HTTP scrape size in bytes. Leave null to let the Slurm module raise it automatically for large clusters."
+  description = "Maximum kube-state-metrics HTTP scrape size in bytes. Leave null to let the sizing tier decide (raised automatically on M and larger clusters)."
   type        = number
   default     = null
   nullable    = true

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -713,6 +713,7 @@ variable "component_overrides" {
     spo_controller          = optional(object({ cpu = string, memory = string }))
     spo_daemon              = optional(object({ cpu = string, memory = string }))
     kruise_manager          = optional(object({ cpu = string, memory = string }))
+    kube_state_metrics      = optional(object({ requests = object({ cpu = string, memory = string }), limits = object({ memory = string }) }))
     vm_single               = optional(object({ memory = string, cpu = string, size = string, gomaxprocs = number }))
     vm_agent                = optional(object({ memory = string, cpu = string }))
     vm_logs                 = optional(object({ memory = string, cpu = string, size = string }))

--- a/soperator/modules/sizing_tier/main.tf
+++ b/soperator/modules/sizing_tier/main.tf
@@ -184,6 +184,21 @@ locals {
     }
   }
 
+  # Cap (bytes) on the kube-state-metrics scrape response accepted by vmagent, per tier.
+  # Fleet measurements: the response is ~4KB per pod on top of a ~1MB infra base
+  # Per-worker cost is therefore 4KB x pods-per-node: 55-75KB/worker observed,
+  # so vmagent's global 32MiB guard (-promscrape.maxScrapeSize) is reached around 450-580 workers and
+  # dense M-tier clusters get close to it too.
+  # Tiers M and up therefore set a per-job limit sized ~2-3x above the tier ceiling's worst-case legitimate response.
+  # null keeps the global guard, under which an oversized response fails its scrape loudly.
+  kube_state_metrics_max_scrape_size_presets = {
+    XS = null
+    S  = null
+    M  = 134217728 # 128MiB vs ~45MB worst-case legit at 500 workers
+    L  = 268435456 # 256MiB vs ~155MB worst-case legit at 2000 workers
+    XL = 536870912 # 512MiB, covers ~7k workers even at dense-cluster rates
+  }
+
   # Per-node agents whose footprint does NOT depend on the cluster size: constant at every
   # tier, still replaceable via component_overrides.
   constant_presets = {

--- a/soperator/modules/sizing_tier/main.tf
+++ b/soperator/modules/sizing_tier/main.tf
@@ -101,6 +101,17 @@ locals {
       L  = { cpu = "3", memory = "8Gi" }
       XL = { cpu = "8", memory = "16Gi" }
     }
+    # Runs on: system nodes (the vm-stack chart's kube-state-metrics Deployment).
+    # Memory scales with the cluster's object count.
+    # Requests cover the worst-case envelope (~100Mi + 70KB/pod at ~20 pods/worker) at
+    # each tier's worker ceiling.
+    kube_state_metrics = {
+      XS = { requests = { cpu = "100m", memory = "256Mi" }, limits = { memory = "512Mi" } }
+      S  = { requests = { cpu = "100m", memory = "512Mi" }, limits = { memory = "1024Mi" } }
+      M  = { requests = { cpu = "200m", memory = "1024Mi" }, limits = { memory = "2048Mi" } }
+      L  = { requests = { cpu = "500m", memory = "3072Mi" }, limits = { memory = "6144Mi" } }
+      XL = { requests = { cpu = "1000m", memory = "6144Mi" }, limits = { memory = "12288Mi" } }
+    }
     # Runs on: system nodes.
     vm_single = {
       XS = { memory = "24Gi", cpu = "6000m", size = "512Gi", gomaxprocs = 6 }
@@ -231,6 +242,7 @@ locals {
     spo_controller          = coalesce(var.component_overrides.spo_controller, local.component_presets.spo_controller[local.sizing_tier])
     spo_daemon              = coalesce(var.component_overrides.spo_daemon, local.constant_presets.spo_daemon)
     kruise_manager          = coalesce(var.component_overrides.kruise_manager, local.component_presets.kruise_manager[local.sizing_tier])
+    kube_state_metrics      = coalesce(var.component_overrides.kube_state_metrics, local.component_presets.kube_state_metrics[local.sizing_tier])
     vm_single               = coalesce(var.component_overrides.vm_single, local.component_presets.vm_single[local.sizing_tier])
     vm_agent                = coalesce(var.component_overrides.vm_agent, local.component_presets.vm_agent[local.sizing_tier])
     vm_logs                 = coalesce(var.component_overrides.vm_logs, local.component_presets.vm_logs[local.sizing_tier])
@@ -307,6 +319,10 @@ locals {
       kruise_manager = {
         cpu    = tonumber(local.component_presets.kruise_manager[tier].cpu)
         memory = tonumber(trimsuffix(local.component_presets.kruise_manager[tier].memory, "Gi"))
+      }
+      kube_state_metrics = {
+        cpu    = tonumber(trimsuffix(local.component_presets.kube_state_metrics[tier].requests.cpu, "m")) / 1000
+        memory = tonumber(trimsuffix(local.component_presets.kube_state_metrics[tier].requests.memory, "Mi")) / 1024
       }
       vm_single = {
         cpu    = tonumber(trimsuffix(local.component_presets.vm_single[tier].cpu, "m")) / 1000

--- a/soperator/modules/sizing_tier/outputs.tf
+++ b/soperator/modules/sizing_tier/outputs.tf
@@ -23,6 +23,11 @@ output "all_node_presets" {
   value       = local.node_presets
 }
 
+output "kube_state_metrics_max_scrape_size" {
+  description = "Cap (bytes) on the kube-state-metrics scrape response for the resolved tier; null keeps vmagent's global 32MiB guard."
+  value       = local.kube_state_metrics_max_scrape_size_presets[local.sizing_tier]
+}
+
 output "capacity_violations" {
   description = <<-EOT
     Broken capacity invariants, one self-explaining message each (see the capacity locals in main.tf).

--- a/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
+++ b/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
@@ -217,6 +217,47 @@ run "xs_matches_legacy_defaults" {
   }
 }
 
+# Scrape-size caps follow the tier.
+
+run "small_tiers_keep_global_scrape_guard" {
+  command = apply
+  variables { worker_count = 99 } # S
+  assert {
+    condition     = output.kube_state_metrics_max_scrape_size == null
+    error_message = "S must keep the global 32MiB scrape guard (null cap)"
+  }
+}
+
+run "m_raises_ksm_scrape_cap" {
+  command = apply
+  variables { worker_count = 100 } # M
+  assert {
+    condition     = output.kube_state_metrics_max_scrape_size == 134217728
+    error_message = "M must raise the kube-state-metrics scrape cap to 128MiB"
+  }
+}
+
+run "l_raises_ksm_scrape_cap" {
+  command = apply
+  variables { worker_count = 500 } # L
+  assert {
+    condition     = output.kube_state_metrics_max_scrape_size == 268435456
+    error_message = "L must raise the kube-state-metrics scrape cap to 256MiB"
+  }
+}
+
+run "forced_xl_raises_ksm_scrape_cap" {
+  command = apply
+  variables {
+    worker_count         = 6 # would derive XS
+    sizing_tier_override = "XL"
+  }
+  assert {
+    condition     = output.kube_state_metrics_max_scrape_size == 536870912
+    error_message = "forced XL must expose the 512MiB XL kube-state-metrics scrape cap"
+  }
+}
+
 # Capacity: presets must fit the nodes they are placed on, in every tier.
 
 run "capacity_fits_all_tiers" {

--- a/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
+++ b/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
@@ -134,9 +134,10 @@ run "component_override_wins_over_tier" {
   variables {
     worker_count = 5 # derives XS
     component_overrides = {
-      rest           = { cpu = 20, memory = 120, ephemeral_storage = 5 }
-      vm_single      = { cpu = "25000m", memory = "24Gi", size = "512Gi", gomaxprocs = 25 }
-      logs_collector = { memory = "1Gi", cpu = "500m" }
+      rest               = { cpu = 20, memory = 120, ephemeral_storage = 5 }
+      vm_single          = { cpu = "25000m", memory = "24Gi", size = "512Gi", gomaxprocs = 25 }
+      logs_collector     = { memory = "1Gi", cpu = "500m" }
+      kube_state_metrics = { requests = { cpu = "300m", memory = "2048Mi" }, limits = { memory = "4096Mi" } }
     }
   }
   assert {
@@ -154,6 +155,10 @@ run "component_override_wins_over_tier" {
   assert {
     condition     = output.preset.logs_collector.memory == "1Gi"
     error_message = "component_overrides.logs_collector must replace the constant"
+  }
+  assert {
+    condition     = output.preset.kube_state_metrics.requests.memory == "2048Mi" && output.preset.kube_state_metrics.limits.memory == "4096Mi"
+    error_message = "component_overrides.kube_state_metrics must replace the XS tier value"
   }
   assert {
     condition     = output.preset.kruise_daemon.memory == 0.128
@@ -235,6 +240,10 @@ run "m_raises_ksm_scrape_cap" {
     condition     = output.kube_state_metrics_max_scrape_size == 134217728
     error_message = "M must raise the kube-state-metrics scrape cap to 128MiB"
   }
+  assert {
+    condition     = output.preset.kube_state_metrics.requests.memory == "1024Mi" && output.preset.kube_state_metrics.requests.cpu == "200m"
+    error_message = "M must expose the 1Gi/200m kube-state-metrics preset"
+  }
 }
 
 run "l_raises_ksm_scrape_cap" {
@@ -255,6 +264,10 @@ run "forced_xl_raises_ksm_scrape_cap" {
   assert {
     condition     = output.kube_state_metrics_max_scrape_size == 536870912
     error_message = "forced XL must expose the 512MiB XL kube-state-metrics scrape cap"
+  }
+  assert {
+    condition     = output.preset.kube_state_metrics.requests.memory == "6144Mi" && output.preset.kube_state_metrics.limits.memory == "12288Mi"
+    error_message = "forced XL must expose the 6Gi/12Gi kube-state-metrics preset"
   }
 }
 

--- a/soperator/modules/sizing_tier/variables.tf
+++ b/soperator/modules/sizing_tier/variables.tf
@@ -43,6 +43,7 @@ variable "component_overrides" {
     spo_controller          = optional(object({ cpu = string, memory = string }))
     spo_daemon              = optional(object({ cpu = string, memory = string }))
     kruise_manager          = optional(object({ cpu = string, memory = string }))
+    kube_state_metrics      = optional(object({ requests = object({ cpu = string, memory = string }), limits = object({ memory = string }) }))
     vm_single               = optional(object({ memory = string, cpu = string, size = string, gomaxprocs = number }))
     vm_agent                = optional(object({ memory = string, cpu = string }))
     vm_logs                 = optional(object({ memory = string, cpu = string, size = string }))

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -149,17 +149,12 @@ locals {
   # This sets metrics ingestion capacity for larger clusters properly
   vm_agent_queue_count = 2 + floor(sum(var.node_count.worker) / 60)
 
-  # kube-state-metrics starts exceeding the default 32MiB scrape limit around 1.1k workers.
-  kube_state_metrics_large_cluster_worker_threshold = 1000
-  kube_state_metrics_large_cluster_max_scrape_size  = 150554432
+  # Cap on the kube-state-metrics scrape response: an explicit var wins, otherwise the sizing
+  # tier decides (null below M keeps vmagent's global 32MiB guard).
   kube_state_metrics_max_scrape_size = (
     var.kube_state_metrics_max_scrape_size != null
     ? var.kube_state_metrics_max_scrape_size
-    : (
-      sum(var.node_count.worker) >= local.kube_state_metrics_large_cluster_worker_threshold
-      ? local.kube_state_metrics_large_cluster_max_scrape_size
-      : null
-    )
+    : module.sizing.kube_state_metrics_max_scrape_size
   )
 
   # Total declared worker nodes across all worker nodesets. Drives the sizing tier.

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -337,6 +337,7 @@ resource "helm_release" "soperator_fluxcd_cm" {
       nfs_server              = local.resources.nfs_server
       spo                     = local.resources.spo
       kruise_manager          = local.selected_preset.kruise_manager
+      kube_state_metrics      = local.selected_preset.kube_state_metrics
     }
 
     vm_agent_queue_count = local.vm_agent_queue_count

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -170,8 +170,9 @@ resources:
               vmagent:
                 spec:
                   extraArgs:
-                    # TODO(SCHED-2105): scale with cluster size; 32MiB is too small
-                    # for kube-state-metrics past ~3.5k workers.
+                    # Default cap for scrape jobs without their own max_scrape_size.
+                    # kube-state-metrics overrides it per-job via kubeStateMetrics.maxScrapeSize
+                    # on large clusters, so this stays at 32MiB as a guard for everything else.
                     promscrape.maxScrapeSize: "33554432"
                   externalLabels:
                     iam_tenant_id: ${iam_tenant_id}

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -162,10 +162,16 @@ resources:
               writer:
                 source: ${tsa_token_writer_source}
             values:
-              %{~ if kube_state_metrics_max_scrape_size != null ~}
               kubeStateMetrics:
+                %{~ if kube_state_metrics_max_scrape_size != null ~}
                 maxScrapeSize: "${kube_state_metrics_max_scrape_size}"
-              %{~ endif ~}
+                %{~ endif ~}
+                resources:
+                  requests:
+                    cpu: ${resources.kube_state_metrics.requests.cpu}
+                    memory: ${resources.kube_state_metrics.requests.memory}
+                  limits:
+                    memory: ${resources.kube_state_metrics.limits.memory}
 
               vmagent:
                 spec:

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -145,6 +145,7 @@ variable "component_overrides" {
     spo_controller          = optional(object({ cpu = string, memory = string }))
     spo_daemon              = optional(object({ cpu = string, memory = string }))
     kruise_manager          = optional(object({ cpu = string, memory = string }))
+    kube_state_metrics      = optional(object({ requests = object({ cpu = string, memory = string }), limits = object({ memory = string }) }))
     vm_single               = optional(object({ memory = string, cpu = string, size = string, gomaxprocs = number }))
     vm_agent                = optional(object({ memory = string, cpu = string }))
     vm_logs                 = optional(object({ memory = string, cpu = string, size = string }))

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -466,7 +466,7 @@ variable "dcgm_job_mapping_enabled" {
 }
 
 variable "kube_state_metrics_max_scrape_size" {
-  description = "Maximum kube-state-metrics HTTP scrape size in bytes. Leave null to raise it automatically for large clusters."
+  description = "Maximum kube-state-metrics HTTP scrape size in bytes. Leave null to let the sizing tier decide (raised automatically on M and larger clusters)."
   type        = number
   default     = null
   nullable    = true


### PR DESCRIPTION
## Problem

Two kube-state-metrics problems that show up as clusters grow:

1. **Scrape size.** The kube-state-metrics response grows with pod count (~4KB per pod), and vmagent rejects responses bigger than 32MiB. That point comes at roughly 450-580 workers. Our old override only started at 1000 workers, so mid-size clusters silently lost all `kube_*` metrics. The override value itself (150MB) is also too small beyond ~3.5k workers.
2. **Resources.** The kube-state-metrics pod runs with no requests or limits at all: the scheduler reserves no room for it, it's the first pod evicted under memory pressure, and the sizing-tier capacity math doesn't know it exists - while its memory grows with the cluster (measured ~400Mi at 254 workers, ~500Mi at 564 workers).

## Solution

Both settings now come from the sizing tier:

- **Scrape size limit**: XS/S keep the 32MiB guard, M gets 128MiB, L gets 256MiB, XL gets 512MiB. Each value is 2-3x above the biggest legitimate response for that tier, so a runaway exporter still trips it. The explicit `kube_state_metrics_max_scrape_size` var still wins. vmagent's global 32MiB flag stays as is and keeps protecting all other scrape jobs.
- **Resources**: requests from 100m/256Mi (XS) up to 1000m/6Gi (XL), memory limit at 2x the request, no CPU limit. Overridable via `component_overrides`. The capacity guard now counts kube-state-metrics when computing how many system nodes a tier needs.

## Related PRs

- nebius/soperator#2772 - the chart side: passes the resources values to the kube-state-metrics chart and pins the pod to system nodes. It must ship in the same or an earlier release than this PR - the terraform values do nothing until the chart reads them. (The chart-side fix for the scrape-limit values key is already merged in soperator.)
- Covers the kube-state-metrics part of SCHED-1519; placement for the other infra Deployments stays in that ticket.

## Testing

`terraform test` in `sizing_tier`: 22 passed, 0 failed - tier boundaries, cap values per tier, resources presets, and override precedence.

e2e test run covering this PR together with nebius/soperator#2772: https://github.com/nebius/soperator/actions/runs/29948551520

## Release Notes

Fix: the kube-state-metrics scrape size limit now scales with cluster size instead of a fixed 1000-worker threshold that left ~500+ worker clusters with failing scrapes. kube-state-metrics also gets resource requests and limits scaled to the cluster size instead of running unbounded.
