### PR TITLE
Use node_group_version 72 for k8s 1.34

### DIFF
--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -724,7 +724,7 @@ k8s_version = 1.34
 
 # Version of the node group to be used.
 # ---
-node_group_version = 67
+node_group_version = 72
 
 # SSH user credentials for accessing k8s nodes.
 # By default, empty list.


### PR DESCRIPTION
## Release Notes (Mandatory Description)