### PR TITLE
Add GPU soak test for MK8s clusters

### DIFF
--- a/k8s-training/gpu-soak-test/README.md
+++ b/k8s-training/gpu-soak-test/README.md
@@ -1,0 +1,222 @@
+# GPU Soak Test — MK8s Equivalent of cloudmeter auto-loader
+
+A Kubernetes-native GPU soak test that replicates the cloudmeter auto-loader's goal on MK8s clusters: sustained GPU compute + HBM fill + InfiniBand/NVLink stress with structured pass/fail output and a clean report.
+
+It runs as a **PyTorchJob** using a single PyTorch image on every pod. `torchrun`
+launches one `torch.distributed` rank per GPU, and each rank concurrently:
+
+1. **Fills HBM** with a resident FP16 tensor (default 75% of device memory),
+2. **Stresses compute** with a continuous FP16 matmul loop (drives util to ~100%),
+3. **Stresses the fabric** with a timed, verified `all_reduce` every iteration.
+
+This avoids the launcher/worker image split that a `nccl-tests` + `mpirun` setup
+requires — PyTorch bundles NCCL, so the same container does the memory fill and
+the collective, and the collective's exit code is authoritative (a real NCCL
+failure fails the job).
+
+## What it tests
+
+| Auto-loader (Slurm) | This tool (MK8s) |
+|---|---|
+| HPL stresses GPUs | PyTorch FP16 matmul stresses GPUs |
+| Fills GPU memory | Dynamic HBM fill — 75% of total memory per GPU (tunable via `HBM_FILL_FRACTION`; leaves NCCL headroom) |
+| NCCL allreduce stresses IB | `torch.distributed.all_reduce` every iteration, verified + busbw measured |
+| GPU temperature monitoring | GPU temperature monitoring (fail >83°C) |
+| GPU overheating check | XID error detection via node dmesg (best-effort; flagged UNVERIFIED if unavailable) |
+| sacct job tracking | Kubernetes pod status tracking |
+| tmux session | Foreground monitor + structured report file |
+
+## Prerequisites
+
+- Kubeflow Training Operator installed (provides the PyTorchJob CRD):
+  ```bash
+  kubectl apply -k 'github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=v1.7.0'
+  ```
+- GPU nodes present and Ready in the cluster
+- kubectl configured and authenticated
+
+## Usage
+
+```bash
+chmod +x run-soak-test.sh scripts/monitor.sh
+
+# 10 minute POC sanity check (2 nodes)
+./run-soak-test.sh 600 2
+
+# 1 hour soak (2 nodes)
+./run-soak-test.sh 3600 2
+
+# 2 hour production handoff run (4 nodes)
+./run-soak-test.sh 7200 4
+
+# Non-interactive (CI): auto-delete the namespace at the end
+AUTO_CLEANUP=y ./run-soak-test.sh 600 2
+
+# More aggressive HBM fill
+HBM_FILL_FRACTION=0.85 ./run-soak-test.sh 3600 2
+```
+
+Duration argument is in seconds: 600 = 10 min, 3600 = 1 hour, 7200 = 2 hours.
+
+For a customer running week-long training jobs, 10 minutes is a sanity check only. Run 2-4 hours minimum for a production handoff to catch thermal creep, slow HBM memory errors, and IB link degradation that only surface under sustained load.
+
+## GPU compatibility — choosing the image (READ THIS for GB300 / B200)
+
+The soak *workload* is generic PyTorch and runs on any CUDA GPU. The only thing
+tied to a specific GPU is the **container image** (`SOAK_IMAGE`), which must match
+both the GPU's compute architecture and the node's CPU architecture:
+
+| GPU | Architecture | CPU | Default image (`24.01`) | `SOAK_IMAGE` to set |
+|---|---|---|---|---|
+| **H100 SXM** | Hopper (sm_90) | x86 | ✅ works (validated) | none — default |
+| **H200 SXM** | Hopper (sm_90) | x86 | ✅ works | none — default |
+| **B200 SXM** | Blackwell (sm_100) | x86 | ❌ CUDA too old | `nvcr.io/nvidia/pytorch:25.06-py3` (or newer) |
+| **GB200** | Blackwell | ARM (Grace) | ❌ arch + CUDA | `nvcr.io/nvidia/pytorch:25.06-py3` (or newer) + `MAX_TEMP=90` |
+| **GB300** | Blackwell Ultra | ARM (Grace) | ❌ arch + CUDA | `nvcr.io/nvidia/pytorch:25.06-py3` (or newer) + `MAX_TEMP=90` |
+
+Why the default doesn't cover Blackwell: `nvcr.io/nvidia/pytorch:24.01-py3` ships
+CUDA 12.3, which predates Blackwell (sm_100) — kernels fail with *"no kernel image
+available for execution on the device."* **Blackwell support begins in the NGC
+PyTorch `25.01` release** (CUDA 12.8+); use a recent `25.x` or newer. NGC PyTorch
+tags are **multi-arch** (the same tag serves x86 and ARM/SBSA), so GB200/GB300
+Grace nodes pull the arm64 build automatically from the same tag — no separate
+arm64 tag needed.
+
+```bash
+# H100 / H200 — nothing to set, the default just works
+./run-soak-test.sh 7200 2
+
+# B200 (x86 Blackwell)
+SOAK_IMAGE=nvcr.io/nvidia/pytorch:25.06-py3 ./run-soak-test.sh 7200 2
+
+# GB200 / GB300 (ARM Blackwell) — same tag (multi-arch) + higher thermal threshold
+SOAK_IMAGE=nvcr.io/nvidia/pytorch:25.06-py3 MAX_TEMP=90 ./run-soak-test.sh 7200 2
+```
+
+`25.06-py3` is a known-good example — prefer the **newest** `YY.MM-py3` (≥ `25.01`),
+or a **Nebius-recommended image** if their GB300 docs publish one. Before a
+multi-hour run on a new GPU, verify the tag and run a short smoke:
+
+```bash
+# Confirm CUDA >=12.6 and Blackwell (sm_100) in the image's compiled arch list:
+docker run --rm nvcr.io/nvidia/pytorch:25.06-py3 \
+  python -c "import torch; print(torch.version.cuda); print(torch.cuda.get_arch_list())"
+# Smoke test (5 min) before committing:
+AUTO_CLEANUP=y SOAK_IMAGE=nvcr.io/nvidia/pytorch:25.06-py3 ./run-soak-test.sh 300 2
+```
+
+Everything else — GPU detection, HBM sizing, 8-GPU layout, NCCL, monitoring,
+report — adapts automatically; only `SOAK_IMAGE` (and `MAX_TEMP` for Blackwell)
+changes per platform.
+
+## GPU type detection — automatic
+
+The script automatically detects whatever GPU node type is present in the cluster at runtime. No configuration needed.
+
+```
+Detecting GPU node type in cluster...
+Detected GPU type: gpu-h100-sxm
+GPU name: H100 SXM (80GB HBM3)
+```
+
+| Hardware | nodeSelector (auto-detected) |
+|---|---|
+| H100 SXM | `gpu-h100-sxm` |
+| H200 SXM | `gpu-h200-sxm` |
+| B200 SXM | `gpu-b200-sxm` |
+| B300 SXM | `gpu-b300-sxm` |
+
+To confirm available GPU types in your cluster:
+```bash
+kubectl get nodes -L node.kubernetes.io/instance-type
+```
+
+## HBM memory fill — dynamic
+
+Each rank queries total GPU memory at runtime and fills `HBM_FILL_FRACTION`
+(default 0.75) of it, regardless of GPU type. Allocation order reserves the
+all_reduce buffer and matmul working set first, then a resident "hog" tensor
+occupies the remainder — so the collective always has headroom and never OOMs.
+
+| GPU | Total HBM | Fill target (75%) |
+|---|---|---|
+| H100 SXM | 80 GB | ~60 GB |
+| H200 SXM | 141 GB | ~106 GB |
+| B200 SXM | 192 GB | ~144 GB |
+
+## What runs
+
+**Every pod (master + workers), one rank per GPU via `torchrun`:**
+- Resident FP16 hog tensor fills HBM to the configured fraction
+- Continuous `torch.matmul(ma, mb, out=mc)` loop (zero runtime allocation) → ~100% util
+- Timed `dist.all_reduce` each iteration across all ranks (IB inter-node, NVLink intra-node)
+- Verifies the all_reduce result each iteration and measures busbw
+- Master (rank 0) prints `BUSBW_GBPS` / `BUSBW_AVG_GBPS` and the pass/fail line;
+  its exit code fails the job on any incorrect result
+
+**Monitor:**
+- Polls every 30 seconds across all job pods
+- Checks GPU temperature, utilization, power draw via nvidia-smi
+- Single end-of-run XID check via node dmesg (marked UNVERIFIED if it cannot run)
+- Checks node Ready status
+- Writes a structured log file and generates a clean report at completion
+
+## Pass/fail criteria
+
+| Check | Pass condition |
+|---|---|
+| NCCL all_reduce | Master exit code 0 (all iterations correct) |
+| GPU temperature | Never exceeds 83°C |
+| XID errors | Zero detected (WARN if the check could not run) |
+| GPU utilization | Stays above 80% (fewer than 10 low-util events) |
+
+## Expected results on H100 SXM
+
+| Metric | Expected |
+|---|---|
+| GPU utilization | ~100% |
+| HBM fill | ~75% (~60 GB of 80 GB) |
+| Temperature | 60–80°C under sustained load |
+| Power draw | 650–700W per GPU |
+| all_reduce busbw | >300 GB/s intra-node (NVLink); inter-node bounded by IB fabric |
+
+## Output files
+
+After each run two files are written to the `gpu-soak-test/` directory:
+
+- `soak-monitor-YYYYMMDD_HHMMSS.log` — full detailed log with every poll and GPU stat
+- `soak-report-YYYYMMDD_HHMMSS.txt` — clean summary report with pass/fail verdict
+
+## Monitoring during the run
+
+```bash
+# Watch master (rank 0) logs — busbw + iteration results
+kubectl logs -f -n gpu-soak -l training.kubeflow.org/replica-type=master
+
+# Watch all pod status
+kubectl get pods -n gpu-soak -w
+
+# Check GPU stats on any job pod directly
+POD=$(kubectl get pods -n gpu-soak -l training.kubeflow.org/replica-type=master -o name | head -1)
+kubectl exec -n gpu-soak ${POD#pod/} -c pytorch -- \
+  nvidia-smi --query-gpu=index,temperature.gpu,utilization.gpu,power.draw \
+  --format=csv,noheader
+```
+
+## Cleanup
+
+The script prompts for cleanup at the end (or use `AUTO_CLEANUP=y`). To clean up manually:
+
+```bash
+kubectl delete namespace gpu-soak
+```
+
+## Known limitations
+
+- Requires the Kubeflow Training Operator (PyTorchJob CRD)
+- Inter-node IB stress requires 2+ GPU nodes — a single node exercises intra-node NVLink only
+- 10 minute run is a sanity check only — use 2+ hours for production handoff
+- XID detection relies on node dmesg via `kubectl debug node`; where that is not
+  permitted (and no DCGM exporter is present) XID is reported UNVERIFIED rather
+  than falsely clean
+- Auto-loader uses HPL (High Performance Linpack), a certified benchmark — this tool uses PyTorch matmul as the compute stressor, which achieves equivalent GPU utilization and thermal stress but is not the same certified benchmark

--- a/k8s-training/gpu-soak-test/README.md
+++ b/k8s-training/gpu-soak-test/README.md
@@ -32,6 +32,12 @@ failure fails the job).
   ```bash
   kubectl apply -k 'github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=v1.7.0'
   ```
+  > **Heads-up for clusters that already run an MPI operator** (e.g. Slurm-on-K8s /
+  > soperator setups): the Training Operator's standalone bundle also ships an
+  > `mpijobs.kubeflow.org` CRD, which can collide with an existing one at a
+  > different version and leave the operator crash-looping (PyTorchJobs then never
+  > reconcile). If you already have a Training Operator, skip this install; if you
+  > have a conflicting MPI operator, reconcile the `mpijobs` CRD versions first.
 - GPU nodes present and Ready in the cluster
 - kubectl configured and authenticated
 
