### PR TITLE
SCHED-2302: Restore metrics TSA token writer

### DIFF
--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -78,7 +78,10 @@ resources:
             secretName: o11y-writer-sa-token
             secretKey: accessToken
             writer:
-              enabled: false
+              enabled: true
+              source: imds
+              namespaces:
+                - monitoring-system
           opentelemetry:
             enabled: ${telemetry_enabled}
 


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Fix TSA token writer for metrics. This changes leaves Terraform in charge of generating token in `logging-system` namespace and enables `tsa-writer` for `monitoring-system` namespace.