### PR TITLE
gpu-soak-test: GB300 / DRA support (auto-detected, x86 unchanged)

### DIFF
--- a/k8s-training/gpu-soak-test/.gitignore
+++ b/k8s-training/gpu-soak-test/.gitignore
@@ -1,0 +1,3 @@
+# generated per-run artifacts (contain node names / run-specific data)
+soak-report-*.txt
+soak-monitor-*.log

--- a/k8s-training/gpu-soak-test/README.md
+++ b/k8s-training/gpu-soak-test/README.md
@@ -115,6 +115,29 @@ Everything else — GPU detection, HBM sizing, 8-GPU layout, NCCL, monitoring,
 report — adapts automatically; only `SOAK_IMAGE` (and `MAX_TEMP` for Blackwell)
 changes per platform.
 
+## GB300 / DRA clusters — automatic
+
+GB300/Grace clusters are usually **DRA-native**: GPUs are advertised via Dynamic
+Resource Allocation (`gpu.nvidia.com` DeviceClass), not the `nvidia.com/gpu` device
+plugin. The script **auto-detects** this (no allocatable `nvidia.com/gpu` +
+DeviceClass present) and adapts — nothing to set:
+
+- Requests GPUs via a `ResourceClaimTemplate` (`dra/`) + the `pytorchjob-dra.yaml`
+  template instead of `nvidia.com/gpu` limits; GPUs/node read from resourceslices.
+- Creates a **ComputeDomain** so cross-node NCCL can form one MNNVL/NVLink domain —
+  without it NCCL's NVLS setup fails with `Cuda failure 801`. Torn down with the namespace.
+
+By default the cross-node collective rides **MNNVL/NVLink** (fastest on GB300). To
+soak the **InfiniBand** fabric instead (as the x86 soak does), set `SOAK_TRANSPORT=ib`
+— it disables MNNVL/NVLS so NCCL routes cross-node over IB:
+
+```bash
+SOAK_TRANSPORT=ib SOAK_IMAGE=nvcr.io/nvidia/pytorch:25.06-py3 MAX_TEMP=90 ./run-soak-test.sh 7200 2
+```
+
+Requires the Training Operator ≥ v1.8.0 (older CRDs reject DRA `resourceClaims`).
+The x86 device-plugin path is unchanged — none of this runs there.
+
 ## GPU type detection — automatic
 
 The script automatically detects whatever GPU node type is present in the cluster at runtime. No configuration needed.

--- a/k8s-training/gpu-soak-test/dra/compute-domain.yaml
+++ b/k8s-training/gpu-soak-test/dra/compute-domain.yaml
@@ -1,0 +1,27 @@
+# =============================================================================
+# GB300 / DRA ComputeDomain for cross-node NCCL.
+#
+# On DRA-native GB300 clusters, cross-node collectives use MNNVL (multi-node
+# NVLink). Without a ComputeDomain the nodes aren't in a shared NVLink clique,
+# so NCCL's NVLS/MNNVL setup fails with "Cuda failure 801 'operation not
+# supported'" (transport/nvls.cc). The ComputeDomain establishes the IMEX
+# channel that lets the pods form one NVLink domain.
+#
+# The NVIDIA controller AUTO-CREATES the channel ResourceClaimTemplate named
+# below (soak-channel) — do not hand-write it. Pods claim it via pytorchjob-dra.yaml.
+# Applied ONLY on DRA clusters (single-node runs skip it — no cross-node fabric).
+#
+# Placeholder patched by run-soak-test.sh:
+#   __NODE_COUNT__   number of GPU nodes in the run (= ComputeDomain size)
+# =============================================================================
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: soak-cd
+  labels:
+    app: gpu-soak
+spec:
+  numNodes: __NODE_COUNT__
+  channel:
+    resourceClaimTemplate:
+      name: soak-channel

