### PR TITLE
Faster initial provisioning of cluster with worker NG autoscaling

### DIFF
--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -305,10 +305,14 @@ slurm_nodeset_workers = [
     autoscaling = {
       enabled = true
       # min_size options:
-      # - null: min=max, no scale-down (default, recommended - saves ~10 min on initial provisioning)
+      # - null: min=max, no scale-down
       #   it can be changed to a number later if needed.
+      # - 0: node group can has no nodes after creation
+      #   (default, recommended at first provisioning of a large cluster
+      #   as there's no wait for nodes to be instantiated during node group creation)
+      #   it should be changed to other number or null later to avoid random node downscale.
       # - N: can scale down to N nodes
-      min_size = null
+      min_size = 0
     }
     resource = {
       platform = "gpu-h100-sxm"

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -770,7 +770,7 @@ variable "slurm_nodeset_workers" {
     size = number
     autoscaling = optional(object({
       enabled  = optional(bool, true)
-      min_size = optional(number)
+      min_size = optional(number, 0)
     }), {})
     resource = object({
       platform = string


### PR DESCRIPTION
## Release Notes (Mandatory Description)

`slurm_nodeset_workers[*].autoscaling.min_size` is set to 0 by default. It allows immediate creation of the node group to unblock Terraform and Helm from provisioning dependent components. Workers are going to be created gradually as soon as they're requested during reconciliation. It's recommended to set this value back to `null` or actual number to avoid random node downscale during cluster operation.