### PR TITLE
SCHED-2236: Adapt terraform to node-local workload log outputs

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -441,6 +441,7 @@ module "slurm" {
   opentelemetry_batch                       = var.opentelemetry_batch
   opentelemetry_sending_queue               = var.opentelemetry_sending_queue
   opentelemetry_delete_jail_logs_after_read = var.opentelemetry_delete_jail_logs_after_read
+  opentelemetry_delete_jail_logs_min_age    = var.opentelemetry_delete_jail_logs_min_age
 
   use_preinstalled_gpu_drivers  = var.use_preinstalled_gpu_drivers
   cuda_version                  = lookup(var.platform_cuda_versions, local.slurm_nodeset_workers[0].resource.platform)

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -611,6 +611,12 @@ dcgm_job_mapping_enabled = true
 # opentelemetry_delete_jail_logs_after_read = false
 opentelemetry_delete_jail_logs_after_read = true
 
+# Minimum time a jail log file must remain unmodified before the OpenTelemetry collector
+# deletes it after reading. Logs are node-local (worker boot disk), so this is also the
+# on-node debugging window. By default, 4h.
+# ---
+# opentelemetry_delete_jail_logs_min_age = "4h"
+
 # Configuration of the Soperator Notifier (https://github.com/nebius/soperator/tree/main/helm/soperator-notifier).
 # ---
 # soperator_notifier = {
@@ -625,7 +631,7 @@ soperator_notifier = {
 # ---
 # nccl_inspector_profiling = {
 #   enabled  = true
-#   dump_dir = "/opt/soperator-outputs/nccl_profiles"
+#   dump_dir = "/opt/soperator-outputs/shared/nccl_profiles"
 #   verbose  = false
 # }
 nccl_inspector_profiling = {

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1510,6 +1510,17 @@ variable "opentelemetry_delete_jail_logs_after_read" {
   default     = true
 }
 
+variable "opentelemetry_delete_jail_logs_min_age" {
+  description = "Minimum time a jail log file must remain unmodified before the OpenTelemetry collector deletes it after reading. Logs are node-local (worker boot disk), so this is also the on-node debugging window."
+  type        = string
+  default     = "4h"
+
+  validation {
+    condition     = can(regex("^[0-9]+(s|m|h)$", var.opentelemetry_delete_jail_logs_min_age))
+    error_message = "Must be a Go-style duration with a single unit, e.g. 90s, 30m, or 4h."
+  }
+}
+
 variable "soperator_notifier" {
   description = "Configuration of the Soperator Notifier (https://github.com/nebius/soperator/tree/main/helm/soperator-notifier)."
   type = object({

--- a/soperator/modules/sizing_tier/main.tf
+++ b/soperator/modules/sizing_tier/main.tf
@@ -143,14 +143,6 @@ locals {
       XL = { memory = "512Mi", cpu = "500m" }
     }
     # Runs on: system nodes.
-    jail_logs_collector = {
-      XS = { memory = "1Gi", cpu = "1000m" }
-      S  = { memory = "1Gi", cpu = "1000m" }
-      M  = { memory = "1Gi", cpu = "1000m" }
-      L  = { memory = "2Gi", cpu = "2000m" }
-      XL = { memory = "4Gi", cpu = "4000m" }
-    }
-    # Runs on: system nodes.
     nccl_profiles_collector = {
       XS = { memory = "200Mi", cpu = "500m" }
       S  = { memory = "200Mi", cpu = "500m" }
@@ -220,6 +212,10 @@ locals {
     # watch is node-scoped); the size-correlated part of the pipeline is the central
     # vm_logs sink, which is tier-scaled above.
     logs_collector = { memory = "200Mi", cpu = "200m" }
+    # Per-worker DaemonSet reading Slurm workload outputs from its own node's boot disk;
+    # its load is bounded by one node's log volume, not by the cluster size. Runs on worker
+    # nodes only, so it is not part of the system-node capacity guard below.
+    jail_logs_collector = { memory = "256Mi", cpu = "200m" }
     # Installs the security profiles onto its own node; the profile count is defined by the
     # workload (soperator ships essentially one static profile), not by the cluster size.
     spo_daemon = { cpu = "100m", memory = "128Mi" }
@@ -250,7 +246,7 @@ locals {
     vm_logs                     = coalesce(var.component_overrides.vm_logs, local.component_presets.vm_logs[local.sizing_tier])
     events_collector            = coalesce(var.component_overrides.events_collector, local.component_presets.events_collector[local.sizing_tier])
     logs_collector              = coalesce(var.component_overrides.logs_collector, local.constant_presets.logs_collector)
-    jail_logs_collector         = coalesce(var.component_overrides.jail_logs_collector, local.component_presets.jail_logs_collector[local.sizing_tier])
+    jail_logs_collector         = coalesce(var.component_overrides.jail_logs_collector, local.constant_presets.jail_logs_collector)
     nccl_profiles_collector     = coalesce(var.component_overrides.nccl_profiles_collector, local.component_presets.nccl_profiles_collector[local.sizing_tier])
   }
 
@@ -341,10 +337,6 @@ locals {
       events_collector = {
         cpu    = tonumber(trimsuffix(local.component_presets.events_collector[tier].cpu, "m")) / 1000
         memory = tonumber(trimsuffix(local.component_presets.events_collector[tier].memory, "Mi")) / 1024
-      }
-      jail_logs_collector = {
-        cpu    = tonumber(trimsuffix(local.component_presets.jail_logs_collector[tier].cpu, "m")) / 1000
-        memory = tonumber(trimsuffix(local.component_presets.jail_logs_collector[tier].memory, "Gi"))
       }
       nccl_profiles_collector = {
         cpu    = tonumber(trimsuffix(local.component_presets.nccl_profiles_collector[tier].cpu, "m")) / 1000

--- a/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
+++ b/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
@@ -149,6 +149,7 @@ run "component_override_wins_over_tier" {
       rest                        = { cpu = 20, memory = 120, ephemeral_storage = 5 }
       vm_single                   = { cpu = "25000m", memory = "24Gi", size = "558Gi", gomaxprocs = 25 }
       logs_collector              = { memory = "1Gi", cpu = "500m" }
+      jail_logs_collector         = { memory = "1Gi", cpu = "1000m" }
       kube_state_metrics          = { requests = { cpu = "300m", memory = "2048Mi" }, limits = { memory = "4096Mi" } }
       soperator_checks_controller = { requests = { cpu = 2, memory = 6 }, limits = { memory = 6 } }
     }
@@ -168,6 +169,10 @@ run "component_override_wins_over_tier" {
   assert {
     condition     = output.preset.logs_collector.memory == "1Gi"
     error_message = "component_overrides.logs_collector must replace the constant"
+  }
+  assert {
+    condition     = output.preset.jail_logs_collector.memory == "1Gi" && output.preset.jail_logs_collector.cpu == "1000m"
+    error_message = "component_overrides.jail_logs_collector must replace the constant"
   }
   assert {
     condition     = output.preset.kube_state_metrics.requests.memory == "2048Mi" && output.preset.kube_state_metrics.limits.memory == "4096Mi"
@@ -212,6 +217,10 @@ run "constants_do_not_scale_with_tier" {
   assert {
     condition     = output.preset.logs_collector.memory == "200Mi" && output.preset.logs_collector.cpu == "200m"
     error_message = "logs_collector must stay constant at XL"
+  }
+  assert {
+    condition     = output.preset.jail_logs_collector.memory == "256Mi" && output.preset.jail_logs_collector.cpu == "200m"
+    error_message = "jail_logs_collector must stay constant at XL (per-worker agent, load bounded by its own node)"
   }
   assert {
     condition     = output.preset.spo_daemon.memory == "128Mi" && output.preset.spo_daemon.cpu == "100m"

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -105,6 +105,7 @@ resource "helm_release" "soperator_fluxcd_cm" {
     opentelemetry_sending_queue               = var.opentelemetry_sending_queue
     opentelemetry_sending_queue_enabled       = local.opentelemetry_sending_queue_enabled
     opentelemetry_delete_jail_logs_after_read = var.opentelemetry_delete_jail_logs_after_read
+    opentelemetry_delete_jail_logs_min_age    = var.opentelemetry_delete_jail_logs_min_age
     prometheus_crds_version                   = var.prometheus_crds_version
     security_profiles_operator_version        = var.security_profiles_operator_version
     vmstack_version                           = var.vmstack_version

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -115,7 +115,7 @@ resources:
                   enabled: true
                   deleteAfterRead:
                     enabled: ${ opentelemetry_delete_jail_logs_after_read }
-                    minAge: 15m
+                    minAge: ${ opentelemetry_delete_jail_logs_min_age }
                   resources:
                     requests:
                       memory: ${resources.jail_logs_collector.memory}

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -560,6 +560,17 @@ variable "opentelemetry_delete_jail_logs_after_read" {
   default     = false
 }
 
+variable "opentelemetry_delete_jail_logs_min_age" {
+  description = "Minimum time a jail log file must remain unmodified before the OpenTelemetry collector deletes it after reading. Logs are node-local (worker boot disk), so this is also the on-node debugging window."
+  type        = string
+  default     = "4h"
+
+  validation {
+    condition     = can(regex("^[0-9]+(s|m|h)$", var.opentelemetry_delete_jail_logs_min_age))
+    error_message = "Must be a Go-style duration with a single unit, e.g. 90s, 30m, or 4h."
+  }
+}
+
 variable "dcgm_job_map_dir" {
   description = "Directory where HPC job mapping files are located"
   type        = string
@@ -688,7 +699,7 @@ variable "nccl_inspector_profiling" {
   type = object({
     enabled  = bool
     verbose  = optional(bool, false)
-    dump_dir = optional(string, "/opt/soperator-outputs/nccl_profiles")
+    dump_dir = optional(string, "/opt/soperator-outputs/shared/nccl_profiles")
   })
   default = {
     enabled = false


### PR DESCRIPTION
## Problem

nebius/soperator#2816 stages workload log outputs on worker boot disks: the jail logs collector becomes a per-worker DaemonSet and shared outputs move under `/opt/soperator-outputs/shared`. The terraform side still sizes the collector as a tier-scaled system-node component (up to 4Gi / 4 CPU) and hardcodes the delete-after-read `minAge` at 15m.

## Solution

- Move `jail_logs_collector` to a constant preset (256Mi / 200m): each replica reads only its own node's logs, so its load does not scale with cluster size. It runs on worker nodes, so it also leaves the system-node capacity guard.
- Add `opentelemetry_delete_jail_logs_min_age` (default `4h`), plumbed through to the fluxcd values instead of the hardcoded 15m. Logs are node-local, so this is also the on-node debugging window.
- Change the `nccl_inspector_profiling.dump_dir` default to `/opt/soperator-outputs/shared/nccl_profiles` to match the new output layout.

## Testing

Updated `sizing_tier` tftests for the constant preset and the override path. `terraform test`: 23 passed, 0 failed.

E2E run on this branch pair: https://github.com/nebius/soperator/actions/runs/30567129248

## Release Notes

Feature: jail log collection runs as a per-worker agent with a constant resource preset; the deletion window is configurable via `opentelemetry_delete_jail_logs_min_age` (default 4h).

