### PR TITLE
SCHED-1912: Use IO M3 SSD for VMSingle storage

### DIFF
--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -266,7 +266,7 @@ sizing_tier_override = null
 # as the component_presets table referenced above. Example:
 # component_overrides = {
 #   rest      = { cpu = 20, memory = 120, ephemeral_storage = 5 }
-#   vm_single = { cpu = "25000m", memory = "24Gi", size = "512Gi", gomaxprocs = 25 }
+#   vm_single = { cpu = "25000m", memory = "24Gi", size = "2046Gi", gomaxprocs = 25 }
 # }
 
 # Configuration of Slurm Controller node set.

--- a/soperator/modules/sizing_tier/main.tf
+++ b/soperator/modules/sizing_tier/main.tf
@@ -109,12 +109,14 @@ locals {
       XL = { requests = { cpu = "1000m", memory = "6144Mi" }, limits = { memory = "12288Mi" } }
     }
     # Runs on: system nodes.
+    # The PVC lands on an IO M3 storage class (see the vmsingle storage block in terraform_fluxcd_values.yaml.tftpl),
+    # so size must be a multiple of 93 GiB.
     vm_single = {
-      XS = { memory = "24Gi", cpu = "6000m", size = "512Gi", gomaxprocs = 6 }
-      S  = { memory = "24Gi", cpu = "6000m", size = "512Gi", gomaxprocs = 6 }
-      M  = { memory = "24Gi", cpu = "8000m", size = "512Gi", gomaxprocs = 8 }
-      L  = { memory = "24Gi", cpu = "12000m", size = "512Gi", gomaxprocs = 12 }
-      XL = { memory = "24Gi", cpu = "25000m", size = "512Gi", gomaxprocs = 25 }
+      XS = { memory = "24Gi", cpu = "6000m", size = "558Gi", gomaxprocs = 6 }
+      S  = { memory = "24Gi", cpu = "6000m", size = "558Gi", gomaxprocs = 6 }
+      M  = { memory = "24Gi", cpu = "8000m", size = "558Gi", gomaxprocs = 8 }
+      L  = { memory = "24Gi", cpu = "12000m", size = "1023Gi", gomaxprocs = 12 }
+      XL = { memory = "24Gi", cpu = "25000m", size = "2046Gi", gomaxprocs = 25 }
     }
     # Runs on: system nodes.
     vm_agent = {

--- a/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
+++ b/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
@@ -82,6 +82,10 @@ run "five_hundred_workers_is_l" {
     condition     = output.preset.soperator_main_controller.limits.memory == 3 && output.preset.soperator_checks_controller.limits.memory == 4
     error_message = "L must expose 3Gi main / 4Gi checks controller memory"
   }
+  assert {
+    condition     = output.preset.vm_single.size == "1023Gi"
+    error_message = "L vm_single size must be 1023Gi (93x11, IO M3 granularity)"
+  }
 }
 
 run "nineteen_ninety_nine_workers_is_l" {
@@ -143,7 +147,7 @@ run "component_override_wins_over_tier" {
     worker_count = 5 # derives XS
     component_overrides = {
       rest                        = { cpu = 20, memory = 120, ephemeral_storage = 5 }
-      vm_single                   = { cpu = "25000m", memory = "24Gi", size = "512Gi", gomaxprocs = 25 }
+      vm_single                   = { cpu = "25000m", memory = "24Gi", size = "558Gi", gomaxprocs = 25 }
       logs_collector              = { memory = "1Gi", cpu = "500m" }
       kube_state_metrics          = { requests = { cpu = "300m", memory = "2048Mi" }, limits = { memory = "4096Mi" } }
       soperator_checks_controller = { requests = { cpu = 2, memory = 6 }, limits = { memory = 6 } }
@@ -187,6 +191,17 @@ run "component_override_wins_over_tier" {
   }
 }
 
+run "vm_single_size_override_must_be_io_m3_multiple" {
+  command = plan
+  variables {
+    worker_count = 5
+    component_overrides = {
+      vm_single = { cpu = "6000m", memory = "24Gi", size = "512Gi", gomaxprocs = 6 } # not a multiple of 93
+    }
+  }
+  expect_failures = [var.component_overrides]
+}
+
 run "constants_do_not_scale_with_tier" {
   command = apply
   variables { worker_count = 6000 } # XL
@@ -228,6 +243,10 @@ run "xs_matches_legacy_defaults" {
   assert {
     condition     = output.preset.vm_single.cpu == "6000m" && output.preset.vm_single.gomaxprocs == 6
     error_message = "XS vm_single must equal the legacy default 6000m / gomaxprocs 6"
+  }
+  assert {
+    condition     = output.preset.vm_single.size == "558Gi"
+    error_message = "XS vm_single size must be 558Gi (93x6, IO M3 granularity)"
   }
   assert {
     condition     = output.preset.vm_agent.memory == "10Gi" && output.preset.vm_agent.cpu == "5000m"
@@ -334,6 +353,10 @@ run "xl_matches_poc_numbers" {
   assert {
     condition     = output.preset.vm_single.cpu == "25000m" && output.preset.vm_single.gomaxprocs == 25
     error_message = "XL vm_single must be 25000m / gomaxprocs 25"
+  }
+  assert {
+    condition     = output.preset.vm_single.size == "2046Gi"
+    error_message = "XL vm_single size must be 2046Gi (93x22, IO M3 granularity)"
   }
   assert {
     condition     = output.preset.vm_agent.memory == "25Gi" && output.preset.vm_agent.cpu == "12000m"

--- a/soperator/modules/sizing_tier/variables.tf
+++ b/soperator/modules/sizing_tier/variables.tf
@@ -54,4 +54,12 @@ variable "component_overrides" {
   })
   default  = {}
   nullable = false
+
+  validation {
+    condition = var.component_overrides.vm_single == null ? true : (
+      can(regex("^\\d+Gi$", var.component_overrides.vm_single.size)) &&
+      tonumber(trimsuffix(var.component_overrides.vm_single.size, "Gi")) % 93 == 0
+    )
+    error_message = "component_overrides.vm_single.size must be \"<N>Gi\" with N a multiple of 93 GiB (IO M3 disk size granularity)."
+  }
 }

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -213,6 +213,7 @@ resources:
                     resources:
                       requests:
                         storage: ${resources.vm_single.size}
+                    storageClassName: "compute-csi-network-ssd-io-m3-ext4"
                   %{~ endif ~}
                   resources:
                     requests:


### PR DESCRIPTION
## Problem

VMSingle PVC used the default network SSD storage class. IO M3 disks are provisioned in 93 GiB increments, so the existing 512Gi presets are not valid for it.

## Solution

- Pin `storageClassName: compute-csi-network-ssd-io-m3-ext4` for the VMSingle PVC
- Change tier sizes to 93 GiB multiples: 558Gi (XS/S/M), 1023Gi (L), 2046Gi (XL)
- Validate that `component_overrides.vm_single.size` is a multiple of 93 GiB

## Testing

- `terraform test` on the `sizing_tier` module: 23 passed.
- https://github.com/nebius/soperator/actions/runs/30464584240

## Release Notes

Feature: VMSingle metrics storage uses IO M3 network SSD.