### PR TITLE
SCHED-2157: Continue to use TF generated secret for logs

### DIFF
--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -72,7 +72,13 @@ resources:
           enabled: ${telemetry_enabled}
           clusterName: ${cluster_name}
           publicEndpointEnabled: ${public_o11y_enabled}
+          publicEndpointTokenKind: secret
           region: ${region}
+          tsaToken:
+            secretName: o11y-writer-sa-token
+            secretKey: accessToken
+            writer:
+              enabled: false
           opentelemetry:
             enabled: ${telemetry_enabled}
 


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Changes in https://github.com/nebius/soperator/pull/2800 provides option to use token from IMDS, but clusters provisioned using Terraform need to keep using generated secret (not from IMDS)