### PR TITLE
Add unified NCCL test runner for MK8s clusters

### DIFF
--- a/k8s-training/k8s-runner-unified/README.md
+++ b/k8s-training/k8s-runner-unified/README.md
@@ -78,11 +78,16 @@ Regenerate a report from existing logs at any time:
 | `NODE_GROUP_ID` | — | **Set per cluster** |
 | `RESERVE_CPU_CORES` / `RESERVE_MEM_GI` | `4` / `50` | Headroom left for kubelet/daemonsets |
 | `MAX_LAUNCH_ATTEMPTS` | `6` | Retry budget for the transient launcher glitch |
-| `HOSTS` | `(1 2 3 4)` | Host counts to sweep (auto-capped to available nodes) |
+| `HOSTS` | `(1 2 3 4)` | Host counts to sweep. Auto-capped **down** to available Ready nodes, but never scales **up** past the values listed — on clusters larger than 4 nodes, edit this to test at full scale (e.g. `(1 2 4 8 16)` for a 16-node group). |
 | `TESTS` | `(all_reduce alltoall)` | Add `all_gather reduce_scatter reduce gather broadcast scatter` for a fuller sweep |
 
 ## Scope & caveats
 
+- **Sweep size is set by `HOSTS`, not auto-scaled.** The runner caps requested
+  counts down to the available Ready nodes so it never hangs, but it won't test
+  beyond the largest value in `HOSTS`. For clusters bigger than 4 nodes, add
+  higher counts (powers of two up to your node count, plus the full count) so the
+  full-cluster fabric actually gets measured.
 - **Supported as-is:** Nebius **x86 + InfiniBand** GPU types — H100, H200, B200, B300.
 - **Not supported as-is:** Grace-ARM types (GH200 / GB200) — aarch64, so the x86
   image won't run and the binding math should be re-validated.

--- a/k8s-training/k8s-runner-unified/README.md
+++ b/k8s-training/k8s-runner-unified/README.md
@@ -88,6 +88,10 @@ Regenerate a report from existing logs at any time:
   beyond the largest value in `HOSTS`. For clusters bigger than 4 nodes, add
   higher counts (powers of two up to your node count, plus the full count) so the
   full-cluster fabric actually gets measured.
+  - *Example — 100-node cluster:* set `HOSTS=(1 2 4 8 16 32 64 100)`. Powers of
+    two give a clean scaling curve, and `100` measures the full cluster. Leaving
+    the default `(1 2 3 4)` would test only 4 of your 100 nodes and tell you
+    nothing about the fabric at scale.
 - **Supported as-is:** Nebius **x86 + InfiniBand** GPU types — H100, H200, B200, B300.
 - **Not supported as-is:** Grace-ARM types (GH200 / GB200) — aarch64, so the x86
   image won't run and the binding math should be re-validated.

--- a/k8s-training/k8s-runner-unified/README.md
+++ b/k8s-training/k8s-runner-unified/README.md
@@ -29,12 +29,16 @@ runs `all_reduce` + `alltoall` over both NVLink (single-node) and InfiniBand
    hwthreads/NUMA and aborts on H200's 64/NUMA.)*
 4. **MPIJob API version** — `v1` vs `v2beta1` (installs differ per cluster);
    `launcherCreationPolicy` is only emitted on `v2beta1`.
-5. **Host-count cap** — requested host counts are capped to the number of nodes
-   actually in the node group, so the sweep never hangs on unschedulable jobs.
+5. **Host-count cap** — requested host counts are capped to the number of
+   **Ready, schedulable** nodes in the node group (Cordoned / NotReady nodes are
+   excluded), so the sweep never hangs on unschedulable jobs.
 
-It also takes a **PID lock** (`/tmp/nccl_runner_unified.lock`) so two runners can't
-share the namespace and delete each other's pods, and retries a launch up to
-`MAX_LAUNCH_ATTEMPTS` times if it fails to start.
+Every run creates **uniquely-named, labelled resources** (`nccl-test-<pid>-<epoch>`,
+labelled `nccl-runner/run=<id>`), so two engineers can run against the same
+namespace without touching each other's MPIJob or pods. A local **PID lock**
+(`/tmp/nccl_runner_unified.lock`) additionally prevents accidental double-runs on
+the same workstation, and a launch is retried up to `MAX_LAUNCH_ATTEMPTS` times if
+it fails to start.
 
 ## Usage
 