@@ -211,8 +217,28 @@ The script prompts for cleanup at the end (or use `AUTO_CLEANUP=y`). To clean up
 kubectl delete namespace gpu-soak
 ```
 
+## Troubleshooting
+
+**Worker pod stuck in `Init:Error` on the first run.** The Kubeflow Training
+Operator injects a worker init container that waits only ~200s for the master
+pod's DNS. On a cold cluster the first-time pull of the (large, ~20GB) NGC image
+can take longer than that, so the worker gives up before the master is Ready.
+
+The runner **pre-pulls the image onto the target GPU nodes** (via a short-lived
+DaemonSet) before submitting the job, which avoids this in the normal case. If
+you still hit it — e.g. the pre-pull timed out on a very slow registry — just
+re-run once the image is cached, or pre-pull manually:
+
+```bash
+kubectl get nodes -l node.kubernetes.io/instance-type=gpu-h200-sxm -o name
+# then let the pre-pull finish, or crictl pull the image on those nodes
+```
+
 ## Known limitations
 
+- **Single-tenant** — a soak saturates every GPU on the cluster, so run only one
+  at a time. The script refuses to start if the `gpu-soak` namespace already has
+  running pods, rather than deleting another run's resources out from under it.
 - Requires the Kubeflow Training Operator (PyTorchJob CRD)
 - Inter-node IB stress requires 2+ GPU nodes — a single node exercises intra-node NVLink only
 - 10 minute run is a sanity check only — use 2+ hours for production handoff

--- a/k8s-training/gpu-soak-test/run-soak-test.sh
+++ b/k8s-training/gpu-soak-test/run-soak-test.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+# =============================================================================
+# GPU Soak Test Runner (PyTorchJob / torch.distributed)
+# Equivalent to cloudmeter auto-loader for MK8s clusters.
+# Runs sustained GPU compute + HBM fill + NCCL all_reduce (IB/NVLink) stress
+# for a configurable duration, then emits a structured pass/fail report.
+#
+# Usage:
+#   ./run-soak-test.sh [duration_seconds] [gpu_node_count]
+#
+# Examples:
+#   ./run-soak-test.sh              # 1 hour, 2 nodes (defaults)
+#   ./run-soak-test.sh 7200 2       # 2 hours, 2 nodes
+#   ./run-soak-test.sh 3600 4       # 1 hour, 4 nodes
+#
+# Environment overrides:
+#   SOAK_IMAGE          Container image (default is a Hopper/H100 CUDA 12.3 image;
+#                       set a CUDA 12.6+ arm64 image for Blackwell B200/GB200/GB300)
+#   HBM_FILL_FRACTION   Fraction of HBM to fill per GPU (default 0.75)
+#   MAX_TEMP            Overtemp threshold in °C (default 83; raise for Blackwell)
+#   AUTO_CLEANUP=y      Delete the namespace at the end without prompting
+#
+# What it tests (equivalent to auto-loader):
+#   - Sustained GPU utilization across all GPU nodes
+#   - Configurable HBM fill (dynamically sized to GPU type)
+#   - InfiniBand/NVLink stress via repeated NCCL all_reduce (verified + busbw)
+#   - GPU temperature monitoring (fail if > 83°C)
+#   - XID error detection (best-effort; flagged UNVERIFIED if unavailable)
+#   - Node health monitoring
+#   - Structured pass/fail output
+# =============================================================================
+set -euo pipefail
+
+DURATION="${1:-3600}"
+NODE_COUNT="${2:-2}"
+NAMESPACE="gpu-soak"
+SLOTS=8
+HBM_FILL_FRACTION="${HBM_FILL_FRACTION:-0.75}"
+# Container image for the workload. The default is a Hopper-era PyTorch (CUDA
+# 12.3) that works on H100/H200. It will NOT run on Blackwell (B200/GB200/GB300)
+# — those need a newer CUDA 12.6+ image, and Grace-based GB200/GB300 also need an
+# arm64/sbsa image. Override per platform, e.g.:
+#   SOAK_IMAGE=nvcr.io/nvidia/pytorch:<blackwell-arm64-tag> ./run-soak-test.sh ...
+SOAK_IMAGE="${SOAK_IMAGE:-nvcr.io/nvidia/pytorch:24.01-py3}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPORT_FILE="soak-report-$(date +%Y%m%d_%H%M%S).txt"
+START_TIME=$(date -u)
+START_EPOCH=$(date +%s)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Delete the test namespace. Guarded so it runs at most once.
+CLEANED=0
+cleanup_ns() {
+  [ "$CLEANED" = "1" ] && return
+  CLEANED=1
+  echo ""
+  echo "Cleaning up namespace $NAMESPACE ..."
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found=true --wait=false 2>/dev/null || true
+}
+# On Ctrl-C / termination, tear down so an aborted run never leaks GPU pods.
+trap 'cleanup_ns; exit 130' INT TERM
+
+echo "=== GPU Soak Test (PyTorchJob / torch.distributed) ==="
+echo "Duration:     ${DURATION}s ($(( DURATION / 60 )) minutes)"
+echo "GPU nodes:    $NODE_COUNT"
+echo "GPUs/node:    $SLOTS"
+echo "HBM fill:     $(awk "BEGIN{printf \"%.0f\", ${HBM_FILL_FRACTION}*100}")%"
+echo "Image:        $SOAK_IMAGE"
+echo "Namespace:    $NAMESPACE"
+echo "Started:      $START_TIME"
+echo ""
+
+# Verify the Training Operator (PyTorchJob CRD) is installed
+if ! kubectl get crd pytorchjobs.kubeflow.org &>/dev/null; then
+  echo -e "${RED}ERROR: Kubeflow Training Operator (PyTorchJob) not installed${NC}"
+  echo "Install it with:"
+  echo "  kubectl apply -k 'github.com/kubeflow/training-operator/manifests/overlays/standalone?ref=v1.7.0'"
+  exit 1
+fi
+
+# =============================================================================
+# DYNAMIC GPU NODE DETECTION
+# =============================================================================
+echo "Detecting GPU node type in cluster..."
+
+GPU_INSTANCE_TYPE=$(kubectl get nodes \
+  -o jsonpath='{.items[*].metadata.labels.node\.kubernetes\.io/instance-type}' \
+  2>/dev/null | tr ' ' '\n' | grep -v "cpu" | sort | uniq -c | sort -rn | head -1 | awk '{print $2}' || echo "")
+
+if [ -z "$GPU_INSTANCE_TYPE" ]; then
+  echo -e "${RED}ERROR: No GPU nodes found in cluster${NC}"
+  echo "Ensure GPU nodes are Ready and have the node.kubernetes.io/instance-type label"
+  exit 1
+fi
+
+echo "Detected GPU type: $GPU_INSTANCE_TYPE"
+
+case "$GPU_INSTANCE_TYPE" in
+  gpu-h100-sxm)  GPU_NAME="H100 SXM (80GB HBM3)" ;;
+  gpu-h200-sxm)  GPU_NAME="H200 SXM (141GB HBM3e)" ;;
+  gpu-b200-sxm)  GPU_NAME="B200 SXM (192GB HBM3e)" ;;
+  gpu-b300-sxm)  GPU_NAME="B300 SXM" ;;
+  *)             GPU_NAME="$GPU_INSTANCE_TYPE" ;;
+esac
+
+echo "GPU name: $GPU_NAME"
+
+# Verify enough Ready GPU nodes are available.
+# NOTE: `grep -c Ready` is wrong — "NotReady" contains the substring "Ready",
+# so it would count degraded nodes as available. Match the STATUS column exactly.
+AVAILABLE_GPU_NODES=$(kubectl get nodes -l "node.kubernetes.io/instance-type=${GPU_INSTANCE_TYPE}" \
+  --no-headers 2>/dev/null | awk '$2=="Ready"' | wc -l | tr -d ' ')
+
+if [ "$AVAILABLE_GPU_NODES" -lt "$NODE_COUNT" ]; then
+  echo -e "${RED}ERROR: Requested $NODE_COUNT GPU nodes but only $AVAILABLE_GPU_NODES available${NC}"
+  exit 1
+fi
+
+echo "GPU nodes available: $AVAILABLE_GPU_NODES ✓"
+echo ""
+
+# Clean up any previous run
+kubectl delete namespace $NAMESPACE --ignore-not-found=true
+kubectl wait --for=delete namespace/$NAMESPACE --timeout=120s 2>/dev/null || true
+
+# Create namespace + mount the workload script as a ConfigMap
+kubectl create namespace $NAMESPACE
+kubectl create configmap soak-script -n $NAMESPACE \
+  --from-file=soak.py="$SCRIPT_DIR/scripts/soak.py"
+
+# Patch the PyTorchJob template. Worker replicas = total nodes - 1 (master is
+# rank 0 and also runs GPUs), so total pods == NODE_COUNT.
+WORKER_REPLICAS=$(( NODE_COUNT - 1 ))
+MANIFEST=$(sed \
+  -e "s/__GPU_INSTANCE_TYPE__/${GPU_INSTANCE_TYPE}/g" \
+  -e "s/__WORKER_REPLICAS__/${WORKER_REPLICAS}/g" \
+  -e "s/__DURATION__/${DURATION}/g" \
+  -e "s/__FILL_FRACTION__/${HBM_FILL_FRACTION}/g" \
+  -e "s/__SLOTS__/${SLOTS}/g" \
+  -e "s|__SOAK_IMAGE__|${SOAK_IMAGE}|g" \
+  "$SCRIPT_DIR/templates/pytorchjob.yaml")
+
+echo "$MANIFEST" | kubectl apply -f -
+
+echo ""
+echo "PyTorchJob submitted. Waiting for master pod to start..."
+
+kubectl wait --namespace $NAMESPACE \
+  --for=condition=Ready \
+  --timeout=300s \
+  -l training.kubeflow.org/replica-type=master \
+  pod 2>/dev/null || true
+
+echo "Pods started. Beginning monitoring..."
+echo ""
+echo "To watch master logs in another terminal:"
+echo "  kubectl logs -f -n $NAMESPACE -l training.kubeflow.org/replica-type=master"
+echo ""
+
+# Run monitor. set +e so a FAILED soak still produces a report and cleans up
+# (bash monitor.sh returning non-zero must NOT abort this script under set -e).
+set +e
+bash "$SCRIPT_DIR/scripts/monitor.sh"
+MONITOR_EXIT=$?
+set -e
+
+# Collect final master logs (rank 0 prints the summary + BUSBW lines)
+MASTER_LOGS=$(kubectl logs -n $NAMESPACE -l training.kubeflow.org/replica-type=master 2>/dev/null | tail -40)
+
+END_TIME=$(date -u)
+END_EPOCH=$(date +%s)
+ACTUAL_DURATION=$(( END_EPOCH - START_EPOCH ))
+
+# =============================================================================
+# GENERATE REPORT
+# =============================================================================
+generate_report() {
+  local LOG_FILE
+  LOG_FILE=$(ls -t "$SCRIPT_DIR"/soak-monitor-*.log 2>/dev/null | head -1)
+
+  # NOTE: `grep -c` prints "0" AND exits 1 when there are no matches, so a
+  # trailing `|| echo 0` would DOUBLE it to "0\n0" and break the "= 0" tests
+  # below. Use `|| true` (keeps grep's own "0") and default empties to 0.
+  local TOTAL_POLLS OVERTEMP LOW_UTIL XID XID_UNVERIFIED
+  TOTAL_POLLS=$(grep -c "Poll #" "$LOG_FILE" 2>/dev/null || true); TOTAL_POLLS=${TOTAL_POLLS:-0}
+  OVERTEMP=$(grep -c "OVERTEMP" "$LOG_FILE" 2>/dev/null || true); OVERTEMP=${OVERTEMP:-0}
+  LOW_UTIL=$(grep -c "LOW UTIL" "$LOG_FILE" 2>/dev/null || true); LOW_UTIL=${LOW_UTIL:-0}
+  XID=$(grep "XID errors detected:" "$LOG_FILE" 2>/dev/null | grep -oP 'detected: \K[0-9]+' | tail -1 || true); XID=${XID:-0}
+  XID_UNVERIFIED=$(grep -c "XID_UNVERIFIED" "$LOG_FILE" 2>/dev/null || true); XID_UNVERIFIED=${XID_UNVERIFIED:-0}
+
+  local MAX_TEMP MAX_UTIL MAX_POWER AVG_UTIL AVG_TEMP
+  MAX_TEMP=$(grep "temp=" "$LOG_FILE" 2>/dev/null | grep -oP 'temp=\K[0-9]+' | sort -n | tail -1 || echo "N/A")
+  MAX_UTIL=$(grep "util=" "$LOG_FILE" 2>/dev/null | grep -oP 'util=\K[0-9]+' | sort -n | tail -1 || echo "N/A")
+  MAX_POWER=$(grep "power=" "$LOG_FILE" 2>/dev/null | grep -oP 'power=\K[0-9.]+' | sort -n | tail -1 || echo "N/A")
+  AVG_UTIL=$(grep "util=" "$LOG_FILE" 2>/dev/null | grep -oP 'util=\K[0-9]+' | awk '{s+=$1;c++} END {if(c)printf "%.0f", s/c; else print "N/A"}')
+  AVG_TEMP=$(grep "temp=" "$LOG_FILE" 2>/dev/null | grep -oP 'temp=\K[0-9]+' | awk '{s+=$1;c++} END {if(c)printf "%.0f", s/c; else print "N/A"}')
+
+  # NCCL evidence straight from the master (rank 0) logs
+  local PEAK_BUSBW AVG_BUSBW ITERS FAILED_ITERS
+  PEAK_BUSBW=$(echo "$MASTER_LOGS" | grep -oP 'BUSBW_GBPS: \K[0-9.]+' | tail -1 || echo "N/A")
+  AVG_BUSBW=$(echo "$MASTER_LOGS" | grep -oP 'BUSBW_AVG_GBPS: \K[0-9.]+' | tail -1 || echo "N/A")
+  ITERS=$(echo "$MASTER_LOGS" | grep -oP 'Total iterations: \K[0-9]+' | tail -1 || echo "N/A")
+  FAILED_ITERS=$(echo "$MASTER_LOGS" | grep -oP 'Failed iterations \(all ranks\): \K[0-9]+' | tail -1 || echo "N/A")
+
+  local RESULT="PASSED"
+  if [ "$MONITOR_EXIT" != "0" ]; then RESULT="FAILED"; fi
+
+  cat > "$SCRIPT_DIR/$REPORT_FILE" << REPORT
+================================================================================
+  GPU SOAK TEST REPORT
+================================================================================
+
+  Cluster:        Nebius MK8s
+  GPU Type:       $GPU_NAME
+  GPU Instance:   $GPU_INSTANCE_TYPE
+  GPU Nodes:      $NODE_COUNT
+  Total GPUs:     $(( NODE_COUNT * SLOTS ))
+  Orchestration:  PyTorchJob + torchrun (torch.distributed, NCCL)
+  Duration:       ${DURATION}s ($(( DURATION / 60 )) minutes)
+  Actual runtime: ${ACTUAL_DURATION}s ($(( ACTUAL_DURATION / 60 )) minutes)
+
+  Started:        $START_TIME
+  Finished:       $END_TIME
+
+================================================================================
+  GPU PERFORMANCE
+================================================================================
+
+  Peak temperature:     ${MAX_TEMP}°C    (threshold: 83°C)
+  Average temperature:  ${AVG_TEMP}°C
+  Peak utilization:     ${MAX_UTIL}%
+  Average utilization:  ${AVG_UTIL}%
+  Peak power draw:      ${MAX_POWER}W    (expected: 650-700W under load)
+
+================================================================================
+  MEMORY STRESS
+================================================================================
+
+  HBM fill:       $(awk "BEGIN{printf \"%.0f\", ${HBM_FILL_FRACTION}*100}")% of total GPU memory per GPU (leaves NCCL headroom)
+  Method:         Resident FP16 hog tensor + continuous matmul
+
+================================================================================
+  NCCL ALL_REDUCE (InfiniBand / NVLink stress)
+================================================================================
+
+  Total iterations:         ${ITERS}
+  Failed iterations:        ${FAILED_ITERS}
+  Peak bus bandwidth:       ${PEAK_BUSBW} GB/s
+  Average bus bandwidth:    ${AVG_BUSBW} GB/s
+  (A blank/N/A bandwidth means NCCL produced no valid result — treat as a red
+   flag even if other checks pass.)
+
+================================================================================
+  HEALTH CHECKS
+================================================================================
+
+  Total monitor polls:       $TOTAL_POLLS
+  Overtemperature events:    $OVERTEMP    (threshold: >83°C)
+  Low utilization events:    $LOW_UTIL    (threshold: <80%)
+  XID errors detected:       $XID
+  XID check unverified:      $([ "$XID_UNVERIFIED" -gt 0 ] 2>/dev/null && echo "YES — see note below" || echo "no")
+
+================================================================================
+  PASS / FAIL SUMMARY
+================================================================================
+
+$(if [ "$OVERTEMP" = "0" ]; then echo "  [PASS] No overtemperature events"; else echo "  [FAIL] $OVERTEMP overtemperature event(s) detected"; fi)
+$(if [ "${XID_UNVERIFIED:-0}" -gt 0 ] 2>/dev/null; then echo "  [WARN] XID check could not run — GPUs NOT certified XID-clean"; elif [ "$XID" = "0" ]; then echo "  [PASS] No XID errors"; else echo "  [FAIL] $XID XID error(s) detected"; fi)
+$(if [ "$MONITOR_EXIT" = "0" ]; then echo "  [PASS] All NCCL all_reduce iterations completed successfully"; else echo "  [FAIL] Soak workload reported failures (see master logs)"; fi)
+$(if [ "$LOW_UTIL" -lt "10" ] 2>/dev/null; then echo "  [PASS] GPU utilization stayed healthy"; else echo "  [WARN] $LOW_UTIL low utilization events detected"; fi)
+
+  OVERALL RESULT: $RESULT
+
+================================================================================
+  Raw log file: $LOG_FILE
+================================================================================
+REPORT
+
+  echo ""
+  echo -e "${BLUE}============================================================${NC}"
+  echo -e "${BLUE}  SOAK TEST REPORT${NC}"
+  echo -e "${BLUE}============================================================${NC}"
+  cat "$SCRIPT_DIR/$REPORT_FILE"
+  echo ""
+  echo "Report saved to: $SCRIPT_DIR/$REPORT_FILE"
+}
+
+generate_report
+
+# Cleanup — auto (CI), interactive prompt (tty), or leave-and-instruct (piped).
+echo ""
+if [ "${AUTO_CLEANUP:-}" = "y" ]; then
+  cleanup_ns
+  echo "Cleaned up."
+elif [ -t 0 ]; then
+  read -p "Delete namespace $NAMESPACE and all test resources? (y/n): " CLEANUP || CLEANUP=n
+  if [ "$CLEANUP" = "y" ]; then
+    cleanup_ns
+    echo "Cleaned up."
+  fi
+else
+  echo "Non-interactive shell — leaving namespace $NAMESPACE in place."
+  echo "Delete with: kubectl delete namespace $NAMESPACE   (or re-run with AUTO_CLEANUP=y)"
+fi
+
+exit $MONITOR_EXIT

--- a/k8s-training/gpu-soak-test/run-soak-test.sh
+++ b/k8s-training/gpu-soak-test/run-soak-test.sh
@@ -32,10 +32,15 @@
 set -euo pipefail
 
 DURATION="${1:-3600}"
+# Exported so monitor.sh can bound its poll loop to the soak duration (+ buffer).
+export SOAK_DURATION_SECONDS="$DURATION"
 NODE_COUNT="${2:-2}"
 NAMESPACE="gpu-soak"
 SLOTS=8
 HBM_FILL_FRACTION="${HBM_FILL_FRACTION:-0.75}"
+# Overtemp threshold °C. Exported so monitor.sh and the report agree on one value
+# (raise for Blackwell, e.g. MAX_TEMP=90). Default matches monitor.sh's default.
+export MAX_TEMP="${MAX_TEMP:-83}"
 # Container image for the workload. The default is a Hopper-era PyTorch (CUDA
 # 12.3) that works on H100/H200. It will NOT run on Blackwell (B200/GB200/GB300)
 # — those need a newer CUDA 12.6+ image, and Grace-based GB200/GB300 also need an
@@ -64,12 +69,20 @@ cleanup_ns() {
 }
 # On Ctrl-C / termination, tear down so an aborted run never leaks GPU pods.
 trap 'cleanup_ns; exit 130' INT TERM
+# On an unexpected error-exit (set -e) BEFORE we reach the normal cleanup
+# decision, also tear down — otherwise a mid-setup failure leaks the namespace.
+# REACHED_END is set to 1 once the run completes and the explicit cleanup
+# decision (prompt / AUTO_CLEANUP / leave-in-place) takes over, so this trap
+# never overrides that deliberate choice on a normal finish.
+REACHED_END=0
+trap '[ "$REACHED_END" = "1" ] || cleanup_ns' EXIT
 
 echo "=== GPU Soak Test (PyTorchJob / torch.distributed) ==="
 echo "Duration:     ${DURATION}s ($(( DURATION / 60 )) minutes)"
 echo "GPU nodes:    $NODE_COUNT"
 echo "GPUs/node:    $SLOTS"
 echo "HBM fill:     $(awk "BEGIN{printf \"%.0f\", ${HBM_FILL_FRACTION}*100}")%"
+echo "Max temp:     ${MAX_TEMP}°C"
 echo "Image:        $SOAK_IMAGE"
 echo "Namespace:    $NAMESPACE"
 echo "Started:      $START_TIME"
@@ -124,14 +137,74 @@ fi
 echo "GPU nodes available: $AVAILABLE_GPU_NODES ✓"
 echo ""
 
-# Clean up any previous run
-kubectl delete namespace $NAMESPACE --ignore-not-found=true
-kubectl wait --for=delete namespace/$NAMESPACE --timeout=120s 2>/dev/null || true
+# Single-tenant by design: a soak saturates every GPU on the cluster, so only one
+# run at a time makes sense. Claim the namespace ATOMICALLY with `kubectl create`
+# — the API server rejects a duplicate, so two runs starting at the same instant
+# can't both win the claim. Only reclaim an existing namespace when it's stale (no
+# running pods); otherwise another run owns it and we refuse.
+if ! kubectl create namespace "$NAMESPACE" 2>/dev/null; then
+  RUNNING_PODS=$(kubectl get pods -n "$NAMESPACE" --no-headers 2>/dev/null | awk '$3=="Running"' | wc -l | tr -d ' ')
+  if [ "${RUNNING_PODS:-0}" -gt 0 ]; then
+    echo -e "${RED}ERROR: namespace $NAMESPACE already has $RUNNING_PODS running pod(s) — another soak run may be in progress.${NC}"
+    echo "A soak saturates all cluster GPUs, so only one run at a time is supported."
+    echo "If you're sure it's stale, delete it manually: kubectl delete namespace $NAMESPACE"
+    exit 1
+  fi
+  echo "Reclaiming stale $NAMESPACE namespace from a previous run..."
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found=true
+  kubectl wait --for=delete namespace/"$NAMESPACE" --timeout=120s 2>/dev/null || true
+  kubectl create namespace "$NAMESPACE"
+fi
 
-# Create namespace + mount the workload script as a ConfigMap
-kubectl create namespace $NAMESPACE
-kubectl create configmap soak-script -n $NAMESPACE \
+# Mount the workload script as a ConfigMap
+kubectl create configmap soak-script -n "$NAMESPACE" \
   --from-file=soak.py="$SCRIPT_DIR/scripts/soak.py"
+
+# Pre-pull the (large) container image onto the target GPU nodes before submitting
+# the job. The Training Operator injects a worker init container that waits only
+# ~200s for the master's DNS; on a cold cluster the first-time image pull can take
+# far longer, so the worker gives up (Init:Error) before the master is Ready.
+# Priming each node's image cache first makes the real pods start promptly.
+echo "Pre-pulling image on GPU nodes (first run on a cold cluster can take several minutes)..."
+kubectl apply -f - <<PREPULL >/dev/null
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: soak-prepull
+  namespace: $NAMESPACE
+spec:
+  selector:
+    matchLabels:
+      app: soak-prepull
+  template:
+    metadata:
+      labels:
+        app: soak-prepull
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: $GPU_INSTANCE_TYPE
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: prepull
+        image: $SOAK_IMAGE
+        command: ["sh", "-c", "echo image-cached; sleep 3600"]
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "16Mi"
+PREPULL
+
+if kubectl rollout status ds/soak-prepull -n "$NAMESPACE" --timeout=900s 2>/dev/null; then
+  echo "Image cached on all target GPU nodes ✓"
+else
+  echo -e "${YELLOW}WARNING: pre-pull did not finish within 15m — proceeding anyway.${NC}"
+  echo "If workers hit Init:Error, the image is likely still pulling; re-run once it's cached."
+fi
+# The image stays in each node's containerd cache after the DaemonSet is removed.
+kubectl delete ds/soak-prepull -n "$NAMESPACE" --ignore-not-found=true --wait=false >/dev/null 2>&1 || true
 
 # Patch the PyTorchJob template. Worker replicas = total nodes - 1 (master is
 # rank 0 and also runs GPUs), so total pods == NODE_COUNT.
@@ -150,7 +223,7 @@ echo "$MANIFEST" | kubectl apply -f -
 echo ""
 echo "PyTorchJob submitted. Waiting for master pod to start..."
 
-kubectl wait --namespace $NAMESPACE \
+kubectl wait --namespace "$NAMESPACE" \
   --for=condition=Ready \
   --timeout=300s \
   -l training.kubeflow.org/replica-type=master \
@@ -159,7 +232,7 @@ kubectl wait --namespace $NAMESPACE \
 echo "Pods started. Beginning monitoring..."
 echo ""
 echo "To watch master logs in another terminal:"
-echo "  kubectl logs -f -n $NAMESPACE -l training.kubeflow.org/replica-type=master"
+echo "  kubectl logs -f -n "$NAMESPACE" -l training.kubeflow.org/replica-type=master"
 echo ""
 
 # Run monitor. set +e so a FAILED soak still produces a report and cleans up
@@ -170,7 +243,7 @@ MONITOR_EXIT=$?
 set -e
 
 # Collect final master logs (rank 0 prints the summary + BUSBW lines)
-MASTER_LOGS=$(kubectl logs -n $NAMESPACE -l training.kubeflow.org/replica-type=master 2>/dev/null | tail -40)
+MASTER_LOGS=$(kubectl logs --request-timeout=30s -n "$NAMESPACE" -l training.kubeflow.org/replica-type=master 2>/dev/null | tail -40)
 
 END_TIME=$(date -u)
 END_EPOCH=$(date +%s)
@@ -190,25 +263,32 @@ generate_report() {
   TOTAL_POLLS=$(grep -c "Poll #" "$LOG_FILE" 2>/dev/null || true); TOTAL_POLLS=${TOTAL_POLLS:-0}
   OVERTEMP=$(grep -c "OVERTEMP" "$LOG_FILE" 2>/dev/null || true); OVERTEMP=${OVERTEMP:-0}
   LOW_UTIL=$(grep -c "LOW UTIL" "$LOG_FILE" 2>/dev/null || true); LOW_UTIL=${LOW_UTIL:-0}
-  XID=$(grep "XID errors detected:" "$LOG_FILE" 2>/dev/null | grep -oP 'detected: \K[0-9]+' | tail -1 || true); XID=${XID:-0}
+  XID=$(grep "XID errors detected:" "$LOG_FILE" 2>/dev/null | sed -n 's/.*detected: \([0-9][0-9]*\).*/\1/p' | tail -1 || true); XID=${XID:-0}
   XID_UNVERIFIED=$(grep -c "XID_UNVERIFIED" "$LOG_FILE" 2>/dev/null || true); XID_UNVERIFIED=${XID_UNVERIFIED:-0}
 
-  local MAX_TEMP MAX_UTIL MAX_POWER AVG_UTIL AVG_TEMP
-  MAX_TEMP=$(grep "temp=" "$LOG_FILE" 2>/dev/null | grep -oP 'temp=\K[0-9]+' | sort -n | tail -1 || echo "N/A")
-  MAX_UTIL=$(grep "util=" "$LOG_FILE" 2>/dev/null | grep -oP 'util=\K[0-9]+' | sort -n | tail -1 || echo "N/A")
-  MAX_POWER=$(grep "power=" "$LOG_FILE" 2>/dev/null | grep -oP 'power=\K[0-9.]+' | sort -n | tail -1 || echo "N/A")
-  AVG_UTIL=$(grep "util=" "$LOG_FILE" 2>/dev/null | grep -oP 'util=\K[0-9]+' | awk '{s+=$1;c++} END {if(c)printf "%.0f", s/c; else print "N/A"}')
-  AVG_TEMP=$(grep "temp=" "$LOG_FILE" 2>/dev/null | grep -oP 'temp=\K[0-9]+' | awk '{s+=$1;c++} END {if(c)printf "%.0f", s/c; else print "N/A"}')
+  # Portable extraction (sed, not grep -oP which is GNU-only / breaks on macOS).
+  local PEAK_TEMP MAX_UTIL MAX_POWER AVG_UTIL AVG_TEMP
+  PEAK_TEMP=$(sed -n 's/.*temp=\([0-9][0-9]*\).*/\1/p' "$LOG_FILE" 2>/dev/null | sort -n | tail -1); PEAK_TEMP=${PEAK_TEMP:-N/A}
+  MAX_UTIL=$(sed -n 's/.*util=\([0-9][0-9]*\).*/\1/p' "$LOG_FILE" 2>/dev/null | sort -n | tail -1); MAX_UTIL=${MAX_UTIL:-N/A}
+  MAX_POWER=$(sed -n 's/.*power=\([0-9][0-9.]*\).*/\1/p' "$LOG_FILE" 2>/dev/null | sort -n | tail -1); MAX_POWER=${MAX_POWER:-N/A}
+  AVG_UTIL=$(sed -n 's/.*util=\([0-9][0-9]*\).*/\1/p' "$LOG_FILE" 2>/dev/null | awk '{s+=$1;c++} END {if(c)printf "%.0f", s/c; else print "N/A"}')
+  AVG_TEMP=$(sed -n 's/.*temp=\([0-9][0-9]*\).*/\1/p' "$LOG_FILE" 2>/dev/null | awk '{s+=$1;c++} END {if(c)printf "%.0f", s/c; else print "N/A"}')
 
   # NCCL evidence straight from the master (rank 0) logs
   local PEAK_BUSBW AVG_BUSBW ITERS FAILED_ITERS
-  PEAK_BUSBW=$(echo "$MASTER_LOGS" | grep -oP 'BUSBW_GBPS: \K[0-9.]+' | tail -1 || echo "N/A")
-  AVG_BUSBW=$(echo "$MASTER_LOGS" | grep -oP 'BUSBW_AVG_GBPS: \K[0-9.]+' | tail -1 || echo "N/A")
-  ITERS=$(echo "$MASTER_LOGS" | grep -oP 'Total iterations: \K[0-9]+' | tail -1 || echo "N/A")
-  FAILED_ITERS=$(echo "$MASTER_LOGS" | grep -oP 'Failed iterations \(all ranks\): \K[0-9]+' | tail -1 || echo "N/A")
+  PEAK_BUSBW=$(echo "$MASTER_LOGS" | sed -n 's/.*BUSBW_GBPS: \([0-9][0-9.]*\).*/\1/p' | tail -1); PEAK_BUSBW=${PEAK_BUSBW:-N/A}
+  AVG_BUSBW=$(echo "$MASTER_LOGS" | sed -n 's/.*BUSBW_AVG_GBPS: \([0-9][0-9.]*\).*/\1/p' | tail -1); AVG_BUSBW=${AVG_BUSBW:-N/A}
+  ITERS=$(echo "$MASTER_LOGS" | sed -n 's/.*Total iterations: \([0-9][0-9]*\).*/\1/p' | tail -1); ITERS=${ITERS:-N/A}
+  FAILED_ITERS=$(echo "$MASTER_LOGS" | sed -n 's/.*Failed iterations (all ranks): \([0-9][0-9]*\).*/\1/p' | tail -1); FAILED_ITERS=${FAILED_ITERS:-N/A}
+
+  # A run with no valid NCCL bandwidth means the collective produced nothing —
+  # treat that as a failure even if the master pod happened to exit 0, so an
+  # empty result never reads as a green PASS.
+  local NCCL_OK=1
+  if [ "$PEAK_BUSBW" = "N/A" ] || [ -z "$PEAK_BUSBW" ]; then NCCL_OK=0; fi
 
   local RESULT="PASSED"
-  if [ "$MONITOR_EXIT" != "0" ]; then RESULT="FAILED"; fi
+  if [ "$MONITOR_EXIT" != "0" ] || [ "$NCCL_OK" = "0" ]; then RESULT="FAILED"; fi
 
   cat > "$SCRIPT_DIR/$REPORT_FILE" << REPORT
 ================================================================================
@@ -231,7 +311,7 @@ generate_report() {
   GPU PERFORMANCE
 ================================================================================
 
-  Peak temperature:     ${MAX_TEMP}°C    (threshold: 83°C)
+  Peak temperature:     ${PEAK_TEMP}°C    (threshold: ${MAX_TEMP}°C)
   Average temperature:  ${AVG_TEMP}°C
   Peak utilization:     ${MAX_UTIL}%
   Average utilization:  ${AVG_UTIL}%
@@ -260,7 +340,7 @@ generate_report() {
 ================================================================================
 
   Total monitor polls:       $TOTAL_POLLS
-  Overtemperature events:    $OVERTEMP    (threshold: >83°C)
+  Overtemperature events:    $OVERTEMP    (threshold: >${MAX_TEMP}°C)
   Low utilization events:    $LOW_UTIL    (threshold: <80%)
   XID errors detected:       $XID
   XID check unverified:      $([ "$XID_UNVERIFIED" -gt 0 ] 2>/dev/null && echo "YES — see note below" || echo "no")
@@ -271,7 +351,8 @@ generate_report() {
 
 $(if [ "$OVERTEMP" = "0" ]; then echo "  [PASS] No overtemperature events"; else echo "  [FAIL] $OVERTEMP overtemperature event(s) detected"; fi)
 $(if [ "${XID_UNVERIFIED:-0}" -gt 0 ] 2>/dev/null; then echo "  [WARN] XID check could not run — GPUs NOT certified XID-clean"; elif [ "$XID" = "0" ]; then echo "  [PASS] No XID errors"; else echo "  [FAIL] $XID XID error(s) detected"; fi)
-$(if [ "$MONITOR_EXIT" = "0" ]; then echo "  [PASS] All NCCL all_reduce iterations completed successfully"; else echo "  [FAIL] Soak workload reported failures (see master logs)"; fi)
+$(if [ "$FAILED_ITERS" = "0" ]; then echo "  [PASS] All NCCL all_reduce iterations completed correctly"; elif [ "$FAILED_ITERS" = "N/A" ]; then echo "  [WARN] all_reduce iteration status unknown — no master summary in logs"; else echo "  [FAIL] $FAILED_ITERS all_reduce iteration(s) returned incorrect data"; fi)
+$(if [ "$NCCL_OK" = "1" ]; then echo "  [PASS] NCCL produced valid bandwidth (peak ${PEAK_BUSBW} GB/s)"; else echo "  [FAIL] No valid NCCL bandwidth recorded — collective produced no result"; fi)
 $(if [ "$LOW_UTIL" -lt "10" ] 2>/dev/null; then echo "  [PASS] GPU utilization stayed healthy"; else echo "  [WARN] $LOW_UTIL low utilization events detected"; fi)
 
   OVERALL RESULT: $RESULT
@@ -291,6 +372,10 @@ REPORT
 }
 
 generate_report
+
+# Run completed and the report is written — from here the explicit cleanup
+# decision below owns teardown, so the error-exit trap must no longer fire.
+REACHED_END=1
 
 # Cleanup — auto (CI), interactive prompt (tty), or leave-and-instruct (piped).
 echo ""

--- a/k8s-training/gpu-soak-test/run-soak-test.sh
+++ b/k8s-training/gpu-soak-test/run-soak-test.sh
@@ -36,7 +36,10 @@ DURATION="${1:-3600}"
 export SOAK_DURATION_SECONDS="$DURATION"
 NODE_COUNT="${2:-2}"
 NAMESPACE="gpu-soak"
-SLOTS=8
+# GPUs per node (nproc_per_node + GPU resource request). Auto-detected from node
+# allocatable below once the GPU node type is known — hardcoding 8 breaks any
+# non-8-GPU node (e.g. GB200/GB300). Set SLOTS=<n> to override detection.
+SLOTS="${SLOTS:-}"
 HBM_FILL_FRACTION="${HBM_FILL_FRACTION:-0.75}"
 # Overtemp threshold °C. Exported so monitor.sh and the report agree on one value
 # (raise for Blackwell, e.g. MAX_TEMP=90). Default matches monitor.sh's default.
@@ -51,6 +54,11 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPORT_FILE="soak-report-$(date +%Y%m%d_%H%M%S).txt"
 START_TIME=$(date -u)
 START_EPOCH=$(date +%s)
+# Anchor the monitor log to this script's dir (not the caller's CWD) so the report
+# generator below reliably finds it no matter where the script was invoked from.
+# Also export the run start so monitor.sh can scope its dmesg XID check to this run.
+export SOAK_LOG_DIR="$SCRIPT_DIR"
+export SOAK_START_EPOCH="$START_EPOCH"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -80,7 +88,6 @@ trap '[ "$REACHED_END" = "1" ] || cleanup_ns' EXIT
 echo "=== GPU Soak Test (PyTorchJob / torch.distributed) ==="
 echo "Duration:     ${DURATION}s ($(( DURATION / 60 )) minutes)"
 echo "GPU nodes:    $NODE_COUNT"
-echo "GPUs/node:    $SLOTS"
 echo "HBM fill:     $(awk "BEGIN{printf \"%.0f\", ${HBM_FILL_FRACTION}*100}")%"
 echo "Max temp:     ${MAX_TEMP}°C"
 echo "Image:        $SOAK_IMAGE"
@@ -135,6 +142,19 @@ if [ "$AVAILABLE_GPU_NODES" -lt "$NODE_COUNT" ]; then
 fi
 
 echo "GPU nodes available: $AVAILABLE_GPU_NODES ✓"
+
+# Detect GPUs per node from a Ready node's allocatable, so the job is sized to the
+# actual hardware (GB200/GB300 are not 8-GPU). Falls back to 8 only if unreadable.
+FIRST_GPU_NODE=$(kubectl get nodes -l "node.kubernetes.io/instance-type=${GPU_INSTANCE_TYPE}" \
+  --no-headers 2>/dev/null | awk '$2=="Ready"{print $1; exit}')
+DETECTED_SLOTS=$(kubectl get node "$FIRST_GPU_NODE" \
+  -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null)
+SLOTS="${SLOTS:-$DETECTED_SLOTS}"
+if ! [ "${SLOTS:-0}" -gt 0 ] 2>/dev/null; then
+  echo -e "${YELLOW}WARNING: could not detect GPUs/node from allocatable — defaulting to 8${NC}"
+  SLOTS=8
+fi
+echo "GPUs/node:           $SLOTS"
 echo ""
 
 # Single-tenant by design: a soak saturates every GPU on the cluster, so only one
@@ -243,7 +263,10 @@ MONITOR_EXIT=$?
 set -e
 
 # Collect final master logs (rank 0 prints the summary + BUSBW lines)
-MASTER_LOGS=$(kubectl logs --request-timeout=30s -n "$NAMESPACE" -l training.kubeflow.org/replica-type=master 2>/dev/null | tail -40)
+# --tail=-1 is required with -l: `kubectl logs` defaults to only the last 10 lines
+# per pod when a label selector is used (unlike naming a pod, which returns all),
+# which would silently drop the summary/BUSBW lines we parse below.
+MASTER_LOGS=$(kubectl logs --request-timeout=30s --tail=-1 -n "$NAMESPACE" -l training.kubeflow.org/replica-type=master 2>/dev/null | tail -40)
 
 END_TIME=$(date -u)
 END_EPOCH=$(date +%s)

--- a/k8s-training/gpu-soak-test/scripts/monitor.sh
+++ b/k8s-training/gpu-soak-test/scripts/monitor.sh
@@ -23,7 +23,10 @@ MIN_UTIL="${MIN_UTIL:-80}"
 # joins) can't make the monitor poll forever. Defaults to the soak duration plus
 # a generous buffer for image pull, startup, and the end-of-run XID check.
 SOAK_MONITOR_TIMEOUT="${SOAK_MONITOR_TIMEOUT:-$(( ${SOAK_DURATION_SECONDS:-3600} + 1200 ))}"
-LOG_FILE="soak-monitor-$(date +%Y%m%d_%H%M%S).log"
+# Write the monitor log to the dir the parent runner reads from (SOAK_LOG_DIR),
+# not the caller's CWD — otherwise the report generator can't find it when the
+# runner is invoked from a different directory. Falls back to CWD if run standalone.
+LOG_FILE="${SOAK_LOG_DIR:-.}/soak-monitor-$(date +%Y%m%d_%H%M%S).log"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -42,11 +45,17 @@ warn() { echo -e "${YELLOW}[WARN]${NC} $*" | tee -a "$LOG_FILE"; }
 # for it to complete, read the count from its logs, then delete it.
 # Echoes an integer count, or "__FAILED__" if it could not run.
 check_xid_on_node() {
-  local node="$1" dbg="" waited=0 phase="" out=""
+  local node="$1" dbg="" waited=0 phase="" out="" since_epoch="${SOAK_START_EPOCH:-0}"
+  # Scope the XID scan to this run. dmesg holds the entire kernel ring buffer, so an
+  # unscoped grep would count XID lines from before the soak even started (a prior
+  # workload, a days-old event) against this run. --since restricts it to the run
+  # window; the date is computed on the host so it matches dmesg's host-local clock.
+  # (Requires a modern util-linux dmesg — standard on Nebius Ubuntu hosts. If the
+  # run start is unknown, since_epoch=0 falls back to the whole buffer.)
   # `grep -c` exits 1 when the count is zero, which would mark the debugger pod
   # Failed on a HEALTHY node — so append `|| true` to keep the container clean.
   kubectl debug node/"$node" --image=ubuntu --profile=sysadmin -q \
-    -- chroot /host sh -c 'dmesg 2>/dev/null | grep -ic xid || true' >/dev/null 2>&1 || true
+    -- chroot /host sh -c "dmesg --since \"\$(date -d @${since_epoch} '+%Y-%m-%d %H:%M:%S' 2>/dev/null)\" 2>/dev/null | grep -ic xid || true" >/dev/null 2>&1 || true
   while [ "$waited" -lt 30 ]; do
     dbg=$(kubectl get pods --request-timeout=30s -n default -o name 2>/dev/null | grep "node-debugger-${node}" | tail -1)
     [ -n "$dbg" ] && break
@@ -106,7 +115,7 @@ echo ""
 log "Waiting for workload steady state (first [soak] iter line)..."
 WARMUP=0
 while [ "$WARMUP" -lt 180 ]; do
-  if kubectl logs --request-timeout=30s -n "$NAMESPACE" -l "$MASTER_SELECTOR" 2>/dev/null | grep -qE '\[soak\] iter [0-9]+'; then
+  if kubectl logs --request-timeout=30s --tail=-1 -n "$NAMESPACE" -l "$MASTER_SELECTOR" 2>/dev/null | grep -qE '\[soak\] iter [0-9]+'; then
     log "Workload is running steadily — starting utilization monitoring"
     break
   fi
@@ -274,7 +283,9 @@ else
   pass "No XID errors"
 fi
 
-if [ "$LOW_UTIL_COUNT" -gt "5" ]; then
+# Threshold of 10 matches the README pass criteria and run-soak-test.sh's report
+# (they previously disagreed — monitor used 5). "Fewer than 10 low-util events" passes.
+if [ "$LOW_UTIL_COUNT" -ge "10" ]; then
   warn "$LOW_UTIL_COUNT low utilization events — GPUs may have throttled"
 else
   pass "GPU utilization stayed healthy throughout"

--- a/k8s-training/gpu-soak-test/scripts/monitor.sh
+++ b/k8s-training/gpu-soak-test/scripts/monitor.sh
@@ -19,6 +19,10 @@ CONTAINER="pytorch"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
 MAX_TEMP="${MAX_TEMP:-83}"
 MIN_UTIL="${MIN_UTIL:-80}"
+# Absolute cap on the poll loop so a hung/stuck master (e.g. a worker that never
+# joins) can't make the monitor poll forever. Defaults to the soak duration plus
+# a generous buffer for image pull, startup, and the end-of-run XID check.
+SOAK_MONITOR_TIMEOUT="${SOAK_MONITOR_TIMEOUT:-$(( ${SOAK_DURATION_SECONDS:-3600} + 1200 ))}"
 LOG_FILE="soak-monitor-$(date +%Y%m%d_%H%M%S).log"
 
 RED='\033[0;31m'
@@ -44,7 +48,7 @@ check_xid_on_node() {
   kubectl debug node/"$node" --image=ubuntu --profile=sysadmin -q \
     -- chroot /host sh -c 'dmesg 2>/dev/null | grep -ic xid || true' >/dev/null 2>&1 || true
   while [ "$waited" -lt 30 ]; do
-    dbg=$(kubectl get pods -n default -o name 2>/dev/null | grep "node-debugger-${node}" | tail -1)
+    dbg=$(kubectl get pods --request-timeout=30s -n default -o name 2>/dev/null | grep "node-debugger-${node}" | tail -1)
     [ -n "$dbg" ] && break
     sleep 2; waited=$(( waited + 2 ))
   done
@@ -57,7 +61,7 @@ check_xid_on_node() {
     if [ "$phase" = "Succeeded" ] || [ "$phase" = "Failed" ]; then break; fi
     sleep 3; waited=$(( waited + 3 ))
   done
-  out=$(kubectl logs -n default "$dbg" 2>/dev/null | tr -d ' \r\n')
+  out=$(kubectl logs --request-timeout=30s -n default "$dbg" 2>/dev/null | tr -d ' \r\n')
   kubectl delete "$dbg" -n default --wait=false >/dev/null 2>&1 || true
   # Accept any valid non-negative integer count; only fail if we got no number.
   if [ -n "$out" ] && [ "$out" -ge 0 ] 2>/dev/null; then
@@ -83,13 +87,13 @@ log "Log file: $LOG_FILE"
 echo ""
 
 # Wait for job pods to appear
-JOB_PODS=$(kubectl get pods -n $NAMESPACE -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
+JOB_PODS=$(kubectl get pods --request-timeout=30s -n "$NAMESPACE" -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
 if [ -z "$JOB_PODS" ]; then
   warn "No job pods found yet — waiting for PyTorchJob to start"
   sleep 30
-  JOB_PODS=$(kubectl get pods -n $NAMESPACE -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
+  JOB_PODS=$(kubectl get pods --request-timeout=30s -n "$NAMESPACE" -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
 fi
-log "Monitoring pods: $(echo $JOB_PODS | tr '\n' ' ')"
+log "Monitoring pods: $(echo "$JOB_PODS" | tr '\n' ' ')"
 echo ""
 
 # Wait until the workload reaches STEADY STATE before judging utilization.
@@ -102,11 +106,11 @@ echo ""
 log "Waiting for workload steady state (first [soak] iter line)..."
 WARMUP=0
 while [ "$WARMUP" -lt 180 ]; do
-  if kubectl logs -n $NAMESPACE -l "$MASTER_SELECTOR" 2>/dev/null | grep -qE '\[soak\] iter [0-9]+'; then
+  if kubectl logs --request-timeout=30s -n "$NAMESPACE" -l "$MASTER_SELECTOR" 2>/dev/null | grep -qE '\[soak\] iter [0-9]+'; then
     log "Workload is running steadily — starting utilization monitoring"
     break
   fi
-  MP=$(kubectl get pods -n $NAMESPACE -l "$MASTER_SELECTOR" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+  MP=$(kubectl get pods --request-timeout=30s -n "$NAMESPACE" -l "$MASTER_SELECTOR" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
   if [ "$MP" = "Failed" ] || [ "$MP" = "Succeeded" ]; then
     warn "Master reached '$MP' before warm-up signal — proceeding to summary"
     break
@@ -116,9 +120,18 @@ while [ "$WARMUP" -lt 180 ]; do
 done
 echo ""
 
+MONITOR_START=$(date +%s)
+MASTER_STATUS="Unknown"
 while true; do
+  # Hard stop: never poll past the soak duration + buffer, so a master that never
+  # reaches a terminal phase (stuck rendezvous, hung worker) can't hang the run.
+  if [ "$(( $(date +%s) - MONITOR_START ))" -gt "$SOAK_MONITOR_TIMEOUT" ]; then
+    warn "Monitor timed out after ${SOAK_MONITOR_TIMEOUT}s with master still '$MASTER_STATUS' — giving up and reporting failure"
+    break
+  fi
+
   # Master (rank 0) exit determines completion.
-  MASTER_STATUS=$(kubectl get pods -n $NAMESPACE -l "$MASTER_SELECTOR" \
+  MASTER_STATUS=$(kubectl get pods --request-timeout=30s -n "$NAMESPACE" -l "$MASTER_SELECTOR" \
     -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Unknown")
 
   if [ "$MASTER_STATUS" = "Succeeded" ] || [ "$MASTER_STATUS" = "Failed" ]; then
@@ -129,19 +142,19 @@ while true; do
   POLL_COUNT=$(( POLL_COUNT + 1 ))
   log "--- Poll #$POLL_COUNT | Master: $MASTER_STATUS ---"
 
-  JOB_PODS=$(kubectl get pods -n $NAMESPACE -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
+  JOB_PODS=$(kubectl get pods --request-timeout=30s -n "$NAMESPACE" -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
 
   for POD in $JOB_PODS; do
-    POD_NAME=$(echo $POD | sed 's|pod/||')
+    POD_NAME=$(echo "$POD" | sed 's|pod/||')
 
     # Record the node this pod runs on (for the end-of-run XID check).
-    NODE=$(kubectl get pod -n $NAMESPACE "$POD_NAME" -o jsonpath='{.spec.nodeName}' 2>/dev/null || echo "")
+    NODE=$(kubectl get pod --request-timeout=30s -n "$NAMESPACE" "$POD_NAME" -o jsonpath='{.spec.nodeName}' 2>/dev/null || echo "")
     if [ -n "$NODE" ] && ! echo "$SOAK_NODES" | grep -qw "$NODE"; then
       SOAK_NODES="$SOAK_NODES $NODE"
     fi
 
     log "Checking $POD_NAME:"
-    GPU_STATS=$(kubectl exec -n $NAMESPACE "$POD_NAME" -c "$CONTAINER" -- \
+    GPU_STATS=$(kubectl exec --request-timeout=30s -n "$NAMESPACE" "$POD_NAME" -c "$CONTAINER" -- \
       nvidia-smi --query-gpu=index,temperature.gpu,utilization.gpu,power.draw,memory.used,memory.total \
       --format=csv,noheader,nounits 2>/dev/null || echo "exec_failed")
 
@@ -151,11 +164,11 @@ while true; do
     fi
 
     while IFS=',' read -r idx temp util power mem_used mem_total; do
-      temp=$(echo $temp | tr -d ' ')
-      util=$(echo $util | tr -d ' ')
-      power=$(echo $power | tr -d ' ')
-      mem_used=$(echo $mem_used | tr -d ' ')
-      mem_total=$(echo $mem_total | tr -d ' ')
+      temp=$(echo "$temp" | tr -d ' ')
+      util=$(echo "$util" | tr -d ' ')
+      power=$(echo "$power" | tr -d ' ')
+      mem_used=$(echo "$mem_used" | tr -d ' ')
+      mem_total=$(echo "$mem_total" | tr -d ' ')
       [ -z "$idx" ] && continue
 
       log "  GPU $idx: temp=${temp}°C util=${util}% power=${power}W mem=${mem_used}/${mem_total}MiB"
@@ -173,13 +186,13 @@ while true; do
   done
 
   # Node readiness
-  NOT_READY=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2!="Ready" && $2!="Ready,SchedulingDisabled"' | wc -l | tr -d ' \n' || echo "0")
+  NOT_READY=$(kubectl get nodes --request-timeout=30s --no-headers 2>/dev/null | awk '$2!="Ready" && $2!="Ready,SchedulingDisabled"' | wc -l | tr -d ' \n' || echo "0")
   if [ "$NOT_READY" -gt "0" ] 2>/dev/null; then
     warn "$NOT_READY node(s) not in Ready state"
   fi
 
   echo ""
-  sleep $POLL_INTERVAL
+  sleep "$POLL_INTERVAL"
 done
 
 # =============================================================================
@@ -206,9 +219,13 @@ else
       log "Node $NODE: no XID errors in dmesg"
     fi
   done
-  # Safety net: remove any stray node-debugger pods.
-  kubectl get pods -n default -o name 2>/dev/null | grep node-debugger \
-    | xargs -r kubectl delete -n default --wait=false 2>/dev/null || true
+  # Safety net: remove any stray node-debugger pods THIS run created (scoped to
+  # our own soak nodes — never another engineer's debug pods in the namespace).
+  for NODE in $SOAK_NODES; do
+    for p in $(kubectl get pods --request-timeout=30s -n default -o name 2>/dev/null | grep "node-debugger-${NODE}"); do
+      kubectl delete "$p" -n default --wait=false >/dev/null 2>&1 || true
+    done
+  done
 fi
 
 # =============================================================================
@@ -223,9 +240,9 @@ log "XID errors detected: $XID_COUNT"
 log "XID check unverified nodes: $XID_UNVERIFIED"
 
 # Master (rank 0) exit code is the authoritative workload pass/fail.
-MASTER_PHASE=$(kubectl get pods -n $NAMESPACE -l "$MASTER_SELECTOR" \
+MASTER_PHASE=$(kubectl get pods --request-timeout=30s -n "$NAMESPACE" -l "$MASTER_SELECTOR" \
   -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Unknown")
-MASTER_EXIT=$(kubectl get pods -n $NAMESPACE -l "$MASTER_SELECTOR" \
+MASTER_EXIT=$(kubectl get pods --request-timeout=30s -n "$NAMESPACE" -l "$MASTER_SELECTOR" \
   -o jsonpath='{.items[0].status.containerStatuses[0].state.terminated.exitCode}' 2>/dev/null || echo "Unknown")
 
 log "Master final phase: $MASTER_PHASE"

--- a/k8s-training/gpu-soak-test/scripts/monitor.sh
+++ b/k8s-training/gpu-soak-test/scripts/monitor.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# =============================================================================
+# GPU Soak Test Monitor (PyTorchJob)
+# Polls GPU temperature, power, and utilization across ALL job pods (master +
+# workers) while the soak runs, then does a single end-of-run XID check and
+# prints a pass/fail summary.
+#
+# XID note: this cluster has no DCGM exporter, so XID comes from node dmesg via
+# `kubectl debug node`. That is too slow/leaky to run per poll, so we run it
+# ONCE at the end. If it cannot run, we mark the result UNVERIFIED (loudly)
+# rather than silently reporting zero.
+# =============================================================================
+set -uo pipefail
+
+NAMESPACE="gpu-soak"
+JOB_SELECTOR="training.kubeflow.org/job-name=gpu-soak-test"
+MASTER_SELECTOR="training.kubeflow.org/replica-type=master"
+CONTAINER="pytorch"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+MAX_TEMP="${MAX_TEMP:-83}"
+MIN_UTIL="${MIN_UTIL:-80}"
+LOG_FILE="soak-monitor-$(date +%Y%m%d_%H%M%S).log"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo "[$(date -u '+%H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+pass() { echo -e "${GREEN}[PASS]${NC} $*" | tee -a "$LOG_FILE"; }
+fail() { echo -e "${RED}[FAIL]${NC} $*" | tee -a "$LOG_FILE"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*" | tee -a "$LOG_FILE"; }
+
+# Count XID lines in a node's kernel ring buffer.
+# `kubectl debug node -q` returns before streaming the command's stdout, so the
+# result lives in the debugger POD's logs, not inline. We therefore launch the
+# debugger, locate the pod it creates (named node-debugger-<node>-<rand>), wait
+# for it to complete, read the count from its logs, then delete it.
+# Echoes an integer count, or "__FAILED__" if it could not run.
+check_xid_on_node() {
+  local node="$1" dbg="" waited=0 phase="" out=""
+  # `grep -c` exits 1 when the count is zero, which would mark the debugger pod
+  # Failed on a HEALTHY node — so append `|| true` to keep the container clean.
+  kubectl debug node/"$node" --image=ubuntu --profile=sysadmin -q \
+    -- chroot /host sh -c 'dmesg 2>/dev/null | grep -ic xid || true' >/dev/null 2>&1 || true
+  while [ "$waited" -lt 30 ]; do
+    dbg=$(kubectl get pods -n default -o name 2>/dev/null | grep "node-debugger-${node}" | tail -1)
+    [ -n "$dbg" ] && break
+    sleep 2; waited=$(( waited + 2 ))
+  done
+  if [ -z "$dbg" ]; then echo "__FAILED__"; return; fi
+  # Wait for a terminal phase so the logs are complete (accept Succeeded OR
+  # Failed — the count is in the logs regardless of the container exit code).
+  waited=0
+  while [ "$waited" -lt 120 ]; do
+    phase=$(kubectl get "$dbg" -n default -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [ "$phase" = "Succeeded" ] || [ "$phase" = "Failed" ]; then break; fi
+    sleep 3; waited=$(( waited + 3 ))
+  done
+  out=$(kubectl logs -n default "$dbg" 2>/dev/null | tr -d ' \r\n')
+  kubectl delete "$dbg" -n default --wait=false >/dev/null 2>&1 || true
+  # Accept any valid non-negative integer count; only fail if we got no number.
+  if [ -n "$out" ] && [ "$out" -ge 0 ] 2>/dev/null; then
+    echo "$out"
+  else
+    echo "__FAILED__"
+  fi
+}
+
+OVERTEMP_COUNT=0
+LOW_UTIL_COUNT=0
+XID_COUNT=0
+XID_UNVERIFIED=0
+POLL_COUNT=0
+SOAK_NODES=""   # captured once so the XID check works even if pods vanish
+
+log "=== GPU Soak Test Monitor Starting (PyTorchJob) ==="
+log "Namespace: $NAMESPACE"
+log "Poll interval: ${POLL_INTERVAL}s"
+log "Max temp threshold: ${MAX_TEMP}°C"
+log "Min utilization threshold: ${MIN_UTIL}%"
+log "Log file: $LOG_FILE"
+echo ""
+
+# Wait for job pods to appear
+JOB_PODS=$(kubectl get pods -n $NAMESPACE -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
+if [ -z "$JOB_PODS" ]; then
+  warn "No job pods found yet — waiting for PyTorchJob to start"
+  sleep 30
+  JOB_PODS=$(kubectl get pods -n $NAMESPACE -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
+fi
+log "Monitoring pods: $(echo $JOB_PODS | tr '\n' ' ')"
+echo ""
+
+# Wait until the workload reaches STEADY STATE before judging utilization.
+# We gate on the first periodic "[soak] iter N" progress line (printed every 20
+# iterations) rather than SOAK_CONFIG_OK — the latter prints just before the
+# first all_reduce, during which NCCL does ring/channel setup and every GPU
+# reads 0% util. Waiting for real iterations guarantees the compute loop is hot
+# and NCCL is warm, eliminating false LOW UTIL events on poll #1.
+# Bounded so a stuck/failed job doesn't hang the monitor.
+log "Waiting for workload steady state (first [soak] iter line)..."
+WARMUP=0
+while [ "$WARMUP" -lt 180 ]; do
+  if kubectl logs -n $NAMESPACE -l "$MASTER_SELECTOR" 2>/dev/null | grep -qE '\[soak\] iter [0-9]+'; then
+    log "Workload is running steadily — starting utilization monitoring"
+    break
+  fi
+  MP=$(kubectl get pods -n $NAMESPACE -l "$MASTER_SELECTOR" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+  if [ "$MP" = "Failed" ] || [ "$MP" = "Succeeded" ]; then
+    warn "Master reached '$MP' before warm-up signal — proceeding to summary"
+    break
+  fi
+  sleep 5
+  WARMUP=$(( WARMUP + 5 ))
+done
+echo ""
+
+while true; do
+  # Master (rank 0) exit determines completion.
+  MASTER_STATUS=$(kubectl get pods -n $NAMESPACE -l "$MASTER_SELECTOR" \
+    -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Unknown")
+
+  if [ "$MASTER_STATUS" = "Succeeded" ] || [ "$MASTER_STATUS" = "Failed" ]; then
+    log "Master pod status: $MASTER_STATUS — test complete"
+    break
+  fi
+
+  POLL_COUNT=$(( POLL_COUNT + 1 ))
+  log "--- Poll #$POLL_COUNT | Master: $MASTER_STATUS ---"
+
+  JOB_PODS=$(kubectl get pods -n $NAMESPACE -l "$JOB_SELECTOR" -o name 2>/dev/null || echo "")
+
+  for POD in $JOB_PODS; do
+    POD_NAME=$(echo $POD | sed 's|pod/||')
+
+    # Record the node this pod runs on (for the end-of-run XID check).
+    NODE=$(kubectl get pod -n $NAMESPACE "$POD_NAME" -o jsonpath='{.spec.nodeName}' 2>/dev/null || echo "")
+    if [ -n "$NODE" ] && ! echo "$SOAK_NODES" | grep -qw "$NODE"; then
+      SOAK_NODES="$SOAK_NODES $NODE"
+    fi
+
+    log "Checking $POD_NAME:"
+    GPU_STATS=$(kubectl exec -n $NAMESPACE "$POD_NAME" -c "$CONTAINER" -- \
+      nvidia-smi --query-gpu=index,temperature.gpu,utilization.gpu,power.draw,memory.used,memory.total \
+      --format=csv,noheader,nounits 2>/dev/null || echo "exec_failed")
+
+    if [ "$GPU_STATS" = "exec_failed" ]; then
+      warn "$POD_NAME: could not exec nvidia-smi (pod may not be running yet)"
+      continue
+    fi
+
+    while IFS=',' read -r idx temp util power mem_used mem_total; do
+      temp=$(echo $temp | tr -d ' ')
+      util=$(echo $util | tr -d ' ')
+      power=$(echo $power | tr -d ' ')
+      mem_used=$(echo $mem_used | tr -d ' ')
+      mem_total=$(echo $mem_total | tr -d ' ')
+      [ -z "$idx" ] && continue
+
+      log "  GPU $idx: temp=${temp}°C util=${util}% power=${power}W mem=${mem_used}/${mem_total}MiB"
+
+      if [ "$temp" -gt "$MAX_TEMP" ] 2>/dev/null; then
+        warn "  GPU $idx OVERTEMP: ${temp}°C exceeds threshold ${MAX_TEMP}°C"
+        OVERTEMP_COUNT=$(( OVERTEMP_COUNT + 1 ))
+      fi
+
+      if [ "$util" -lt "$MIN_UTIL" ] 2>/dev/null; then
+        warn "  GPU $idx LOW UTIL: ${util}% below threshold ${MIN_UTIL}%"
+        LOW_UTIL_COUNT=$(( LOW_UTIL_COUNT + 1 ))
+      fi
+    done <<< "$GPU_STATS"
+  done
+
+  # Node readiness
+  NOT_READY=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2!="Ready" && $2!="Ready,SchedulingDisabled"' | wc -l | tr -d ' \n' || echo "0")
+  if [ "$NOT_READY" -gt "0" ] 2>/dev/null; then
+    warn "$NOT_READY node(s) not in Ready state"
+  fi
+
+  echo ""
+  sleep $POLL_INTERVAL
+done
+
+# =============================================================================
+# END-OF-RUN XID CHECK (once per node; best-effort)
+# =============================================================================
+echo ""
+log "=== XID error check (node dmesg, end of run) ==="
+if [ -z "$SOAK_NODES" ]; then
+  warn "No soak nodes were recorded — XID check UNVERIFIED"
+  log "XID_UNVERIFIED"
+  XID_UNVERIFIED=1
+else
+  for NODE in $SOAK_NODES; do
+    log "Checking XID on node: $NODE"
+    XID_OUT=$(check_xid_on_node "$NODE")
+    if [ "$XID_OUT" = "__FAILED__" ]; then
+      warn "Node $NODE: XID check could NOT run (node debug unavailable) — UNVERIFIED"
+      log "XID_UNVERIFIED"
+      XID_UNVERIFIED=$(( XID_UNVERIFIED + 1 ))
+    elif [ "$XID_OUT" -gt 0 ]; then
+      warn "Node $NODE: $XID_OUT XID line(s) in dmesg"
+      XID_COUNT=$(( XID_COUNT + XID_OUT ))
+    else
+      log "Node $NODE: no XID errors in dmesg"
+    fi
+  done
+  # Safety net: remove any stray node-debugger pods.
+  kubectl get pods -n default -o name 2>/dev/null | grep node-debugger \
+    | xargs -r kubectl delete -n default --wait=false 2>/dev/null || true
+fi
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+echo ""
+log "=== Soak Test Monitor Summary ==="
+log "Total polls: $POLL_COUNT"
+log "Overtemp events: $OVERTEMP_COUNT"
+log "Low utilization events: $LOW_UTIL_COUNT"
+log "XID errors detected: $XID_COUNT"
+log "XID check unverified nodes: $XID_UNVERIFIED"
+
+# Master (rank 0) exit code is the authoritative workload pass/fail.
+MASTER_PHASE=$(kubectl get pods -n $NAMESPACE -l "$MASTER_SELECTOR" \
+  -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "Unknown")
+MASTER_EXIT=$(kubectl get pods -n $NAMESPACE -l "$MASTER_SELECTOR" \
+  -o jsonpath='{.items[0].status.containerStatuses[0].state.terminated.exitCode}' 2>/dev/null || echo "Unknown")
+
+log "Master final phase: $MASTER_PHASE"
+log "Master exit code: $MASTER_EXIT"
+echo ""
+
+OVERALL_PASS=true
+
+if [ "$MASTER_EXIT" != "0" ]; then
+  fail "Soak workload reported failures (master exit code: $MASTER_EXIT)"
+  OVERALL_PASS=false
+else
+  pass "All NCCL all_reduce iterations completed successfully"
+fi
+
+if [ "$OVERTEMP_COUNT" -gt "0" ]; then
+  fail "$OVERTEMP_COUNT GPU overtemperature event(s) detected"
+  OVERALL_PASS=false
+else
+  pass "No overtemperature events"
+fi
+
+if [ "$XID_COUNT" -gt "0" ]; then
+  fail "$XID_COUNT XID error(s) detected — potential GPU hardware issue"
+  OVERALL_PASS=false
+elif [ "$XID_UNVERIFIED" -gt "0" ]; then
+  warn "XID check could not run on $XID_UNVERIFIED node(s) — GPUs NOT certified XID-clean"
+else
+  pass "No XID errors"
+fi
+
+if [ "$LOW_UTIL_COUNT" -gt "5" ]; then
+  warn "$LOW_UTIL_COUNT low utilization events — GPUs may have throttled"
+else
+  pass "GPU utilization stayed healthy throughout"
+fi
+
+echo ""
+if [ "$OVERALL_PASS" = "true" ]; then
+  pass "=== SOAK TEST PASSED ==="
+  exit 0
+else
+  fail "=== SOAK TEST FAILED ==="
+  exit 1
+fi

--- a/k8s-training/gpu-soak-test/scripts/soak.py
+++ b/k8s-training/gpu-soak-test/scripts/soak.py
@@ -142,9 +142,12 @@ def main():
             busbw_sum += busbw
             peak_busbw = max(peak_busbw, busbw)
 
-        # Correctness: every element should equal `world`.
+        # Correctness: every element should equal `world`. Use a tolerance that
+        # scales with `world` — fp16 represents integers exactly only up to 2048,
+        # so a fixed 1e-3 would false-fail at large scale (>256 nodes). A genuine
+        # corrupt all_reduce is off by whole multiples, well outside 0.5%.
         result = ar[0].item()
-        if abs(result - expected) > 1e-3:
+        if abs(result - expected) > max(1e-3, expected * 5e-3):
             failures += 1
             print(
                 f"[WARN] rank {rank} iter {iterations}: all_reduce result "

--- a/k8s-training/gpu-soak-test/scripts/soak.py
+++ b/k8s-training/gpu-soak-test/scripts/soak.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# =============================================================================
+# GPU Soak Test — distributed workload (one process per GPU, via torchrun)
+#
+# Each rank runs THREE stresses on its GPU, concurrently:
+#   1. HBM occupancy — a large resident tensor fills a configurable fraction
+#      of device memory (default 75%), leaving headroom for NCCL buffers.
+#   2. Sustained compute — a tight FP16 matmul loop keeps the SMs ~100% busy.
+#   3. InfiniBand / NVLink stress — a timed dist.all_reduce every iteration,
+#      whose result is verified for correctness and whose bus bandwidth is
+#      measured (NCCL busbw convention).
+#
+# Ranks are launched by torchrun; RANK / LOCAL_RANK / WORLD_SIZE come from the
+# environment torchrun sets. The PyTorchJob operator provides MASTER_ADDR /
+# MASTER_PORT / (node) RANK / WORLD_SIZE, which the launch command feeds to
+# torchrun as --node_rank / --nnodes.
+#
+# Exit code: rank 0 exits non-zero if ANY rank saw an incorrect all_reduce
+# result, so the PyTorchJob master pod (and thus the job) fails loudly.
+# =============================================================================
+import os
+import sys
+import time
+
+import torch
+import torch.distributed as dist
+
+FP16 = torch.float16
+GiB = 1024 ** 3
+
+
+def env_int(name, default):
+    return int(os.environ.get(name, str(default)))
+
+
+def env_float(name, default):
+    return float(os.environ.get(name, str(default)))
+
+
+def main():
+    rank = env_int("RANK", 0)
+    local_rank = env_int("LOCAL_RANK", 0)
+    world = env_int("WORLD_SIZE", 1)
+
+    duration = env_int("SOAK_DURATION_SECONDS", 3600)
+    fill_fraction = env_float("HBM_FILL_FRACTION", 0.75)
+    allreduce_gb = env_float("ALLREDUCE_GB", 2.0)
+    matmuls_per_iter = env_int("MATMULS_PER_ITER", 100)
+    matmul_side = env_int("MATMUL_SIDE", 8192)
+
+    is_master = rank == 0
+
+    if not torch.cuda.is_available():
+        print("[FAIL] CUDA not available in worker", flush=True)
+        sys.exit(1)
+
+    torch.cuda.set_device(local_rank)
+    dev = torch.device(f"cuda:{local_rank}")
+
+    # NCCL backend; env:// rendezvous is populated by torchrun.
+    dist.init_process_group(backend="nccl", init_method="env://")
+
+    gpu_name = torch.cuda.get_device_name(local_rank)
+    total_mem = torch.cuda.get_device_properties(local_rank).total_memory
+
+    # ---- Allocate in headroom-safe order -----------------------------------
+    # 1) all_reduce buffer (must not be squeezed out by the HBM hog)
+    ar_elems = int(allreduce_gb * GiB / 2)  # fp16 = 2 bytes
+    ar = torch.empty(ar_elems, device=dev, dtype=FP16)
+    ar_bytes = ar.numel() * 2
+
+    # 2) matmul working set (small, fast — drives utilization, not memory)
+    ma = torch.randn(matmul_side, matmul_side, device=dev, dtype=FP16)
+    mb = torch.randn(matmul_side, matmul_side, device=dev, dtype=FP16)
+    mc = torch.empty(matmul_side, matmul_side, device=dev, dtype=FP16)
+    matmul_bytes = 3 * matmul_side * matmul_side * 2
+
+    # 3) HBM hog — occupy the rest up to fill_fraction of total memory.
+    #    Reserve ~2GB extra for NCCL internal buffers / CUDA context / workspace.
+    reserve_bytes = ar_bytes + matmul_bytes + 2 * GiB
+    hog_bytes = int(total_mem * fill_fraction) - reserve_bytes
+    hog = None
+    if hog_bytes > 0:
+        hog = torch.empty(hog_bytes // 2, device=dev, dtype=FP16)
+        hog.fill_(1.0)  # touch pages so the memory is truly committed
+
+    torch.cuda.synchronize()
+    allocated_gb = torch.cuda.memory_allocated(local_rank) / GiB
+
+    if is_master:
+        print(
+            f"[soak] world={world} gpus/node={env_int('NPROC_PER_NODE', 8)} "
+            f"gpu='{gpu_name}' total={total_mem / GiB:.1f}GB",
+            flush=True,
+        )
+        print(
+            f"[soak] per-rank: fill={fill_fraction * 100:.0f}% "
+            f"allreduce={allreduce_gb:.1f}GB matmul={matmul_side}x{matmul_side} "
+            f"allocated={allocated_gb:.1f}GB duration={duration}s",
+            flush=True,
+        )
+        print("SOAK_CONFIG_OK", flush=True)
+
+    # ---- Main soak loop ----------------------------------------------------
+    # Termination is decided collectively: rank 0 raises the stop flag when the
+    # clock expires, and an all_reduce(MAX) makes every rank break on the SAME
+    # iteration. Without this, ranks could desync and deadlock in a collective.
+    end = time.time() + duration
+    stop = torch.zeros(1, device=dev)
+    expected = float(world)  # all_reduce(SUM) of ones over `world` ranks
+    iterations = 0
+    failures = 0
+    busbw_sum = 0.0
+    peak_busbw = 0.0
+
+    while True:
+        if is_master and time.time() >= end:
+            stop.fill_(1.0)
+        dist.all_reduce(stop, op=dist.ReduceOp.MAX)
+        if stop.item() > 0:
+            break
+
+        iterations += 1
+
+        # Sustained compute — keeps GPU utilization pinned high.
+        for _ in range(matmuls_per_iter):
+            torch.matmul(ma, mb, out=mc)
+
+        # IB/NVLink stress — timed, verified all_reduce.
+        ar.fill_(1.0)
+        torch.cuda.synchronize()
+        dist.barrier()
+        t0 = time.time()
+        dist.all_reduce(ar, op=dist.ReduceOp.SUM)
+        torch.cuda.synchronize()
+        dt = time.time() - t0
+
+        # busbw (NCCL convention): algbw * 2*(n-1)/n
+        if dt > 0:
+            algbw = ar_bytes / dt
+            busbw = algbw * 2 * (world - 1) / world / 1e9
+            busbw_sum += busbw
+            peak_busbw = max(peak_busbw, busbw)
+
+        # Correctness: every element should equal `world`.
+        result = ar[0].item()
+        if abs(result - expected) > 1e-3:
+            failures += 1
+            print(
+                f"[WARN] rank {rank} iter {iterations}: all_reduce result "
+                f"{result} != expected {expected}",
+                flush=True,
+            )
+
+        if is_master and iterations % 20 == 0:
+            remaining = int(end - time.time())
+            avg = busbw_sum / iterations if iterations else 0.0
+            print(
+                f"[soak] iter {iterations} | busbw={busbw:.1f} GB/s "
+                f"(avg {avg:.1f}) | all_reduce {allreduce_gb:.1f}GB in "
+                f"{dt * 1000:.1f}ms | remaining {remaining}s",
+                flush=True,
+            )
+
+    # ---- Aggregate results across all ranks --------------------------------
+    fail_tensor = torch.tensor([float(failures)], device=dev, dtype=torch.float64)
+    peak_tensor = torch.tensor([peak_busbw], device=dev, dtype=torch.float64)
+    dist.all_reduce(fail_tensor, op=dist.ReduceOp.SUM)
+    dist.all_reduce(peak_tensor, op=dist.ReduceOp.MAX)
+    total_failures = int(fail_tensor.item())
+    global_peak_busbw = peak_tensor.item()
+
+    if is_master:
+        avg = busbw_sum / iterations if iterations else 0.0
+        print("=== GPU Soak Test Complete ===", flush=True)
+        print(f"Total iterations: {iterations}", flush=True)
+        print(f"Failed iterations (all ranks): {total_failures}", flush=True)
+        print(f"BUSBW_GBPS: {global_peak_busbw:.1f}", flush=True)
+        print(f"BUSBW_AVG_GBPS: {avg:.1f}", flush=True)
+        if total_failures == 0:
+            print("[PASS] All all_reduce iterations completed with correct results", flush=True)
+        else:
+            print(f"[FAIL] {total_failures} all_reduce iteration(s) returned incorrect data", flush=True)
+
+    dist.destroy_process_group()
+
+    # Fail the job (via the master rank's exit code) on any incorrect result.
+    if is_master and total_failures > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/k8s-training/gpu-soak-test/templates/pytorchjob.yaml
+++ b/k8s-training/gpu-soak-test/templates/pytorchjob.yaml
@@ -1,0 +1,146 @@
+# =============================================================================
+# GPU Soak Test — PyTorchJob
+#
+# Single image (PyTorch NGC) for BOTH master and workers, so torch.distributed
+# ranks launch cleanly on every pod (no mpirun/SSH, no launcher/worker image
+# split). The kubeflow Training Operator injects MASTER_ADDR / MASTER_PORT /
+# RANK / WORLD_SIZE per pod; torchrun uses those to launch one rank per GPU.
+#
+# The workload (scripts/soak.py) is mounted from a ConfigMap created by
+# run-soak-test.sh, so the manifest stays free of inlined Python.
+#
+# Placeholders patched by run-soak-test.sh:
+#   __GPU_INSTANCE_TYPE__  node.kubernetes.io/instance-type value
+#   __WORKER_REPLICAS__    number of Worker pods (total nodes - 1)
+#   __DURATION__           soak duration in seconds
+#   __FILL_FRACTION__      HBM fill fraction (0-1)
+#   __SLOTS__              GPUs per node (nproc_per_node)
+#   __SOAK_IMAGE__         container image (must match GPU arch + CPU arch)
+# =============================================================================
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: gpu-soak-test
+  namespace: gpu-soak
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        metadata:
+          labels:
+            app: gpu-soak
+        spec:
+          nodeSelector:
+            node.kubernetes.io/instance-type: __GPU_INSTANCE_TYPE__
+          tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          containers:
+          - name: pytorch          # PyTorchJob REQUIRES this container name
+            image: __SOAK_IMAGE__
+            command: ["/bin/sh", "-c"]
+            args:
+            - |
+              set -e
+              echo "Node rank ${RANK}/${WORLD_SIZE}  master=${MASTER_ADDR}:${MASTER_PORT}"
+              torchrun \
+                --nnodes="${WORLD_SIZE}" \
+                --node_rank="${RANK}" \
+                --nproc_per_node="${NPROC_PER_NODE}" \
+                --master_addr="${MASTER_ADDR}" \
+                --master_port="${MASTER_PORT}" \
+                /workspace/soak.py
+            env:
+            - name: NPROC_PER_NODE
+              value: "__SLOTS__"
+            - name: SOAK_DURATION_SECONDS
+              value: "__DURATION__"
+            - name: HBM_FILL_FRACTION
+              value: "__FILL_FRACTION__"
+            - name: NCCL_DEBUG
+              value: "WARN"
+            - name: NCCL_IB_GID_INDEX
+              value: "3"
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0"
+            resources:
+              limits:
+                nvidia.com/gpu: "__SLOTS__"
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - name: soak-script
+              mountPath: /workspace
+            - name: shm
+              mountPath: /dev/shm
+          volumes:
+          - name: soak-script
+            configMap:
+              name: soak-script
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 64Gi
+    Worker:
+      replicas: __WORKER_REPLICAS__
+      restartPolicy: Never
+      template:
+        metadata:
+          labels:
+            app: gpu-soak
+        spec:
+          nodeSelector:
+            node.kubernetes.io/instance-type: __GPU_INSTANCE_TYPE__
+          tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          containers:
+          - name: pytorch
+            image: __SOAK_IMAGE__
+            command: ["/bin/sh", "-c"]
+            args:
+            - |
+              set -e
+              echo "Node rank ${RANK}/${WORLD_SIZE}  master=${MASTER_ADDR}:${MASTER_PORT}"
+              torchrun \
+                --nnodes="${WORLD_SIZE}" \
+                --node_rank="${RANK}" \
+                --nproc_per_node="${NPROC_PER_NODE}" \
+                --master_addr="${MASTER_ADDR}" \
+                --master_port="${MASTER_PORT}" \
+                /workspace/soak.py
+            env:
+            - name: NPROC_PER_NODE
+              value: "__SLOTS__"
+            - name: SOAK_DURATION_SECONDS
+              value: "__DURATION__"
+            - name: HBM_FILL_FRACTION
+              value: "__FILL_FRACTION__"
+            - name: NCCL_DEBUG
+              value: "WARN"
+            - name: NCCL_IB_GID_INDEX
+              value: "3"
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0"
+            resources:
+              limits:
+                nvidia.com/gpu: "__SLOTS__"
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - name: soak-script
+              mountPath: /workspace
+            - name: shm
+              mountPath: /dev/shm
+          volumes:
+          - name: soak-script
+            configMap:
+              name: soak-script
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 64Gi


### PR DESCRIPTION
## Summary
Adds a Kubernetes-native GPU soak test for MK8s clusters — the MK8s equivalent of the cloudmeter auto-loader: sustained GPU compute + HBM fill + InfiniBand/NVLink stress with structured pass/fail output and a report.

## How it works
Runs as a **PyTorchJob** with a single PyTorch image on every pod. `torchrun` launches one `torch.distributed` rank per GPU, and each rank concurrently:
1. **Fills HBM** with a resident FP16 tensor (default 75% of device memory)
2. **Stresses compute** with a continuous FP16 matmul loop (drives util to ~100%)
3. **Stresses the fabric** with a timed, verified `all_reduce` every iteration

Because PyTorch bundles NCCL, the same container does the memory fill and the collective — no launcher/worker image split — and the collective's exit code is authoritative (a real NCCL failure fails the job).

## Files
- `run-soak-test.sh` — driver
- `scripts/soak.py` — per-rank soak workload
- `scripts/monitor.sh` — monitoring
- `templates/pytorchjob.yaml` — PyTorchJob manifest
- `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)