### PR TITLE
SCHED-0000 Run NCCL network vars prolog in jail

### DIFF
--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -384,7 +384,7 @@ resources:
                       "on_ok": "none",
                       "reason_base": "",
                       "reason_append_details": false,
-                      "run_in_jail": false,
+                      "run_in_jail": true,
                       "log": "slurm_scripts/$worker.$name.$context.out",
                       "need_env": []
                     }


### PR DESCRIPTION
## Problem

The Terraform template mounts `90-nccl-network-vars.sh` into the worker jail at `/etc/profile.d/90-nccl-network-vars.sh`, but generated the prolog check with `run_in_jail=false`.

As a result, the check ran on the worker container filesystem, where `/etc/profile.d/90-nccl-network-vars.sh` does not exist. Slurm treated the prolog failure as a job setup failure, cancelled GPU ActiveCheck jobs, and blocked dependent ActiveChecks.

## Fix

Set `run_in_jail=true` for the generated `nccl-network-vars` prolog check, so the existing script path resolves in the same jailed filesystem that Slurm jobs use.