### PR TITLE
SCHED-1519: upgrade version fluxcd and set coorect settings

### DIFF
--- a/soperator/modules/fluxcd/main.tf
+++ b/soperator/modules/fluxcd/main.tf
@@ -19,17 +19,18 @@ resource "terraform_data" "flux_namespace" {
 resource "terraform_data" "flux2" {
   depends_on = [terraform_data.flux_namespace]
   provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    command = join(
-      " ",
-      [
-        "${path.module}/../scripts/retry.sh", "--",
-        "kubectl", "--context", var.k8s_cluster_context,
-        "apply", "-f", "https://github.com/fluxcd/flux2/releases/download/${var.flux_version}/install.yaml",
-      ]
-    )
+    command = "${path.module}/../scripts/retry.sh -- ${path.module}/scripts/install.sh"
+    environment = {
+      FLUX_K8S_CONTEXT = var.k8s_cluster_context
+      FLUX_VERSION     = var.flux_version
+    }
   }
   triggers_replace = {
-    first_run = "true"
+    flux_version = var.flux_version
+    installer_sha256 = sha256(join("", [
+      filesha256("${path.module}/scripts/install.sh"),
+      filesha256("${path.module}/templates/kustomization.yaml"),
+      filesha256("${path.module}/templates/migration-job.yaml"),
+    ]))
   }
 }

--- a/soperator/modules/fluxcd/scripts/install.sh
+++ b/soperator/modules/fluxcd/scripts/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FLUX_K8S_CONTEXT:?FLUX_K8S_CONTEXT must be set}"
+: "${FLUX_VERSION:?FLUX_VERSION must be set}"
+
+readonly module_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly work_dir="$(mktemp -d)"
+trap 'rm -rf -- "${work_dir}"' EXIT
+
+curl --fail --silent --show-error --location \
+  "https://github.com/fluxcd/flux2/releases/download/${FLUX_VERSION}/install.yaml" \
+  --output "${work_dir}/install.yaml"
+cp "${module_dir}/templates/kustomization.yaml" "${work_dir}/kustomization.yaml"
+
+# Flux v2.8+ removes deprecated API versions. Migrate objects and CRD
+# storedVersions before updating an existing installation.
+if kubectl --context "${FLUX_K8S_CONTEXT}" get \
+  customresourcedefinition kustomizations.kustomize.toolkit.fluxcd.io \
+  >/dev/null 2>&1; then
+  sed "s/FLUX_VERSION/${FLUX_VERSION}/g" \
+    "${module_dir}/templates/migration-job.yaml" \
+    >"${work_dir}/migration-job.yaml"
+
+  kubectl --context "${FLUX_K8S_CONTEXT}" --namespace flux-system delete \
+    job flux-api-migration --ignore-not-found
+  kubectl --context "${FLUX_K8S_CONTEXT}" apply \
+    --filename "${work_dir}/migration-job.yaml"
+  kubectl --context "${FLUX_K8S_CONTEXT}" --namespace flux-system wait \
+    --for=condition=complete job/flux-api-migration --timeout=10m
+  kubectl --context "${FLUX_K8S_CONTEXT}" --namespace flux-system delete \
+    job flux-api-migration
+fi
+
+kubectl --context "${FLUX_K8S_CONTEXT}" apply -k "${work_dir}"
+
+# Remove controllers that may be left from an older full-manifest installation.
+kubectl --context "${FLUX_K8S_CONTEXT}" --namespace flux-system delete deployment \
+  image-automation-controller \
+  image-reflector-controller \
+  notification-controller \
+  source-watcher \
+  --ignore-not-found
+kubectl --context "${FLUX_K8S_CONTEXT}" --namespace flux-system delete serviceaccount \
+  image-automation-controller \
+  image-reflector-controller \
+  notification-controller \
+  source-watcher \
+  --ignore-not-found
+kubectl --context "${FLUX_K8S_CONTEXT}" --namespace flux-system delete service \
+  notification-controller \
+  source-watcher \
+  webhook-receiver \
+  --ignore-not-found
+kubectl --context "${FLUX_K8S_CONTEXT}" --namespace flux-system delete networkpolicy \
+  allow-webhooks \
+  --ignore-not-found

--- a/soperator/modules/fluxcd/templates/kustomization.yaml
+++ b/soperator/modules/fluxcd/templates/kustomization.yaml
@@ -1,0 +1,88 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - install.yaml
+
+patches:
+  # Install only the components used by Soperator. The full upstream manifest
+  # also contains the image, notification, and source-watcher components.
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: >-
+        (artifactgenerators.source.extensions.fluxcd.io|imagepolicies.image.toolkit.fluxcd.io|imagerepositories.image.toolkit.fluxcd.io|imageupdateautomations.image.toolkit.fluxcd.io|alerts.notification.toolkit.fluxcd.io|providers.notification.toolkit.fluxcd.io|receivers.notification.toolkit.fluxcd.io)
+    patch: |-
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: unused
+      $patch: delete
+
+  - target:
+      version: v1
+      kind: ServiceAccount
+      labelSelector: >-
+        app.kubernetes.io/component in
+        (image-automation-controller,image-reflector-controller,notification-controller,source-watcher)
+    patch: |-
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: unused
+      $patch: delete
+
+  - target:
+      version: v1
+      kind: Service
+      labelSelector: >-
+        app.kubernetes.io/component in (notification-controller,source-watcher)
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: unused
+      $patch: delete
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      labelSelector: >-
+        app.kubernetes.io/component in
+        (image-automation-controller,image-reflector-controller,notification-controller,source-watcher)
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: unused
+      $patch: delete
+
+  - target:
+      group: networking.k8s.io
+      version: v1
+      kind: NetworkPolicy
+      name: allow-webhooks
+    patch: |-
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: unused
+      $patch: delete
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: (helm|kustomize|source)-controller
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/args/0
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          slurm.nebius.ai/nodeset: system
+      - op: add
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 100m

--- a/soperator/modules/fluxcd/templates/migration-job.yaml
+++ b/soperator/modules/fluxcd/templates/migration-job.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flux-api-migration
+  namespace: flux-system
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      serviceAccountName: kustomize-controller
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: ghcr.io/fluxcd/flux-cli:FLUX_VERSION
+          args:
+            - migrate

--- a/soperator/modules/fluxcd/variables.tf
+++ b/soperator/modules/fluxcd/variables.tf
@@ -6,5 +6,10 @@ variable "k8s_cluster_context" {
 variable "flux_version" {
   description = "The version of Flux to install."
   type        = string
-  default     = "v2.7.4"
+  default     = "v2.9.3"
+
+  validation {
+    condition     = can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+$", var.flux_version))
+    error_message = "flux_version must be a stable semantic version such as v2.9.3."
+  }
 }


### PR DESCRIPTION
## Release Notes (Mandatory Description)

Upgraded FluxCD to v2.9.3, deployed only the required controllers on system/infra nodes with 100m CPU requests, and added an API migration job to ensure safe upgrades from older Flux versions.