@@ -60,9 +64,10 @@ Regenerate a report from existing logs at any time:
 ./generate-report.sh results/nccl-<timestamp>
 ```
 
-> **One runner per namespace at a time** — the lock enforces this. Two concurrent
-> runners on the same namespace force-delete each other's pods and produce spurious
-> launcher failures.
+> **Concurrent runs are isolated by unique resource names + labels**, so multiple
+> engineers can share a namespace safely. Cleanup is always scoped to a run's own
+> MPIJob and cascaded gracefully — the runner never force-deletes pods or touches
+> pods it doesn't own.
 
 ## Configuration (top of `nccl_runner_unified.sh`)
 

--- a/k8s-training/k8s-runner-unified/README.md
+++ b/k8s-training/k8s-runner-unified/README.md
@@ -1,0 +1,87 @@
+# Unified NCCL Test Runner
+
+A single, reusable NCCL benchmarking toolchain for Nebius MK8s clusters.
+It **auto-adapts to the GPU node type it is pointed at** (H100 / H200 / B200 / B300)
+instead of hardcoding per-hardware assumptions that break when switching clusters,
+runs `all_reduce` + `alltoall` over both NVLink (single-node) and InfiniBand
+(multi-node), and produces a shareable markdown report.
+
+## Contents
+
+| File | Role |
+|---|---|
+| `nccl_runner_unified.sh` | Orchestrator — detects hardware, renders + runs jobs, retries, reports |
+| `nccl-test-template.yaml` | Parameterized Kubeflow MPIJob (envsubst `${VAR}` placeholders) |
+| `generate-report.sh` | Parses raw logs → `report.md` (auto-invoked by the runner) |
+
+## What it auto-detects (so you don't hardcode it)
+
+1. **Node capacity** — allocatable CPU / memory / GPU → worker resource sizing
+   (`allocatable − RESERVE_*`).
+2. **IB devices** — a throwaway pod runs `ibv_devinfo`; only ports that are
+   `link_layer: InfiniBand` **and** `state: PORT_ACTIVE` are kept, giving the real
+   `NCCL_IB_HCA` list (e.g. B300 → `mlx5_4…11`, H200 → `mlx5_0…7`).
+3. **CPU topology** — `nproc` + NUMA node count + GPU count are used to compute the
+   process binding: `pe = CPUs / GPUs`, `procs_per_numa = GPUs / NUMA`, rendered as
+   `--map-by ppr:${procs_per_numa}:numa:pe=${pe} -bind-to hwthread`. Falls back to
+   coarse `-bind-to numa` when GPUs don't divide evenly across NUMA nodes.
+   *(This is the fix for the B300→H200 breakage: a fixed `pe=24` needs 96
+   hwthreads/NUMA and aborts on H200's 64/NUMA.)*
+4. **MPIJob API version** — `v1` vs `v2beta1` (installs differ per cluster);
+   `launcherCreationPolicy` is only emitted on `v2beta1`.
+5. **Host-count cap** — requested host counts are capped to the number of nodes
+   actually in the node group, so the sweep never hangs on unschedulable jobs.
+
+It also takes a **PID lock** (`/tmp/nccl_runner_unified.lock`) so two runners can't
+share the namespace and delete each other's pods, and retries a launch up to
+`MAX_LAUNCH_ATTEMPTS` times if it fails to start.
+
+## Usage
+
+```bash
+# 1. Install the MPI Operator if it isn't present (the runner tells you if not):
+kubectl apply --server-side -k \
+  "github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.6.0"
+
+# 2. Set NODE_GROUP_ID (and review IMAGE) at the top of nccl_runner_unified.sh.
+#    Find the node group ID with:
+kubectl get nodes -o custom-columns=\
+'NAME:.metadata.name,GROUP:.metadata.labels.nebius\.com/node-group-id,GPU:.status.capacity.nvidia\.com/gpu'
+
+# 3. Run:
+./nccl_runner_unified.sh
+#    -> results/nccl-<timestamp>/<test>-<hosts>.log  (raw NCCL output)
+#    -> results/nccl-<timestamp>/report.md           (auto-generated summary)
+```
+
+Regenerate a report from existing logs at any time:
+
+```bash
+./generate-report.sh results/nccl-<timestamp>
+```
+
+> **One runner per namespace at a time** — the lock enforces this. Two concurrent
+> runners on the same namespace force-delete each other's pods and produce spurious
+> launcher failures.
+
+## Configuration (top of `nccl_runner_unified.sh`)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `NAMESPACE` | `nccl-tests` | Namespace to run in |
+| `IMAGE` | Nebius `nccl-tests` image | Must be pullable on the cluster |
+| `NODE_GROUP_ID` | — | **Set per cluster** |
+| `RESERVE_CPU_CORES` / `RESERVE_MEM_GI` | `4` / `50` | Headroom left for kubelet/daemonsets |
+| `MAX_LAUNCH_ATTEMPTS` | `6` | Retry budget for the transient launcher glitch |
+| `HOSTS` | `(1 2 3 4)` | Host counts to sweep (auto-capped to available nodes) |
+| `TESTS` | `(all_reduce alltoall)` | Add `all_gather reduce_scatter reduce gather broadcast scatter` for a fuller sweep |
+
+## Scope & caveats
+
+- **Supported as-is:** Nebius **x86 + InfiniBand** GPU types — H100, H200, B200, B300.
+- **Not supported as-is:** Grace-ARM types (GH200 / GB200) — aarch64, so the x86
+  image won't run and the binding math should be re-validated.
+- Assumes an **InfiniBand** fabric (RoCE/Ethernet clusters return no IB devices and
+  the runner errors out) and the Nebius `nebius.com/node-group-id` label.
+- `busbw` (bus bandwidth) is the figure to compare against reference numbers.
+  Single-host runs measure intra-node NVLink; multi-host runs cross the IB fabric.

--- a/k8s-training/k8s-runner-unified/generate-report.sh
+++ b/k8s-training/k8s-runner-unified/generate-report.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Generate a shareable markdown report from a unified-runner results directory.
+#
+# The unified runner writes one raw NCCL log per test as "<test>-<hosts>.log"
+# (e.g. all_reduce-2.log). This parses each of those into a combined report —
+# it does NOT talk to the cluster, so it works after pods are long gone.
+#
+# Usage: ./generate-report.sh [results/nccl-<timestamp>]
+#        (defaults to the most recent results/nccl-* directory)
+
+set -e
+
+RESULTS_DIR="${1:-$(ls -dt results/nccl-* 2>/dev/null | head -1)}"
+if [ -z "$RESULTS_DIR" ] || [ ! -d "$RESULTS_DIR" ]; then
+  echo "ERROR: no results directory given and none found under results/nccl-*"
+  echo "Usage: $0 [results/nccl-<timestamp>]"
+  exit 1
+fi
+
+REPORT="$RESULTS_DIR/report.md"
+
+# awk program shared by the summary and per-test sections: emits genuine NCCL
+# data rows only (13 fields, field 3 a real dtype), so NCCL_DEBUG noise is dropped.
+DATA_ROWS='NF==13 && $3 ~ /^(float|double|half|bfloat16|int|int8|uint8|char)$/'
+
+# Collect the log files, sorted by host count then test name for a stable order.
+mapfile -t LOGS < <(ls "$RESULTS_DIR"/*.log 2>/dev/null | sort)
+if [ "${#LOGS[@]}" -eq 0 ]; then
+  echo "ERROR: no *.log files in $RESULTS_DIR"
+  exit 1
+fi
+
+{
+  echo "# NCCL Test Report"
+  echo ""
+  echo "**Results directory:** \`$RESULTS_DIR\`"
+  echo "**Generated:** $(date '+%Y-%m-%d %H:%M:%S %Z')"
+  echo ""
+  echo "> \`busbw\` (bus bandwidth) is the hardware-utilization figure to compare against"
+  echo "> reference numbers. Single-host runs exercise intra-node NVLink; multi-host runs"
+  echo "> cross the InfiniBand fabric. Peak is the max across the size sweep (some collectives"
+  echo "> — notably alltoall — peak mid-sweep and decline, so the last row is not the peak)."
+  echo ""
+
+  # ---- Summary table ----
+  echo "## Summary"
+  echo ""
+  echo "| Test | Hosts | Scope | Transport | Peak busbw (oop) | @ size | Errors |"
+  echo "|---|---|---|---|---|---|---|"
+  for f in "${LOGS[@]}"; do
+    base=$(basename "$f" .log)
+    hosts="${base##*-}"
+    test="${base%-*}"
+    if [ "$hosts" -gt 1 ] 2>/dev/null; then scope="cross-node"; else scope="single-node"; fi
+    if grep -q "Using network IB" "$f" 2>/dev/null; then
+      transport=$([ "$hosts" -gt 1 ] 2>/dev/null && echo "InfiniBand" || echo "NVLink (IB init'd)")
+    else
+      transport="?"
+    fi
+    # peak busbw (field 8) and its size (field 1); errors if any field 9/13 nonzero (N/A ok)
+    read -r peak psize < <(awk "$DATA_ROWS"' {if($8+0>max){max=$8+0;sz=$1}} END{printf "%.1f %s\n", max, sz}' "$f")
+    errs=$(awk "$DATA_ROWS"' (($9!="N/A" && $9+0!=0)||($13!="N/A" && $13+0!=0)){c++} END{print c+0}' "$f")
+    errflag=$([ "$errs" -eq 0 ] && echo "none ✓" || echo "$errs ⚠️")
+    echo "| $test | $hosts | $scope | $transport | ${peak} GB/s | ${psize}B | $errflag |"
+  done
+  echo ""
+
+  # ---- Per-test detail ----
+  HEADER="| Size (B) | Count | Type | Redop | Root | Time(us) oop | Algbw oop | Busbw oop | Err oop | Time(us) ip | Algbw ip | Busbw ip | Err ip |"
+  DIVIDER="|---|---|---|---|---|---|---|---|---|---|---|---|---|"
+  for f in "${LOGS[@]}"; do
+    base=$(basename "$f" .log)
+    hosts="${base##*-}"
+    test="${base%-*}"
+    echo "---"
+    echo ""
+    echo "## $test — $hosts host(s)"
+    echo ""
+
+    ROWS=$(awk "$DATA_ROWS" "$f")
+    if [ -z "$ROWS" ]; then
+      echo "_No data rows found — the test may not have completed._"
+      echo ""
+      continue
+    fi
+
+    # Peak row (max busbw oop) and largest-size row.
+    PEAK_ROW=$(echo "$ROWS" | sort -k8,8 -g | tail -1)
+    LAST_ROW=$(echo "$ROWS" | tail -1)
+    read -r p_size _ _ _ _ _ _ p_oop _ _ _ p_ip _ <<<"$PEAK_ROW"
+    read -r l_size _ _ _ _ _ _ l_oop _ _ _ l_ip _ <<<"$LAST_ROW"
+
+    echo "**Peak busbw @ ${p_size}B:** ${p_oop} GB/s (oop) / ${p_ip} GB/s (ip)"
+    echo ""
+    if [ "$p_size" != "$l_size" ]; then
+      echo "**Note:** peak is mid-sweep; at the largest size (${l_size}B) busbw is ${l_oop} GB/s (oop) / ${l_ip} GB/s (ip)."
+      echo ""
+    fi
+
+    ERRORS=$(echo "$ROWS" | awk '($9!="N/A" && $9+0!=0)||($13!="N/A" && $13+0!=0)')
+    if [ -n "$ERRORS" ]; then
+      echo "**⚠️ Non-zero error column(s) — possible data corruption:**"
+      echo ""; echo '```'; echo "$ERRORS"; echo '```'
+    else
+      echo "**Correctness:** error columns all zero — no data corruption."
+    fi
+    echo ""
+
+    echo "$HEADER"; echo "$DIVIDER"
+    echo "$ROWS" | awk '{printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13}'
+    echo ""
+  done
+} > "$REPORT"
+
+echo "Report written to: $REPORT"

--- a/k8s-training/k8s-runner-unified/generate-report.sh
+++ b/k8s-training/k8s-runner-unified/generate-report.sh
@@ -8,7 +8,7 @@
 # Usage: ./generate-report.sh [results/nccl-<timestamp>]
 #        (defaults to the most recent results/nccl-* directory)
 
-set -e
+set -eo pipefail
 
 RESULTS_DIR="${1:-$(ls -dt results/nccl-* 2>/dev/null | head -1)}"
 if [ -z "$RESULTS_DIR" ] || [ ! -d "$RESULTS_DIR" ]; then
@@ -24,7 +24,11 @@ REPORT="$RESULTS_DIR/report.md"
 DATA_ROWS='NF==13 && $3 ~ /^(float|double|half|bfloat16|int|int8|uint8|char)$/'
 
 # Collect the log files, sorted by host count then test name for a stable order.
-mapfile -t LOGS < <(ls "$RESULTS_DIR"/*.log 2>/dev/null | sort)
+# Built with a read loop rather than `mapfile`, which is bash 4+ (macOS ships 3.2).
+LOGS=()
+while IFS= read -r logfile; do
+  [ -n "$logfile" ] && LOGS+=("$logfile")
+done < <(ls "$RESULTS_DIR"/*.log 2>/dev/null | sort)
 if [ "${#LOGS[@]}" -eq 0 ]; then
   echo "ERROR: no *.log files in $RESULTS_DIR"
   exit 1
@@ -56,6 +60,15 @@ fi
       transport=$([ "$hosts" -gt 1 ] 2>/dev/null && echo "InfiniBand" || echo "NVLink (IB init'd)")
     else
       transport="?"
+    fi
+    # Guard against an empty/failed log: with no NCCL data rows the awk aggregates
+    # below return peak 0 and zero errors, which would render as a green
+    # "0.0 GB/s | none ✓" even for a run that only produced a launcher failure.
+    # Require at least one parsed data row before reporting any result.
+    nrows=$(awk "$DATA_ROWS"' {c++} END{print c+0}' "$f")
+    if [ "$nrows" -eq 0 ]; then
+      echo "| $test | $hosts | $scope | $transport | — | — | ✗ no data (incomplete/failed) |"
+      continue
     fi
     # peak busbw (field 8) and its size (field 1); errors if any field 9/13 nonzero (N/A ok)
     read -r peak psize < <(awk "$DATA_ROWS"' {if($8+0>max){max=$8+0;sz=$1}} END{printf "%.1f %s\n", max, sz}' "$f")

--- a/k8s-training/k8s-runner-unified/nccl-test-template.yaml
+++ b/k8s-training/k8s-runner-unified/nccl-test-template.yaml
@@ -1,8 +1,11 @@
 apiVersion: kubeflow.org/${MPIJOB_API_VERSION}
 kind: MPIJob
 metadata:
-  name: nccl-test
+  name: ${JOB_NAME}
   namespace: ${NAMESPACE}
+  labels:
+    nccl-runner/run: "${RUN_SUFFIX}"
+    nccl-runner/owner: "${RUN_OWNER}"
 spec:
   slotsPerWorker: ${GPUS_PER_NODE}
   ${LAUNCHER_CREATION_POLICY_LINE}
@@ -12,6 +15,10 @@ spec:
     Launcher:
       replicas: 1
       template:
+        metadata:
+          labels:
+            nccl-runner/run: "${RUN_SUFFIX}"
+            nccl-runner/role: launcher
         spec:
           containers:
             - image: ${IMAGE}
@@ -42,6 +49,10 @@ spec:
     Worker:
       replicas: ${WORKER_REPLICAS}
       template:
+        metadata:
+          labels:
+            nccl-runner/run: "${RUN_SUFFIX}"
+            nccl-runner/role: worker
         spec:
           tolerations:
             - key: nvidia.com/gpu

--- a/k8s-training/k8s-runner-unified/nccl-test-template.yaml
+++ b/k8s-training/k8s-runner-unified/nccl-test-template.yaml
@@ -1,0 +1,79 @@
+apiVersion: kubeflow.org/${MPIJOB_API_VERSION}
+kind: MPIJob
+metadata:
+  name: nccl-test
+  namespace: ${NAMESPACE}
+spec:
+  slotsPerWorker: ${GPUS_PER_NODE}
+  ${LAUNCHER_CREATION_POLICY_LINE}
+  runPolicy:
+    cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - image: ${IMAGE}
+              name: nccl-test
+              env:
+                - name: OMPI_ALLOW_RUN_AS_ROOT
+                  value: "1"
+                - name: OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
+                  value: "1"
+              command: ["/bin/bash", "-c"]
+              args:
+                - >
+                  mpirun
+                  -bind-to ${BIND_TO}
+                  --map-by ${MAP_BY_SPEC}
+                  -x NCCL_SOCKET_IFNAME=eth0
+                  -x UCX_NET_DEVICES=${UCX_NET_DEVICE}
+                  -x OMPI_MCA_coll_hcoll_enable=0
+                  -x OMPI_MCA_coll_ucc_enable=0
+                  -x NCCL_DEBUG=INFO
+                  -x NCCL_IB_HCA=${NCCL_IB_HCA}
+                  -x UCX_DC_MLX5_TX_POLICY=hw_dcs
+                  /opt/nccl_tests/build/${TEST_BINARY}_perf -b 8 -e 64G -f 2 -g 1 -t 1
+              resources:
+                requests:
+                  cpu: 1
+                  memory: 128Mi
+    Worker:
+      replicas: ${WORKER_REPLICAS}
+      template:
+        spec:
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nebius.com/node-group-id
+                        operator: In
+                        values:
+                          - ${NODE_GROUP_ID}
+          containers:
+            - image: ${IMAGE}
+              name: nccl-test
+              securityContext:
+                privileged: true
+              resources:
+                requests:
+                  cpu: "${WORKER_CPU}"
+                  memory: ${WORKER_MEMORY}
+                  nvidia.com/gpu: ${GPUS_PER_NODE}
+                limits:
+                  cpu: "${WORKER_CPU_LIMIT}"
+                  memory: ${WORKER_MEMORY}
+                  nvidia.com/gpu: ${GPUS_PER_NODE}
+              volumeMounts:
+                - mountPath: /dev/shm
+                  name: dshm
+          volumes:
+            - name: dshm
+              emptyDir:
+                medium: Memory

--- a/k8s-training/k8s-runner-unified/nccl_runner_unified.sh
+++ b/k8s-training/k8s-runner-unified/nccl_runner_unified.sh
@@ -1,0 +1,339 @@
+#!/bin/bash
+# Unified NCCL test runner — auto-discovers IB devices and API version on
+# whatever cluster/GPU type it's pointed at, instead of hardcoding either.
+#
+# Usage: ./nccl-runner-unified.sh
+
+set -e
+
+# Guard against a second concurrent runner. Two runners sharing the nccl-tests
+# namespace delete each other's launcher/worker pods mid-launch, which looks
+# exactly like random launcher crashes ("lost communication") — don't allow it.
+LOCKFILE="/tmp/nccl_runner_unified.lock"
+if [ -f "$LOCKFILE" ] && kill -0 "$(cat "$LOCKFILE" 2>/dev/null)" 2>/dev/null; then
+  echo "ERROR: another nccl_runner_unified.sh is already running (PID $(cat "$LOCKFILE"))."
+  echo "Two runners on the same namespace stomp each other's pods. Let it finish first,"
+  echo "or if that PID is dead, remove $LOCKFILE and re-run."
+  exit 1
+fi
+echo $$ > "$LOCKFILE"
+trap 'rm -f "$LOCKFILE"' EXIT
+
+# ============ CONFIGURE FOR YOUR CLUSTER ============
+NAMESPACE=nccl-tests
+TEMPLATE=nccl-test-template.yaml
+IMAGE="cr.eu-north1.nebius.cloud/e00b94r7bkvywphmn6/nccl-tests:v2.18.3-cudav13.2.1-ncclv2.30.4-1-hpcxv2.26"
+
+# GPU node group ID — get via:
+#   kubectl get nodes -o custom-columns='NAME:.metadata.name,GROUP:.metadata.labels.nebius\.com/node-group-id,GPU:.status.capacity.nvidia\.com/gpu'
+NODE_GROUP_ID="mk8snodegroup-e02j9bmhyza8zwvj9c"
+
+# Worker resource sizing — auto-detected below from actual node capacity.
+# RESERVE values are headroom left for kubelet, device plugins, DaemonSets, etc.
+RESERVE_CPU_CORES=4
+RESERVE_MEM_GI=50
+
+# The MPIJob launcher intermittently fails to start with an hwloc/topology
+# init glitch ("opal_hwloc_base_open failed" / "binding policy not recognized")
+# — a transient race that clears on a fresh launch. Each failed attempt fails
+# fast (launcher crash-loops within ~1 min), so we just relaunch a few times.
+MAX_LAUNCH_ATTEMPTS=6
+
+HOSTS=(1 2 3 4)
+# The two tests that actually matter for validating a cluster: all_reduce
+# (canonical bus-bandwidth number) and alltoall (stresses the fabric hardest).
+# The other NCCL collectives are nice-to-haves — add them here if you want a
+# fuller sweep: all_gather reduce_scatter reduce gather broadcast scatter
+TESTS=(all_reduce alltoall)
+# ======================================================
+
+echo "=== Detecting node capacity for node group $NODE_GROUP_ID ==="
+NODE_NAMES=($(kubectl get nodes -l "nebius.com/node-group-id=$NODE_GROUP_ID" -o jsonpath='{.items[*].metadata.name}'))
+NODE_NAME="${NODE_NAMES[0]}"
+if [ -z "$NODE_NAME" ]; then
+  echo "ERROR: no nodes found matching node-group-id=$NODE_GROUP_ID"
+  exit 1
+fi
+NODE_COUNT=${#NODE_NAMES[@]}
+
+# Drop any requested host counts that exceed the nodes actually in this group,
+# so the tool "just runs" on a 2-node cluster without hanging on unschedulable
+# 3-/4-node jobs.
+CAPPED_HOSTS=()
+for h in "${HOSTS[@]}"; do
+  if [ "$h" -le "$NODE_COUNT" ]; then CAPPED_HOSTS+=("$h"); fi
+done
+if [ "${#CAPPED_HOSTS[@]}" -lt "${#HOSTS[@]}" ]; then
+  echo "NOTE: node group has $NODE_COUNT node(s); capping host counts to ${CAPPED_HOSTS[*]} (dropped: was ${HOSTS[*]})"
+fi
+HOSTS=("${CAPPED_HOSTS[@]}")
+
+ALLOC_CPU_RAW=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.cpu}')
+ALLOC_MEM_RAW=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.memory}')
+GPUS_PER_NODE=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
+if [ -z "$GPUS_PER_NODE" ] || [ "$GPUS_PER_NODE" -le 0 ] 2>/dev/null; then
+  echo "ERROR: node '$NODE_NAME' reports no allocatable nvidia.com/gpu — is this a GPU node group?"
+  exit 1
+fi
+
+# CPU may be reported as whole cores ("128") or millicores ("127900m") — normalize to millicores.
+if [[ "$ALLOC_CPU_RAW" == *m ]]; then
+  ALLOC_CPU_MILLI="${ALLOC_CPU_RAW%m}"
+else
+  ALLOC_CPU_MILLI=$((ALLOC_CPU_RAW * 1000))
+fi
+ALLOC_CPU_CORES=$((ALLOC_CPU_MILLI / 1000))
+
+# Memory is typically reported in Ki — convert to Gi (1 Gi = 1,048,576 Ki).
+ALLOC_MEM_KI="${ALLOC_MEM_RAW%Ki}"
+ALLOC_MEM_GI=$((ALLOC_MEM_KI / 1048576))
+
+WORKER_CPU_LIMIT=$((ALLOC_CPU_CORES - RESERVE_CPU_CORES))
+WORKER_CPU=$((WORKER_CPU_LIMIT - RESERVE_CPU_CORES))  # small gap between request/limit, same pattern as before
+WORKER_MEMORY_GI=$((ALLOC_MEM_GI - RESERVE_MEM_GI))
+WORKER_MEMORY="${WORKER_MEMORY_GI}Gi"
+
+if [ "$WORKER_CPU" -le 0 ] || [ "$WORKER_MEMORY_GI" -le 0 ]; then
+  echo "ERROR: computed worker sizing is non-positive (CPU=$WORKER_CPU, MEM=${WORKER_MEMORY_GI}Gi)."
+  echo "Node allocatable was: CPU=$ALLOC_CPU_CORES cores, MEM=${ALLOC_MEM_GI}Gi — check RESERVE_* values."
+  exit 1
+fi
+
+echo "Node '$NODE_NAME' allocatable: ${ALLOC_CPU_CORES} CPU cores, ${ALLOC_MEM_GI}Gi memory, ${GPUS_PER_NODE} GPUs"
+echo "Worker sizing: request=${WORKER_CPU} CPU / limit=${WORKER_CPU_LIMIT} CPU, memory=${WORKER_MEMORY}"
+echo ""
+
+echo "=== Discovering IB devices on node group $NODE_GROUP_ID ==="
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+# Spin up a single throwaway pod on the target node group to inspect real IB hardware.
+# This removes all guesswork about mlx5_X numbering per GPU type — it asks the
+# actual node what devices it has, every time.
+cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ib-discovery
+  namespace: $NAMESPACE
+spec:
+  restartPolicy: Never
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: nebius.com/node-group-id
+                operator: In
+                values:
+                  - $NODE_GROUP_ID
+  containers:
+    - name: ib-discovery
+      image: $IMAGE
+      command: ["sleep", "120"]
+      securityContext:
+        privileged: true
+EOF
+
+echo "Waiting for discovery pod to be ready..."
+if ! kubectl wait --namespace "$NAMESPACE" --for=condition=Ready pod/ib-discovery --timeout=120s; then
+  echo "ERROR: discovery pod never became ready — check GPU availability / node affinity."
+  kubectl delete pod ib-discovery -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1
+  exit 1
+fi
+
+# List all devices, then keep only ones that are actually InfiniBand and ACTIVE.
+ALL_DEVICES=$(kubectl exec -n "$NAMESPACE" ib-discovery -- bash -c "ibv_devices | tail -n +3 | awk '{print \$1}'" 2>/dev/null)
+
+if [ -z "$ALL_DEVICES" ]; then
+  echo "ERROR: no IB devices found at all on this node (ibv_devices returned nothing)."
+  kubectl delete pod ib-discovery -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1
+  exit 1
+fi
+
+ACTIVE_DEVICES=""
+for dev in $ALL_DEVICES; do
+  INFO=$(kubectl exec -n "$NAMESPACE" ib-discovery -- ibv_devinfo -d "$dev" 2>/dev/null)
+  LINK_LAYER=$(echo "$INFO" | grep -oP 'link_layer:\s*\K\S+')
+  STATE=$(echo "$INFO" | grep -oP 'state:\s*PORT_\K[A-Z]+')
+  if [ "$LINK_LAYER" == "InfiniBand" ] && [ "$STATE" == "ACTIVE" ]; then
+    ACTIVE_DEVICES="${ACTIVE_DEVICES}${ACTIVE_DEVICES:+,}${dev}"
+  fi
+done
+
+# While the discovery pod is still up, grab CPU topology from the SAME node so
+# process binding can be computed instead of hardcoded. The old template used
+# a fixed "ppr:4:numa:pe=24" tuned for B300's wide CPUs — that demands 96
+# hwthreads/NUMA and aborts on narrower nodes (e.g. H200: 64 hwthreads/NUMA),
+# which surfaces as the launcher's "ORTE has lost communication" crash.
+CONTAINER_CPUS=$(kubectl exec -n "$NAMESPACE" ib-discovery -- nproc 2>/dev/null)
+NUMA_NODES=$(kubectl exec -n "$NAMESPACE" ib-discovery -- bash -c 'ls -d /sys/devices/system/node/node[0-9]* 2>/dev/null | wc -l' 2>/dev/null)
+
+kubectl delete pod ib-discovery -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1
+
+if [ -z "$ACTIVE_DEVICES" ]; then
+  echo "ERROR: no ACTIVE InfiniBand devices found among: $ALL_DEVICES"
+  echo "Check node health, fabric config, or run ibv_devinfo manually to investigate."
+  exit 1
+fi
+
+NCCL_IB_HCA="$ACTIVE_DEVICES"
+FIRST_DEVICE=$(echo "$ACTIVE_DEVICES" | cut -d',' -f1)
+UCX_NET_DEVICE="${FIRST_DEVICE}:1"
+
+echo "Discovered active IB devices: $NCCL_IB_HCA"
+echo "Using UCX_NET_DEVICES: $UCX_NET_DEVICE"
+echo ""
+
+# Compute process binding from the real CPU/NUMA/GPU topology.
+# One rank per GPU, ranks spread evenly across NUMA nodes, each rank pinned to
+# an equal share of that NUMA's hwthreads (pe). Filling exactly avoids ORTE's
+# "binding more processes than cpus" overload abort. When GPUs don't divide
+# evenly across NUMA nodes (or topology couldn't be read), fall back to a
+# coarse NUMA binding that has no per-element requirement and can't overload.
+if [ -n "$CONTAINER_CPUS" ] && [ -n "$NUMA_NODES" ] && [ "$NUMA_NODES" -gt 0 ] 2>/dev/null \
+   && [ $((GPUS_PER_NODE % NUMA_NODES)) -eq 0 ]; then
+  PROCS_PER_NUMA=$((GPUS_PER_NODE / NUMA_NODES))
+  PE_PER_PROC=$((CONTAINER_CPUS / GPUS_PER_NODE))   # = hwthreads-per-NUMA / procs-per-NUMA
+  if [ "$PE_PER_PROC" -ge 1 ]; then
+    BIND_TO="hwthread"
+    MAP_BY_SPEC="ppr:${PROCS_PER_NUMA}:numa:pe=${PE_PER_PROC}"
+  fi
+fi
+if [ -z "${MAP_BY_SPEC:-}" ]; then
+  echo "NOTE: falling back to coarse NUMA binding (CPUs=${CONTAINER_CPUS:-?}, NUMA=${NUMA_NODES:-?}, GPUs=$GPUS_PER_NODE)"
+  BIND_TO="numa"
+  MAP_BY_SPEC="ppr:${GPUS_PER_NODE}:node"
+fi
+echo "Detected topology: ${CONTAINER_CPUS:-?} hwthreads across ${NUMA_NODES:-?} NUMA node(s), $GPUS_PER_NODE GPUs"
+echo "Process binding: -bind-to $BIND_TO --map-by $MAP_BY_SPEC"
+echo ""
+
+# Auto-detect the MPIJob API version actually registered on THIS cluster.
+# Different clusters/operator installs register v1 or v2beta1 — hardcoding
+# either one breaks on the other, so detect it fresh each run.
+MPIJOB_API_VERSION=$(kubectl get crd mpijobs.kubeflow.org -o jsonpath='{.spec.versions[0].name}' 2>/dev/null)
+if [ -z "$MPIJOB_API_VERSION" ]; then
+  echo "ERROR: mpijobs.kubeflow.org CRD not found on this cluster."
+  echo "Install the MPI Operator first, e.g.:"
+  echo "  kubectl apply --server-side -k \"github.com/kubeflow/mpi-operator/manifests/overlays/standalone?ref=v0.6.0\""
+  exit 1
+fi
+echo "Detected MPIJob API version: $MPIJOB_API_VERSION"
+
+# launcherCreationPolicy only exists on v2beta1 — omit entirely on v1
+if [ "$MPIJOB_API_VERSION" == "v2beta1" ]; then
+  LAUNCHER_CREATION_POLICY_LINE="launcherCreationPolicy: WaitForWorkersReady"
+else
+  LAUNCHER_CREATION_POLICY_LINE=""
+fi
+
+# Watch a launched job and classify the outcome:
+#   PASS    — MPIJob reached Succeeded (real results are in the launcher log)
+#   FLAKE   — launcher crash-looped or the job failed early (the hwloc glitch); retry
+#   TIMEOUT — job ran but never finished within the window; don't retry, just collect
+watch_job() {
+  local waited=0 timeout=1500 interval=5 lp rs failed
+  while [ "$waited" -lt "$timeout" ]; do
+    if kubectl get mpijob nccl-test -n "$NAMESPACE" \
+         -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null | grep -q True; then
+      echo PASS; return
+    fi
+    failed=$(kubectl get mpijob nccl-test -n "$NAMESPACE" \
+         -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+    if [ "$failed" == "True" ]; then echo FLAKE; return; fi
+    lp=$(kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null | grep launcher | head -1)
+    rs=$(kubectl get -n "$NAMESPACE" "$lp" -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null)
+    if [ "${rs:-0}" -ge 3 ] 2>/dev/null; then echo FLAKE; return; fi
+    sleep "$interval"; waited=$((waited + interval))
+  done
+  echo TIMEOUT
+}
+
+OUTPUT_PATH=results/nccl-$(date +"%Y-%m-%d_%H-%M-%S")
+mkdir -p "$OUTPUT_PATH"
+
+for HOST_NUM in "${HOSTS[@]}"; do
+  for TEST in "${TESTS[@]}"; do
+    echo "=== Starting $TEST on $HOST_NUM host(s) ==="
+
+    # Clean up any leftover release from a prior iteration before starting
+    kubectl delete mpijob nccl-test -n "$NAMESPACE" --ignore-not-found || true
+    kubectl delete pods --all -n "$NAMESPACE" --grace-period=0 --force || true
+    sleep 2
+
+    RENDERED=$(mktemp)
+    NAMESPACE="$NAMESPACE" \
+    IMAGE="$IMAGE" \
+    UCX_NET_DEVICE="$UCX_NET_DEVICE" \
+    NCCL_IB_HCA="$NCCL_IB_HCA" \
+    NODE_GROUP_ID="$NODE_GROUP_ID" \
+    WORKER_REPLICAS="$HOST_NUM" \
+    WORKER_CPU="$WORKER_CPU" \
+    WORKER_CPU_LIMIT="$WORKER_CPU_LIMIT" \
+    WORKER_MEMORY="$WORKER_MEMORY" \
+    GPUS_PER_NODE="$GPUS_PER_NODE" \
+    BIND_TO="$BIND_TO" \
+    MAP_BY_SPEC="$MAP_BY_SPEC" \
+    TEST_BINARY="$TEST" \
+    MPIJOB_API_VERSION="$MPIJOB_API_VERSION" \
+    LAUNCHER_CREATION_POLICY_LINE="$LAUNCHER_CREATION_POLICY_LINE" \
+    envsubst < "$TEMPLATE" > "$RENDERED"
+
+    # Launch, retrying on the transient launcher hwloc glitch (see MAX_LAUNCH_ATTEMPTS).
+    OUTCOME=""
+    for ATTEMPT in $(seq 1 "$MAX_LAUNCH_ATTEMPTS"); do
+      echo "Launch attempt $ATTEMPT/$MAX_LAUNCH_ATTEMPTS..."
+      kubectl apply -f "$RENDERED" >/dev/null
+      OUTCOME=$(watch_job)
+      if [ "$OUTCOME" == "PASS" ]; then
+        echo "Job succeeded."
+        break
+      elif [ "$OUTCOME" == "TIMEOUT" ]; then
+        echo "Job ran but did not finish within the window — collecting logs anyway."
+        break
+      fi
+      # FLAKE — relaunch on a clean slate
+      echo "Launcher glitched before starting (transient hwloc init); relaunching..."
+      kubectl delete mpijob nccl-test -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1
+      kubectl delete pods --all -n "$NAMESPACE" --grace-period=0 --force >/dev/null 2>&1
+      sleep 3
+    done
+    if [ "$OUTCOME" != "PASS" ] && [ "$OUTCOME" != "TIMEOUT" ]; then
+      echo "WARNING: $TEST on $HOST_NUM host(s) never launched cleanly after $MAX_LAUNCH_ATTEMPTS attempts."
+    fi
+
+    echo "Collecting logs..."
+    # Launcher pod name varies by API version (v2beta1 appends a random suffix),
+    # so resolve it by name match instead of assuming a fixed name.
+    LAUNCHER_POD=$(kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null | grep launcher | head -1)
+    if [ -n "$LAUNCHER_POD" ]; then
+      kubectl logs --namespace "$NAMESPACE" "$LAUNCHER_POD" > "$OUTPUT_PATH/$TEST-$HOST_NUM.log" 2>&1 || true
+    else
+      echo "WARNING: no launcher pod found to collect logs from." | tee "$OUTPUT_PATH/$TEST-$HOST_NUM.log"
+    fi
+
+    echo "Cleaning up..."
+    kubectl delete -f "$RENDERED" --ignore-not-found >/dev/null 2>&1
+    rm -f "$RENDERED"
+  done
+done
+
+echo ""
+echo "All tests complete. Logs saved to: $OUTPUT_PATH"
+
+# Auto-generate the shareable markdown report from the raw logs just collected.
+REPORT_SCRIPT="$(dirname "$0")/generate-report.sh"
+if [ -x "$REPORT_SCRIPT" ]; then
+  echo "Generating report..."
+  if "$REPORT_SCRIPT" "$OUTPUT_PATH"; then
+    echo "Report: $OUTPUT_PATH/report.md"
+  else
+    echo "WARNING: report generation failed — raw logs are still in $OUTPUT_PATH"
+  fi
+else
+  echo "NOTE: $REPORT_SCRIPT not found/executable — skipping report (raw logs are in $OUTPUT_PATH)."
+fi

--- a/k8s-training/k8s-runner-unified/nccl_runner_unified.sh
+++ b/k8s-training/k8s-runner-unified/nccl_runner_unified.sh
@@ -4,29 +4,60 @@
 #
 # Usage: ./nccl-runner-unified.sh
 
-set -e
+# Exit on error and surface failures mid-pipeline. We deliberately do NOT add -u:
+# the script relies on conditionally-unset vars (e.g. MAP_BY_SPEC and empty query
+# results), guarded with ${var:-} where it matters.
+set -eo pipefail
 
-# Guard against a second concurrent runner. Two runners sharing the nccl-tests
-# namespace delete each other's launcher/worker pods mid-launch, which looks
-# exactly like random launcher crashes ("lost communication") — don't allow it.
+# Prevent accidental double-runs on THIS workstation (they'd share the local
+# results dir and lock). Cross-workstation safety does not come from this lock —
+# it comes from the unique per-run resource names/labels below.
 LOCKFILE="/tmp/nccl_runner_unified.lock"
 if [ -f "$LOCKFILE" ] && kill -0 "$(cat "$LOCKFILE" 2>/dev/null)" 2>/dev/null; then
-  echo "ERROR: another nccl_runner_unified.sh is already running (PID $(cat "$LOCKFILE"))."
-  echo "Two runners on the same namespace stomp each other's pods. Let it finish first,"
-  echo "or if that PID is dead, remove $LOCKFILE and re-run."
+  echo "ERROR: another nccl_runner_unified.sh is already running on this machine (PID $(cat "$LOCKFILE"))."
+  echo "Let it finish first, or if that PID is dead, remove $LOCKFILE and re-run."
   exit 1
 fi
 echo $$ > "$LOCKFILE"
 trap 'rm -f "$LOCKFILE"' EXIT
+
+# Unique per-run resource identity. A local lock can't stop a second engineer on
+# a different workstation from driving the same namespace, so every run names and
+# labels its own MPIJob/pods (nccl-test-<pid>-<epoch>, label nccl-runner/run=<id>).
+# All lookups and cleanup below are scoped to these, so concurrent runs sharing a
+# namespace never touch each other's resources.
+RUN_SUFFIX="$$-$(date +%s)"
+JOB_NAME="nccl-test-${RUN_SUFFIX}"
+# Sanitize into a valid Kubernetes label value: lowercase, non-alphanumerics to
+# '-', collapse repeats, and trim leading/trailing '-' (a label must start and
+# end alphanumeric — e.g. id -un's trailing newline would otherwise leave "user-").
+RUN_OWNER=$(id -un 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed -E 's/-+/-/g; s/^-+//; s/-+$//')
+RUN_OWNER="${RUN_OWNER:0:40}"
+RUN_OWNER="${RUN_OWNER:-unknown}"
+
+# Clean up this run's cluster resources on exit or interrupt (Ctrl-C). Everything
+# we create is uniquely named/labelled for this run, so this only ever removes our
+# own MPIJob and discovery pod — never another engineer's. Idempotent, so it's
+# harmless on a normal exit where per-iteration cleanup has already run.
+cleanup() {
+  rm -f "$LOCKFILE"
+  [ -z "${NAMESPACE:-}" ] && return
+  kubectl delete mpijob "$JOB_NAME" -n "$NAMESPACE" \
+    --ignore-not-found --cascade=foreground --wait=false >/dev/null 2>&1 || true
+  kubectl delete pod ib-discovery -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # ============ CONFIGURE FOR YOUR CLUSTER ============
 NAMESPACE=nccl-tests
 TEMPLATE=nccl-test-template.yaml
 IMAGE="cr.eu-north1.nebius.cloud/e00b94r7bkvywphmn6/nccl-tests:v2.18.3-cudav13.2.1-ncclv2.30.4-1-hpcxv2.26"
 
-# GPU node group ID — get via:
+# GPU node group ID — SET THIS for your cluster. Get it via:
 #   kubectl get nodes -o custom-columns='NAME:.metadata.name,GROUP:.metadata.labels.nebius\.com/node-group-id,GPU:.status.capacity.nvidia\.com/gpu'
-NODE_GROUP_ID="mk8snodegroup-e02j9bmhyza8zwvj9c"
+NODE_GROUP_ID="<your-node-group-id>"   # e.g. mk8snodegroup-xxxxxxxxxxxxxxxxxx
 
 # Worker resource sizing — auto-detected below from actual node capacity.
 # RESERVE values are headroom left for kubelet, device plugins, DaemonSets, etc.
@@ -47,11 +78,31 @@ HOSTS=(1 2 3 4)
 TESTS=(all_reduce alltoall)
 # ======================================================
 
+if [ -z "$NODE_GROUP_ID" ] || [[ "$NODE_GROUP_ID" == "<"* ]]; then
+  echo "ERROR: set NODE_GROUP_ID at the top of this script to your GPU node group ID."
+  echo "Find it with:"
+  echo "  kubectl get nodes -o custom-columns='NAME:.metadata.name,GROUP:.metadata.labels.nebius\\.com/node-group-id'"
+  exit 1
+fi
+
 echo "=== Detecting node capacity for node group $NODE_GROUP_ID ==="
-NODE_NAMES=($(kubectl get nodes -l "nebius.com/node-group-id=$NODE_GROUP_ID" -o jsonpath='{.items[*].metadata.name}'))
-NODE_NAME="${NODE_NAMES[0]}"
+# Count only nodes that can actually take work: Ready AND schedulable. A Cordoned
+# or NotReady node still carries the node-group label, so counting it would size a
+# host sweep the cluster can't place — the launcher never appears and watch_job
+# then burns the full timeout waiting for it.
+NODE_NAMES=()
+while read -r name ready unsched; do
+  [ -n "$name" ] || continue
+  [ "$ready" = "True" ] || continue
+  [ "$unsched" = "true" ] && continue
+  NODE_NAMES+=("$name")
+done < <(kubectl get nodes -l "nebius.com/node-group-id=$NODE_GROUP_ID" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.conditions[?(@.type=="Ready")].status}{" "}{.spec.unschedulable}{"\n"}{end}')
+
+NODE_NAME="${NODE_NAMES[0]:-}"
 if [ -z "$NODE_NAME" ]; then
-  echo "ERROR: no nodes found matching node-group-id=$NODE_GROUP_ID"
+  echo "ERROR: no Ready, schedulable nodes found for node-group-id=$NODE_GROUP_ID"
+  echo "(Nodes may be Cordoned or NotReady — check: kubectl get nodes -l nebius.com/node-group-id=$NODE_GROUP_ID)"
   exit 1
 fi
 NODE_COUNT=${#NODE_NAMES[@]}
@@ -157,8 +208,10 @@ fi
 ACTIVE_DEVICES=""
 for dev in $ALL_DEVICES; do
   INFO=$(kubectl exec -n "$NAMESPACE" ib-discovery -- ibv_devinfo -d "$dev" 2>/dev/null)
-  LINK_LAYER=$(echo "$INFO" | grep -oP 'link_layer:\s*\K\S+')
-  STATE=$(echo "$INFO" | grep -oP 'state:\s*PORT_\K[A-Z]+')
+  # ibv_devinfo prints "link_layer: InfiniBand" and "state: PORT_ACTIVE (4)".
+  # Parse with awk — grep -oP (PCRE / \K) is GNU-only and not available on macOS.
+  LINK_LAYER=$(echo "$INFO" | awk '$1=="link_layer:"{print $2; exit}')
+  STATE=$(echo "$INFO" | awk '$1=="state:"{sub(/^PORT_/,"",$2); print $2; exit}')
   if [ "$LINK_LAYER" == "InfiniBand" ] && [ "$STATE" == "ACTIVE" ]; then
     ACTIVE_DEVICES="${ACTIVE_DEVICES}${ACTIVE_DEVICES:+,}${dev}"
   fi
@@ -238,14 +291,14 @@ fi
 watch_job() {
   local waited=0 timeout=1500 interval=5 lp rs failed
   while [ "$waited" -lt "$timeout" ]; do
-    if kubectl get mpijob nccl-test -n "$NAMESPACE" \
+    if kubectl get mpijob "$JOB_NAME" -n "$NAMESPACE" \
          -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null | grep -q True; then
       echo PASS; return
     fi
-    failed=$(kubectl get mpijob nccl-test -n "$NAMESPACE" \
+    failed=$(kubectl get mpijob "$JOB_NAME" -n "$NAMESPACE" \
          -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
     if [ "$failed" == "True" ]; then echo FLAKE; return; fi
-    lp=$(kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null | grep launcher | head -1)
+    lp=$(kubectl get pods -n "$NAMESPACE" -l "nccl-runner/run=$RUN_SUFFIX,nccl-runner/role=launcher" -o name 2>/dev/null | head -1)
     rs=$(kubectl get -n "$NAMESPACE" "$lp" -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null)
     if [ "${rs:-0}" -ge 3 ] 2>/dev/null; then echo FLAKE; return; fi
     sleep "$interval"; waited=$((waited + interval))
@@ -256,16 +309,25 @@ watch_job() {
 OUTPUT_PATH=results/nccl-$(date +"%Y-%m-%d_%H-%M-%S")
 mkdir -p "$OUTPUT_PATH"
 
+# Count tests that never launched cleanly, so the script can exit non-zero at the
+# end — a run where nothing launched must not look like success to a caller/CI.
+FAILED_TESTS=0
+
 for HOST_NUM in "${HOSTS[@]}"; do
   for TEST in "${TESTS[@]}"; do
     echo "=== Starting $TEST on $HOST_NUM host(s) ==="
 
-    # Clean up any leftover release from a prior iteration before starting
-    kubectl delete mpijob nccl-test -n "$NAMESPACE" --ignore-not-found || true
-    kubectl delete pods --all -n "$NAMESPACE" --grace-period=0 --force || true
-    sleep 2
+    # Clean up this run's previous iteration before starting. Scoped to our own
+    # uniquely-named MPIJob and cascaded gracefully (foreground) so we delete the
+    # pods this MPIJob owns — never unrelated pods, and never a force-kill that
+    # removes Pod objects before their processes have actually stopped.
+    kubectl delete mpijob "$JOB_NAME" -n "$NAMESPACE" \
+      --ignore-not-found --cascade=foreground --wait=true --timeout=60s || true
 
     RENDERED=$(mktemp)
+    JOB_NAME="$JOB_NAME" \
+    RUN_SUFFIX="$RUN_SUFFIX" \
+    RUN_OWNER="$RUN_OWNER" \
     NAMESPACE="$NAMESPACE" \
     IMAGE="$IMAGE" \
     UCX_NET_DEVICE="$UCX_NET_DEVICE" \
@@ -296,20 +358,21 @@ for HOST_NUM in "${HOSTS[@]}"; do
         echo "Job ran but did not finish within the window — collecting logs anyway."
         break
       fi
-      # FLAKE — relaunch on a clean slate
+      # FLAKE — relaunch on a clean slate (scoped, graceful; no force-delete)
       echo "Launcher glitched before starting (transient hwloc init); relaunching..."
-      kubectl delete mpijob nccl-test -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1
-      kubectl delete pods --all -n "$NAMESPACE" --grace-period=0 --force >/dev/null 2>&1
+      kubectl delete mpijob "$JOB_NAME" -n "$NAMESPACE" \
+        --ignore-not-found --cascade=foreground --wait=true --timeout=60s >/dev/null 2>&1 || true
       sleep 3
     done
     if [ "$OUTCOME" != "PASS" ] && [ "$OUTCOME" != "TIMEOUT" ]; then
       echo "WARNING: $TEST on $HOST_NUM host(s) never launched cleanly after $MAX_LAUNCH_ATTEMPTS attempts."
+      FAILED_TESTS=$((FAILED_TESTS + 1))
     fi
 
     echo "Collecting logs..."
     # Launcher pod name varies by API version (v2beta1 appends a random suffix),
     # so resolve it by name match instead of assuming a fixed name.
-    LAUNCHER_POD=$(kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null | grep launcher | head -1)
+    LAUNCHER_POD=$(kubectl get pods -n "$NAMESPACE" -l "nccl-runner/run=$RUN_SUFFIX,nccl-runner/role=launcher" -o name 2>/dev/null | head -1)
     if [ -n "$LAUNCHER_POD" ]; then
       kubectl logs --namespace "$NAMESPACE" "$LAUNCHER_POD" > "$OUTPUT_PATH/$TEST-$HOST_NUM.log" 2>&1 || true
     else
@@ -336,4 +399,11 @@ if [ -x "$REPORT_SCRIPT" ]; then
   fi
 else
   echo "NOTE: $REPORT_SCRIPT not found/executable — skipping report (raw logs are in $OUTPUT_PATH)."
+fi
+
+# Fail loudly if any test never launched, so callers/CI can tell a run went bad
+# even though logs and a report were still produced.
+if [ "$FAILED_TESTS" -gt 0 ]; then
+  echo "ERROR: $FAILED_TESTS test(s) never launched cleanly — see WARNING lines above and $OUTPUT_PATH."
+  exit 1
 fi


### PR DESCRIPTION
## Summary
Adds a single, reusable NCCL benchmarking toolchain for Nebius MK8s clusters that **auto-adapts to the GPU node type** (H100/H200/B200/B300) instead of hardcoding per-hardware assumptions that break when switching clusters.

## What it auto-detects per run
- **Node capacity** (CPU/mem/GPU) → worker resource sizing
- **Active InfiniBand devices** via `ibv_devinfo` (e.g. B300 `mlx5_4..11` vs H200 `mlx5_0..7`)
- **CPU/NUMA topology** → process binding `pe = CPUs/GPUs`. *This fixes the B300→H200 breakage where a hardcoded `pe=24` needs 96 hwthreads/NUMA and aborts on H200's 64/NUMA.*
- **MPIJob API version** (`v1` vs `v2beta1`) → correct manifest variant
- **Available node count** → caps host counts so sweeps never hang on unschedulable jobs

## Behavior
Runs `all_reduce` + `alltoall` over NVLink (single-node) and InfiniBand (multi-node), takes a PID lock so two runners can't stomp each other's pods, retries transient launcher glitches, and auto-generates a markdown `report.md`.

## Files
- `nccl_runner_unified.sh` — orchestrator
- `nccl-test-template.yaml` — parameterized MPIJob
- `generate-report.sh` — raw logs → report
- `README.md`

## Validation
Verified end-to-end on a 2-node H200 cluster: all 4 jobs pass, cross-node runs confirmed `Using network IB` across all 8 HCAs. Peak busbw: all_reduce ~482 GB/s (NVLink & IB), alltoall ~347 (NVLink) / ~92 (IB), zero data errors.

## Scope
Nebius x86 + InfiniBand types (H100/H200/B200/B300). Grace-ARM (GH200/GB200) would need an aarch64 image and re-validated binding math.

