### PR TITLE
SCHED-1775: Validation for cpu arch of worker nodesets

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -150,6 +150,7 @@ resource "terraform_data" "check_variables" {
   depends_on = [
     terraform_data.check_slurm_nodeset,
     terraform_data.check_slurm_nodeset_accounting,
+    terraform_data.check_slurm_worker_cpu_platform,
     terraform_data.check_nfs,
     terraform_data.check_nfs_exclusivity,
     terraform_data.check_jail_submount_paths,
@@ -293,6 +294,7 @@ module "k8s" {
     module.cleanup,
     terraform_data.check_slurm_nodeset_accounting,
     terraform_data.check_slurm_nodeset,
+    terraform_data.check_slurm_worker_cpu_platform,
   ]
 
   source = "../../modules/k8s"

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1245,15 +1245,22 @@ resource "terraform_data" "check_slurm_nodeset" {
 }
 
 locals {
-  slurm_worker_cpu_platforms = compact(concat(
-    local.login_node_group.node_group_enabled ? [
-      try(module.resources.by_platform[local.login_node_group.resource.platform][local.login_node_group.resource.preset].cpu_platform, "")
-    ] : [],
-    [
-      for worker in var.slurm_nodeset_workers :
-      try(module.resources.by_platform[worker.resource.platform][worker.resource.preset].cpu_platform, "")
-    ],
-  ))
+  slurm_worker_cpu_platform_entries = [
+    for worker in var.slurm_nodeset_workers : {
+      name         = worker.name
+      platform     = worker.resource.platform
+      cpu_platform = try(module.resources.by_platform[worker.resource.platform][worker.resource.preset].cpu_platform, "")
+    }
+  ]
+
+  slurm_worker_cpu_platforms = compact([
+    for entry in local.slurm_worker_cpu_platform_entries : entry.cpu_platform
+  ])
+
+  slurm_worker_cpu_platform_message = join("\n", [
+    for entry in local.slurm_worker_cpu_platform_entries :
+    format("%s (%s) -> %s", entry.name, entry.platform, entry.cpu_platform)
+  ])
 }
 
 resource "terraform_data" "check_slurm_worker_cpu_platform" {
@@ -1263,10 +1270,10 @@ resource "terraform_data" "check_slurm_worker_cpu_platform" {
 
   lifecycle {
     precondition {
-      # Workers and login nodes share binaries through one jail filesystem, so
-      # all jail-mounted node groups must be binary-compatible.
+      # Worker nodesets share binaries through one jail filesystem, so all
+      # worker nodesets must be binary-compatible.
       condition     = length(distinct(local.slurm_worker_cpu_platforms)) <= 1
-      error_message = "Slurm worker nodesets and the enabled login node group must use the same CPU platform because they share one jail filesystem."
+      error_message = "Slurm worker nodesets must use the same CPU platform because they share one jail filesystem.\nConfigured CPU platforms:\n${local.slurm_worker_cpu_platform_message}"
     }
   }
 }

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1244,6 +1244,33 @@ resource "terraform_data" "check_slurm_nodeset" {
   }
 }
 
+locals {
+  slurm_worker_cpu_platforms = compact(concat(
+    local.login_node_group.node_group_enabled ? [
+      try(module.resources.by_platform[local.login_node_group.resource.platform][local.login_node_group.resource.preset].cpu_platform, "")
+    ] : [],
+    [
+      for worker in var.slurm_nodeset_workers :
+      try(module.resources.by_platform[worker.resource.platform][worker.resource.preset].cpu_platform, "")
+    ],
+  ))
+}
+
+resource "terraform_data" "check_slurm_worker_cpu_platform" {
+  depends_on = [
+    terraform_data.check_slurm_nodeset,
+  ]
+
+  lifecycle {
+    precondition {
+      # Workers and login nodes share binaries through one jail filesystem, so
+      # all jail-mounted node groups must be binary-compatible.
+      condition     = length(distinct(local.slurm_worker_cpu_platforms)) <= 1
+      error_message = "Slurm worker nodesets and the enabled login node group must use the same CPU platform because they share one jail filesystem."
+    }
+  }
+}
+
 resource "terraform_data" "check_local_nvme" {
   lifecycle {
     precondition {

--- a/soperator/modules/available_resources/outputs.tf
+++ b/soperator/modules/available_resources/outputs.tf
@@ -18,6 +18,11 @@ output "platform_regions" {
   value       = local.platform_regions
 }
 
+output "cpu_platform_by_platform" {
+  description = "Map of binary-compatible CPU platform grouped by Nebius platform."
+  value       = local.cpu_platform_by_platform
+}
+
 output "by_platform" {
   description = "Map of available resource presets grouped by platform."
   value       = local.presets_by_platforms

--- a/soperator/modules/available_resources/platform.tf
+++ b/soperator/modules/available_resources/platform.tf
@@ -10,6 +10,17 @@ locals {
     gpu-gb300      = "gpu-gb300"
   }
 
+  cpu_platform_by_platform = {
+    (local.platforms.cpu-e2)         = "amd64"
+    (local.platforms.cpu-d3)         = "amd64"
+    (local.platforms.gpu-h100-sxm)   = "amd64"
+    (local.platforms.gpu-h200-sxm)   = "amd64"
+    (local.platforms.gpu-b200-sxm)   = "amd64"
+    (local.platforms.gpu-b200-sxm-a) = "amd64"
+    (local.platforms.gpu-b300-sxm)   = "amd64"
+    (local.platforms.gpu-gb300)      = "arm64"
+  }
+
   platform_regions = tomap({
     (local.platforms.cpu-e2) = [
       local.regions.eu-north1,

--- a/soperator/modules/available_resources/preset.tf
+++ b/soperator/modules/available_resources/preset.tf
@@ -400,6 +400,7 @@ locals {
   presets_by_platforms = tomap({
     for platform, presets in local.presets_by_platforms_raw : platform => tomap({
       for preset, resources in presets : preset => merge(resources, {
+        cpu_platform = local.cpu_platform_by_platform[platform]
         local_nvme_supported = anytrue([
           for region in [for _, region in local.regions : region] : try(local.local_nvme_supported_by_region_platform_preset[region][platform][preset], false)
         ])


### PR DESCRIPTION
## Release Notes (Mandatory Description)
Validation for cpu arch of worker nodesets to prevent mixing CPU arch in nodesets (due to shared jails and binaries in it) 

Example error message:

```
╷
│ Error: Resource precondition failed
│
│   on variables.tf line 1284, in resource "terraform_data" "check_slurm_worker_cpu_platform":
│ 1284:       condition     = length(distinct(local.slurm_worker_cpu_platforms)) <= 1
│     ├────────────────
│     │ local.slurm_worker_cpu_platforms is list of string with 3 elements
│
│ Slurm worker nodesets and the enabled login node group must use the same
│ CPU platform because they share one jail filesystem.
│ Configured CPU platforms:
│ worker-gpu (gpu-h200-sxm) -> amd64
│ worker-gb300 (gpu-gb300) -> arm64
│ worker-cpu (cpu-d3) -> amd64
╵
```