--- a/k8s-training/gpu-soak-test/dra/gpu-resourceclaim-template.yaml
+++ b/k8s-training/gpu-soak-test/dra/gpu-resourceclaim-template.yaml
@@ -1,0 +1,29 @@
+# =============================================================================
+# GB300 / DRA GPU claim for the soak pods.
+#
+# Applied ONLY on DRA clusters (Grace/GB300), which advertise GPUs via Dynamic
+# Resource Allocation instead of the nvidia.com/gpu device plugin. x86
+# device-plugin clusters never reach this file — run-soak-test.sh auto-detects
+# the mode and uses templates/pytorchjob.yaml (limits.nvidia.com/gpu) there.
+#
+# Scoped to the gpu-soak namespace (created fresh per run and torn down on
+# cleanup), so this claim is removed with the namespace — no separate cleanup.
+#
+# Placeholder patched by run-soak-test.sh:
+#   __SLOTS__   GPUs to claim per pod (auto-detected from resourceslices)
+# =============================================================================
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: soak-gpus
+  labels:
+    app: gpu-soak
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpus
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: __SLOTS__

--- a/k8s-training/gpu-soak-test/run-soak-test.sh
+++ b/k8s-training/gpu-soak-test/run-soak-test.sh
@@ -51,6 +51,11 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPORT_FILE="soak-report-$(date +%Y%m%d_%H%M%S).txt"
 START_TIME=$(date -u)
 START_EPOCH=$(date +%s)
+# Anchor the monitor log to this script's dir (not the caller's CWD) so the report
+# generator reliably finds it regardless of invocation directory. Also export the
+# run start so monitor.sh can scope its dmesg XID check to this run.
+export SOAK_LOG_DIR="$SCRIPT_DIR"
+export SOAK_START_EPOCH="$START_EPOCH"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -333,7 +338,10 @@ MONITOR_EXIT=$?
 set -e
 
 # Collect final master logs (rank 0 prints the summary + BUSBW lines)
-MASTER_LOGS=$(kubectl logs --request-timeout=30s -n "$NAMESPACE" -l training.kubeflow.org/replica-type=master 2>/dev/null | tail -40)
+# --tail=-1 is required with -l: `kubectl logs` defaults to only the last 10 lines
+# per pod when a label selector is used (unlike naming a pod, which returns all),
+# which would silently drop the summary/BUSBW lines we parse below.
+MASTER_LOGS=$(kubectl logs --request-timeout=30s --tail=-1 -n "$NAMESPACE" -l training.kubeflow.org/replica-type=master 2>/dev/null | tail -40)
 
 END_TIME=$(date -u)
 END_EPOCH=$(date +%s)

--- a/k8s-training/gpu-soak-test/run-soak-test.sh
+++ b/k8s-training/gpu-soak-test/run-soak-test.sh
@@ -36,7 +36,7 @@ DURATION="${1:-3600}"
 export SOAK_DURATION_SECONDS="$DURATION"
 NODE_COUNT="${2:-2}"
 NAMESPACE="gpu-soak"
-SLOTS=8
+SLOTS="${SLOTS:-8}"   # device-plugin default; auto-detected from DRA on GB300 (see GPU-mode detection below)
 HBM_FILL_FRACTION="${HBM_FILL_FRACTION:-0.75}"
 # Overtemp threshold °C. Exported so monitor.sh and the report agree on one value
 # (raise for Blackwell, e.g. MAX_TEMP=90). Default matches monitor.sh's default.
@@ -77,10 +77,50 @@ trap 'cleanup_ns; exit 130' INT TERM
 REACHED_END=0
 trap '[ "$REACHED_END" = "1" ] || cleanup_ns' EXIT
 
