### PR TITLE
Add snapshot-backed boot disks to vm-instance

### DIFF
--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -1,10 +1,40 @@
+data "nebius_compute_v1_disk_snapshot" "boot-disk" {
+  count = var.boot_disk_snapshot_id == null ? 0 : 1
+  id    = var.boot_disk_snapshot_id
+}
+
 resource "nebius_compute_v1_disk" "boot-disk" {
   parent_id           = var.parent_id
   name                = join("-", ["instance-boot-disk", var.instance_name])
   block_size_bytes    = 4096
   size_bytes          = 1024 * 1024 * 1024 * var.boot_disk_size_gb
   type                = "NETWORK_SSD"
-  source_image_family = { image_family = "ubuntu24.04-cuda12" }
+  source_image_family = var.boot_disk_snapshot_id == null ? { image_family = "ubuntu24.04-cuda12" } : null
+  source_snapshot_id  = var.boot_disk_snapshot_id
+
+  lifecycle {
+    precondition {
+      condition = var.boot_disk_snapshot_id == null ? true : (
+        data.nebius_compute_v1_disk_snapshot.boot-disk[0].parent_id == var.parent_id
+      )
+      error_message = "The boot disk snapshot must belong to the same project as the VM."
+    }
+
+    precondition {
+      condition = var.boot_disk_snapshot_id == null ? true : (
+        data.nebius_compute_v1_disk_snapshot.boot-disk[0].status.state == "READY"
+      )
+      error_message = "The boot disk snapshot must be in READY state."
+    }
+
+    precondition {
+      condition = var.boot_disk_snapshot_id == null ? true : (
+        1024 * 1024 * 1024 * var.boot_disk_size_gb >=
+        data.nebius_compute_v1_disk_snapshot.boot-disk[0].status.content_size_bytes
+      )
+      error_message = "boot_disk_size_gb must be at least as large as the snapshot content size."
+    }
+  }
 }
 
 resource "nebius_compute_v1_disk" "extra-storage-disk" {

--- a/modules/instance/provider.tf
+++ b/modules/instance/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nebius = {
       source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
-      version = ">= 0.5.55"
+      version = ">= 0.5.240"
     }
   }
 }

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -86,6 +86,17 @@ variable "boot_disk_size_gb" {
   description = "size of the boot disk"
 }
 
+variable "boot_disk_snapshot_id" {
+  type        = string
+  default     = null
+  description = "ID of a project-local disk snapshot used to initialize the boot disk. When null, the default Ubuntu image is used."
+
+  validation {
+    condition     = var.boot_disk_snapshot_id == null || trimspace(var.boot_disk_snapshot_id) != ""
+    error_message = "boot_disk_snapshot_id must be null or a non-empty disk snapshot ID."
+  }
+}
+
 variable "extra_storage_size_gb" {
   type        = number
   default     = 50

--- a/vm-instance/README.md
+++ b/vm-instance/README.md
@@ -9,6 +9,7 @@ This Terraform configuration script provisions cloud instances with specific har
 * Mount S3 Bucket to all instances
 * Attach extra storage to all instances
 * Add VMs to a GPU cluster and connect them over Infiniband
+* Initialize VM boot disks from a project-local disk snapshot
 
 ## Configuring Terraform for Nebius Cloud
 
@@ -134,3 +135,42 @@ fabric = "fabric-6"
 This will create a GPU cluster and add all vms inside there. This gives them the possibility to connect over Infiniband. 
 
 It is not possible to change that for already running instances
+
+### Example 5: Create VMs from a disk snapshot
+
+Set `boot_disk_snapshot_id` to initialize each VM with an independent boot disk
+created from the snapshot:
+
+```hcl
+preset   = "16vcpu-64gb"
+platform = "cpu-d3"
+
+boot_disk_snapshot_id = "computedisksnapshot-..."
+boot_disk_size_gb     = 500
+
+users = [
+  {
+    user_name    = "admin"
+    ssh_key_path = "~/.ssh/id_rsa.pub"
+  }
+]
+
+public_ip     = true
+instance_count = 1
+```
+
+The snapshot must:
+
+* Be in the same project as the VM.
+* Be in `READY` state.
+* Fit within `boot_disk_size_gb`.
+* Contain an operating system compatible with the selected VM platform's CPU architecture.
+
+This is a full-disk clone, not a generalized image. The restored disk can retain
+the source VM's hostname, machine ID, SSH host keys, users, and cloud-init state.
+If cloud-init has already completed on the source disk, the `users` configuration
+above might not be applied to the restored VM. Prepare and sanitize the source
+disk before using its snapshot as a reusable VM baseline.
+
+Snapshots are project-scoped. For details, see
+[Managing disk snapshots in Compute](https://docs.nebius.com/compute/storage/disk-snapshots).

--- a/vm-instance/main.tf
+++ b/vm-instance/main.tf
@@ -17,6 +17,7 @@ module "instance-module" {
   preset                  = var.preset
   platform                = var.platform
   boot_disk_size_gb       = var.boot_disk_size_gb
+  boot_disk_snapshot_id   = var.boot_disk_snapshot_id
   shared_filesystem_id    = var.shared_filesystem_id
   shared_filesystem_mount = var.shared_filesystem_mount
   extra_path              = var.extra_path

--- a/vm-instance/provider.tf
+++ b/vm-instance/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nebius = {
       source  = "terraform-provider.storage.eu-north1.nebius.cloud/nebius/nebius"
-      version = ">= 0.4.24"
+      version = ">= 0.5.240"
     }
   }
 }

--- a/vm-instance/terraform.tfvars
+++ b/vm-instance/terraform.tfvars
@@ -23,6 +23,9 @@ public_ip      = true
 instance_count = 2
 preemptible    = false
 
+# Optional: initialize each VM boot disk from this project-local snapshot.
+# boot_disk_snapshot_id = "computedisksnapshot-..."
+
 shared_filesystem_id = ""
 mount_bucket         = ""
 

--- a/vm-instance/variables.tf
+++ b/vm-instance/variables.tf
@@ -96,6 +96,17 @@ variable "boot_disk_size_gb" {
   description = "size of boot disk"
 }
 
+variable "boot_disk_snapshot_id" {
+  type        = string
+  default     = null
+  description = "ID of a project-local disk snapshot used to initialize each VM boot disk. When null, the default Ubuntu image is used."
+
+  validation {
+    condition     = var.boot_disk_snapshot_id == null || trimspace(var.boot_disk_snapshot_id) != ""
+    error_message = "boot_disk_snapshot_id must be null or a non-empty disk snapshot ID."
+  }
+}
+
 variable "public_ip" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Adds optional snapshot-backed boot disks to the `vm-instance` solution. Existing deployments continue to use the default Ubuntu image unless `boot_disk_snapshot_id` is set.

## What changed

- Added `boot_disk_snapshot_id` to the root solution and instance module.
- Creates each VM boot disk from the selected project-local snapshot.
- Validates that the snapshot belongs to the project, is ready, and fits within the configured disk size.
- Raised the Nebius provider minimum to `0.5.240`, which introduced `source_snapshot_id`.
- Documented snapshot requirements and full-disk clone caveats, including retained guest identity and cloud-init state.

## Validation

- `terraform fmt -check -recursive vm-instance modules/instance`
- `terraform validate -no-color` with Terraform 1.11.4 in Linux