+# --- GPU allocation mode: device-plugin (x86) vs DRA (Grace/GB300) [additive] ---
+# x86 GPU clusters advertise the nvidia.com/gpu device-plugin resource. DRA-native
+# clusters (Grace/GB300) advertise GPUs via Dynamic Resource Allocation and report
+# 0 nvidia.com/gpu. Auto-detect so the x86 device-plugin path stays unchanged and
+# GB300/DRA is handled additively. Fails loudly if neither is present.
+GPU_MODE="device-plugin"
+DEVPLUGIN_NODES=$(kubectl get nodes \
+  -o jsonpath='{range .items[*]}{.status.allocatable.nvidia\.com/gpu}{"\n"}{end}' 2>/dev/null \
+  | awk 'NF{c++} END{print c+0}')
+if [ "${DEVPLUGIN_NODES:-0}" -eq 0 ]; then
+  if kubectl get deviceclass gpu.nvidia.com >/dev/null 2>&1; then
+    GPU_MODE="dra"
+    # On DRA, GPUs/node comes from the resourceslices, not a hardcoded value.
+    # Portable awk (no python / no grep -P): count device names in the first
+    # gpu.nvidia.com slice. Note: do NOT `exit` early in awk — closing the pipe
+    # would SIGPIPE the upstream kubectl and, under `set -o pipefail`, abort the
+    # script. Process all lines and print only the first match instead.
+    DETECTED_SLOTS=$(kubectl get resourceslices \
+      -o jsonpath='{range .items[*]}{.spec.driver}{"\t"}{range .spec.devices[*]}{.name}{","}{end}{"\n"}{end}' 2>/dev/null \
+      | awk -F'\t' '$1=="gpu.nvidia.com" && !seen {n=gsub(/,/,",",$2); if(n>0){print n; seen=1}}')
+    if [ -n "$DETECTED_SLOTS" ] && [ "$DETECTED_SLOTS" -gt 0 ] 2>/dev/null; then
+      SLOTS="$DETECTED_SLOTS"
+    fi
+  else
+    echo -e "${RED}ERROR: no GPUs found — neither the nvidia.com/gpu device plugin nor the gpu.nvidia.com DRA DeviceClass is present${NC}" >&2
+    exit 1
+  fi
+fi
+
+# Cross-node NCCL transport (DRA/GB300 only). On GB300 the two nodes fuse into one
+# MNNVL (multi-node NVLink) domain, so by default NCCL runs collectives over NVLink
+# and the IB fabric stays idle. Set SOAK_TRANSPORT=ib to disable MNNVL/NVLS so NCCL
+# falls back to InfiniBand cross-node — to soak the IB fabric itself (as the x86
+# soak does). No effect on x86 (its template has no such vars).
+SOAK_TRANSPORT="${SOAK_TRANSPORT:-auto}"
+
 echo "=== GPU Soak Test (PyTorchJob / torch.distributed) ==="
 echo "Duration:     ${DURATION}s ($(( DURATION / 60 )) minutes)"
 echo "GPU nodes:    $NODE_COUNT"
 echo "GPUs/node:    $SLOTS"
+echo "GPU mode:     $GPU_MODE"
+if [ "$GPU_MODE" = "dra" ] && [ "$NODE_COUNT" -gt 1 ]; then
+  echo "Transport:    ${SOAK_TRANSPORT} ($([ "$SOAK_TRANSPORT" = "ib" ] && echo "InfiniBand cross-node" || echo "MNNVL/NVLink cross-node"))"
+fi
 echo "HBM fill:     $(awk "BEGIN{printf \"%.0f\", ${HBM_FILL_FRACTION}*100}")%"
 echo "Max temp:     ${MAX_TEMP}°C"
 echo "Image:        $SOAK_IMAGE"
@@ -209,14 +249,64 @@ kubectl delete ds/soak-prepull -n "$NAMESPACE" --ignore-not-found=true --wait=fa
 # Patch the PyTorchJob template. Worker replicas = total nodes - 1 (master is
 # rank 0 and also runs GPUs), so total pods == NODE_COUNT.
 WORKER_REPLICAS=$(( NODE_COUNT - 1 ))
+
+# Map the transport choice to the NCCL env the DRA template carries (no-op on x86).
+if [ "$SOAK_TRANSPORT" = "ib" ]; then
+  NCCL_MNNVL_ENABLE=0; NCCL_NVLS_ENABLE=0
+  if [ "$GPU_MODE" != "dra" ]; then
+    echo -e "${YELLOW}NOTE: SOAK_TRANSPORT=ib only affects DRA/GB300; ignored on device-plugin (x86 already soaks IB cross-node).${NC}"
+  fi
+else
+  NCCL_MNNVL_ENABLE=1; NCCL_NVLS_ENABLE=1
+fi
+
+# Select the GPU-allocation variant. x86 -> device-plugin template (unchanged).
+# DRA -> apply the GPU ResourceClaimTemplate + a ComputeDomain first, then use the
+# DRA PyTorchJob template. Both live in $NAMESPACE, so they're torn down with it.
+if [ "$GPU_MODE" = "dra" ]; then
+  echo "Applying DRA GPU ResourceClaimTemplate (count=$SLOTS)..."
+  sed -e "s/__SLOTS__/${SLOTS}/g" "$SCRIPT_DIR/dra/gpu-resourceclaim-template.yaml" \
+    | kubectl apply -n "$NAMESPACE" -f -
+  # Cross-node NCCL on GB300 needs an MNNVL ComputeDomain (without it NVLS setup
+  # fails with "Cuda failure 801 operation not supported"). The NVIDIA controller
+  # auto-creates the channel claim template (soak-channel); wait for it (bounded).
+  echo "Applying DRA ComputeDomain (numNodes=$NODE_COUNT) for cross-node NCCL..."
+  sed -e "s/__NODE_COUNT__/${NODE_COUNT}/g" "$SCRIPT_DIR/dra/compute-domain.yaml" \
+    | kubectl apply -n "$NAMESPACE" -f -
+  echo "Waiting for the ComputeDomain channel claim template (soak-channel)..."
+  CHANNEL_READY=0
+  for _ in $(seq 1 30); do
+    if kubectl get resourceclaimtemplate soak-channel -n "$NAMESPACE" --request-timeout=10s >/dev/null 2>&1; then
+      CHANNEL_READY=1; break
+    fi
+    sleep 2
+  done
+  if [ "$CHANNEL_READY" != "1" ]; then
+    echo -e "${RED}ERROR: ComputeDomain channel template 'soak-channel' did not appear — is the NVIDIA DRA/ComputeDomain controller running?${NC}" >&2
+    exit 1
+  fi
+  PYTORCHJOB_TEMPLATE="$SCRIPT_DIR/templates/pytorchjob-dra.yaml"
+else
+  PYTORCHJOB_TEMPLATE="$SCRIPT_DIR/templates/pytorchjob.yaml"
+fi
+
 MANIFEST=$(sed \
   -e "s/__GPU_INSTANCE_TYPE__/${GPU_INSTANCE_TYPE}/g" \
   -e "s/__WORKER_REPLICAS__/${WORKER_REPLICAS}/g" \
   -e "s/__DURATION__/${DURATION}/g" \
   -e "s/__FILL_FRACTION__/${HBM_FILL_FRACTION}/g" \
   -e "s/__SLOTS__/${SLOTS}/g" \
+  -e "s/__NCCL_MNNVL_ENABLE__/${NCCL_MNNVL_ENABLE}/g" \
+  -e "s/__NCCL_NVLS_ENABLE__/${NCCL_NVLS_ENABLE}/g" \
   -e "s|__SOAK_IMAGE__|${SOAK_IMAGE}|g" \
-  "$SCRIPT_DIR/templates/pytorchjob.yaml")
+  "$PYTORCHJOB_TEMPLATE")
+
+# Single-node run (NODE_COUNT=1) has no workers. The Training Operator rejects
+# Worker.replicas=0, so render a master-only PyTorchJob by dropping the Worker
+# replica spec — it is the last block in the template, so cut from its line to EOF.
+if [ "$WORKER_REPLICAS" -lt 1 ]; then
+  MANIFEST=$(printf '%s\n' "$MANIFEST" | awk '/^    Worker:/{exit} {print}')
+fi
 
 echo "$MANIFEST" | kubectl apply -f -
 

--- a/k8s-training/gpu-soak-test/scripts/monitor.sh
+++ b/k8s-training/gpu-soak-test/scripts/monitor.sh
@@ -45,8 +45,12 @@ check_xid_on_node() {
   local node="$1" dbg="" waited=0 phase="" out=""
   # `grep -c` exits 1 when the count is zero, which would mark the debugger pod
   # Failed on a HEALTHY node — so append `|| true` to keep the container clean.
+  # Count only genuine HARDWARE Xids: match the "NVRM: Xid (...): <code>," format
+  # and exclude app/process-caused codes (13/31/43/45/68). Xid 45 in particular
+  # (channel/process kill) accumulates in a shared node's dmesg from ordinary pod
+  # churn by other workloads — counting it would fail an otherwise-clean soak.
   kubectl debug node/"$node" --image=ubuntu --profile=sysadmin -q \
-    -- chroot /host sh -c 'dmesg 2>/dev/null | grep -ic xid || true' >/dev/null 2>&1 || true
+    -- chroot /host sh -c 'dmesg 2>/dev/null | grep "NVRM: Xid" | grep -vcE "\): (13|31|43|45|68)," || true' >/dev/null 2>&1 || true
   while [ "$waited" -lt 30 ]; do
     dbg=$(kubectl get pods --request-timeout=30s -n default -o name 2>/dev/null | grep "node-debugger-${node}" | tail -1)
     [ -n "$dbg" ] && break

--- a/k8s-training/gpu-soak-test/scripts/monitor.sh
+++ b/k8s-training/gpu-soak-test/scripts/monitor.sh
@@ -23,7 +23,10 @@ MIN_UTIL="${MIN_UTIL:-80}"
 # joins) can't make the monitor poll forever. Defaults to the soak duration plus
 # a generous buffer for image pull, startup, and the end-of-run XID check.
 SOAK_MONITOR_TIMEOUT="${SOAK_MONITOR_TIMEOUT:-$(( ${SOAK_DURATION_SECONDS:-3600} + 1200 ))}"
-LOG_FILE="soak-monitor-$(date +%Y%m%d_%H%M%S).log"
+# Write the monitor log to the dir the parent runner reads from (SOAK_LOG_DIR),
+# not the caller's CWD — otherwise the report generator can't find it when the
+# runner is invoked from a different directory. Falls back to CWD if run standalone.
+LOG_FILE="${SOAK_LOG_DIR:-.}/soak-monitor-$(date +%Y%m%d_%H%M%S).log"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -42,15 +45,18 @@ warn() { echo -e "${YELLOW}[WARN]${NC} $*" | tee -a "$LOG_FILE"; }
 # for it to complete, read the count from its logs, then delete it.
 # Echoes an integer count, or "__FAILED__" if it could not run.
 check_xid_on_node() {
-  local node="$1" dbg="" waited=0 phase="" out=""
+  local node="$1" dbg="" waited=0 phase="" out="" since_epoch="${SOAK_START_EPOCH:-0}"
   # `grep -c` exits 1 when the count is zero, which would mark the debugger pod
   # Failed on a HEALTHY node — so append `|| true` to keep the container clean.
   # Count only genuine HARDWARE Xids: match the "NVRM: Xid (...): <code>," format
   # and exclude app/process-caused codes (13/31/43/45/68). Xid 45 in particular
   # (channel/process kill) accumulates in a shared node's dmesg from ordinary pod
   # churn by other workloads — counting it would fail an otherwise-clean soak.
+  # dmesg --since scopes the scan to THIS run so a pre-existing hardware Xid from
+  # before the soak isn't attributed to it (date computed host-side to match
+  # dmesg's host-local clock; since_epoch=0 falls back to the whole buffer).
   kubectl debug node/"$node" --image=ubuntu --profile=sysadmin -q \
-    -- chroot /host sh -c 'dmesg 2>/dev/null | grep "NVRM: Xid" | grep -vcE "\): (13|31|43|45|68)," || true' >/dev/null 2>&1 || true
+    -- chroot /host sh -c "dmesg --since \"\$(date -d @${since_epoch} '+%Y-%m-%d %H:%M:%S' 2>/dev/null)\" 2>/dev/null | grep 'NVRM: Xid' | grep -vcE '\): (13|31|43|45|68),' || true" >/dev/null 2>&1 || true
   while [ "$waited" -lt 30 ]; do
     dbg=$(kubectl get pods --request-timeout=30s -n default -o name 2>/dev/null | grep "node-debugger-${node}" | tail -1)
     [ -n "$dbg" ] && break
@@ -110,7 +116,7 @@ echo ""
 log "Waiting for workload steady state (first [soak] iter line)..."
 WARMUP=0
 while [ "$WARMUP" -lt 180 ]; do
-  if kubectl logs --request-timeout=30s -n "$NAMESPACE" -l "$MASTER_SELECTOR" 2>/dev/null | grep -qE '\[soak\] iter [0-9]+'; then
+  if kubectl logs --request-timeout=30s --tail=-1 -n "$NAMESPACE" -l "$MASTER_SELECTOR" 2>/dev/null | grep -qE '\[soak\] iter [0-9]+'; then
     log "Workload is running steadily — starting utilization monitoring"
     break
   fi
@@ -278,7 +284,9 @@ else
   pass "No XID errors"
 fi
 
-if [ "$LOW_UTIL_COUNT" -gt "5" ]; then
+# Threshold of 10 matches the README pass criteria and run-soak-test.sh's report
+# (they previously disagreed — monitor used 5). "Fewer than 10 low-util events" passes.
+if [ "$LOW_UTIL_COUNT" -ge "10" ]; then
   warn "$LOW_UTIL_COUNT low utilization events — GPUs may have throttled"
 else
   pass "GPU utilization stayed healthy throughout"

--- a/k8s-training/gpu-soak-test/templates/pytorchjob-dra.yaml
+++ b/k8s-training/gpu-soak-test/templates/pytorchjob-dra.yaml
@@ -1,0 +1,173 @@
+# =============================================================================
+# GPU Soak Test — PyTorchJob (DRA / GB300 variant)
+#
+# Identical to templates/pytorchjob.yaml EXCEPT how GPUs are requested:
+#   - device-plugin (x86):  resources.limits."nvidia.com/gpu": __SLOTS__
+#   - DRA (this file):      pod resourceClaims + container resources.claims
+#
+# Used ONLY on DRA clusters (Grace/GB300); run-soak-test.sh auto-selects it.
+# The referenced claim (soak-gpus) is created from
+# dra/gpu-resourceclaim-template.yaml in the same namespace before this applies.
+#
+# Placeholders patched by run-soak-test.sh (same set as the x86 template):
+#   __GPU_INSTANCE_TYPE__  node.kubernetes.io/instance-type value
+#   __WORKER_REPLICAS__    number of Worker pods (total nodes - 1)
+#   __DURATION__           soak duration in seconds
+#   __FILL_FRACTION__      HBM fill fraction (0-1)
+#   __SLOTS__              GPUs per node (nproc_per_node)
+#   __SOAK_IMAGE__         container image (must match GPU arch + CPU arch)
+# =============================================================================
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: gpu-soak-test
+  namespace: gpu-soak
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: Never
+      template:
+        metadata:
+          labels:
+            app: gpu-soak
+        spec:
+          nodeSelector:
+            node.kubernetes.io/instance-type: __GPU_INSTANCE_TYPE__
+          tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          # DRA: claim GPUs via ResourceClaimTemplate instead of nvidia.com/gpu limits.
+          resourceClaims:
+          - name: gpus
+            resourceClaimTemplateName: soak-gpus
+          - name: compute-domain-channel
+            resourceClaimTemplateName: soak-channel
+          containers:
+          - name: pytorch          # PyTorchJob REQUIRES this container name
+            image: __SOAK_IMAGE__
+            command: ["/bin/sh", "-c"]
+            args:
+            - |
+              set -e
+              echo "Node rank ${RANK}/${WORLD_SIZE}  master=${MASTER_ADDR}:${MASTER_PORT}"
+              torchrun \
+                --nnodes="${WORLD_SIZE}" \
+                --node_rank="${RANK}" \
+                --nproc_per_node="${NPROC_PER_NODE}" \
+                --master_addr="${MASTER_ADDR}" \
+                --master_port="${MASTER_PORT}" \
+                /workspace/soak.py
+            env:
+            - name: NPROC_PER_NODE
+              value: "__SLOTS__"
+            - name: SOAK_DURATION_SECONDS
+              value: "__DURATION__"
+            - name: HBM_FILL_FRACTION
+              value: "__FILL_FRACTION__"
+            - name: NCCL_DEBUG
+              value: "WARN"
+            - name: NCCL_IB_GID_INDEX
+              value: "3"
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0"
+            # Cross-node transport, set by run-soak-test.sh from SOAK_TRANSPORT:
+            #   auto (default) -> MNNVL/NVLS over NVLink (highest bandwidth)
+            #   ib             -> disable MNNVL+NVLS so NCCL uses InfiniBand cross-node
+            - name: NCCL_MNNVL_ENABLE
+              value: "__NCCL_MNNVL_ENABLE__"
+            - name: NCCL_NVLS_ENABLE
+              value: "__NCCL_NVLS_ENABLE__"
+            resources:
+              claims:
+              - name: gpus
+              - name: compute-domain-channel
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - name: soak-script
+              mountPath: /workspace
+            - name: shm
+              mountPath: /dev/shm
+          volumes:
+          - name: soak-script
+            configMap:
+              name: soak-script
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 64Gi
+    Worker:
+      replicas: __WORKER_REPLICAS__
+      restartPolicy: Never
+      template:
+        metadata:
+          labels:
+            app: gpu-soak
+        spec:
+          nodeSelector:
+            node.kubernetes.io/instance-type: __GPU_INSTANCE_TYPE__
+          tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          resourceClaims:
+          - name: gpus
+            resourceClaimTemplateName: soak-gpus
+          - name: compute-domain-channel
+            resourceClaimTemplateName: soak-channel
+          containers:
+          - name: pytorch
+            image: __SOAK_IMAGE__
+            command: ["/bin/sh", "-c"]
+            args:
+            - |
+              set -e
+              echo "Node rank ${RANK}/${WORLD_SIZE}  master=${MASTER_ADDR}:${MASTER_PORT}"
+              torchrun \
+                --nnodes="${WORLD_SIZE}" \
+                --node_rank="${RANK}" \
+                --nproc_per_node="${NPROC_PER_NODE}" \
+                --master_addr="${MASTER_ADDR}" \
+                --master_port="${MASTER_PORT}" \
+                /workspace/soak.py
+            env:
+            - name: NPROC_PER_NODE
+              value: "__SLOTS__"
+            - name: SOAK_DURATION_SECONDS
+              value: "__DURATION__"
+            - name: HBM_FILL_FRACTION
+              value: "__FILL_FRACTION__"
+            - name: NCCL_DEBUG
+              value: "WARN"
+            - name: NCCL_IB_GID_INDEX
+              value: "3"
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0"
+            # Cross-node transport, set by run-soak-test.sh from SOAK_TRANSPORT:
+            #   auto (default) -> MNNVL/NVLS over NVLink (highest bandwidth)
+            #   ib             -> disable MNNVL+NVLS so NCCL uses InfiniBand cross-node
+            - name: NCCL_MNNVL_ENABLE
+              value: "__NCCL_MNNVL_ENABLE__"
+            - name: NCCL_NVLS_ENABLE
+              value: "__NCCL_NVLS_ENABLE__"
+            resources:
+              claims:
+              - name: gpus
+              - name: compute-domain-channel
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - name: soak-script
+              mountPath: /workspace
+            - name: shm
+              mountPath: /dev/shm
+          volumes:
+          - name: soak-script
+            configMap:
+              name: soak-script
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 64Gi


### PR DESCRIPTION
Adds GB300 (Grace/ARM, DRA-native) support to gpu-soak-test. The x86 device-plugin path is unchanged — all GB300 behavior is behind runtime auto-detection.

## What's new
- Auto-detects device-plugin vs DRA (`gpu.nvidia.com` DeviceClass); picks the GPU request mechanism and GPUs/node accordingly.
- DRA manifests: `dra/gpu-resourceclaim-template.yaml`, `dra/compute-domain.yaml`, `templates/pytorchjob-dra.yaml` (claims instead of `nvidia.com/gpu` limits).
- ComputeDomain establishes the MNNVL channel so cross-node NCCL works on GB300 (avoids the `Cuda 801` NVLS failure).
- `SOAK_TRANSPORT=ib` opt-in forces NCCL over InfiniBand (default = MNNVL/NVLink).
- Single-node (master-only) rendering; XID counting fixed to hardware Xids only.

## Validated on 2-node GB300 (DRA)
| Config | Transport | busbw | Result |
|---|---|---|---|
| single-node | NVLink | 556 GB/s | PASS |
| 2-node default | MNNVL/NVLink | 599 GB/s | PASS |
| 2-node SOAK_TRANSPORT=ib | InfiniBand GDR (4 rails) | 246 GB/s | PASS |

All 0 hardware XID, 100% util, ~75% HBM, 74°C peak.
