### PR TITLE
nccl-runner: GB300 / DRA support (auto-detected, x86 unchanged)

### DIFF
--- a/k8s-training/k8s-runner-unified/.gitignore
+++ b/k8s-training/k8s-runner-unified/.gitignore
@@ -1,0 +1,3 @@
+# Per-run outputs — raw NCCL logs + generated report. They embed node names and
+# cluster-specific device/topology details, so they are not committed.
+results/

--- a/k8s-training/k8s-runner-unified/README.md
+++ b/k8s-training/k8s-runner-unified/README.md
@@ -11,7 +11,10 @@ runs `all_reduce` + `alltoall` over both NVLink (single-node) and InfiniBand
 | File | Role |
 |---|---|
 | `nccl_runner_unified.sh` | Orchestrator — detects hardware, renders + runs jobs, retries, reports |
-| `nccl-test-template.yaml` | Parameterized Kubeflow MPIJob (envsubst `${VAR}` placeholders) |
+| `nccl-test-template.yaml` | Parameterized Kubeflow MPIJob, x86/device-plugin (`nvidia.com/gpu` limits) |
+| `nccl-test-template-dra.yaml` | Same MPIJob for DRA/GB300 (GPU claims + ComputeDomain channel) |
+| `dra/gpu-resourceclaim-template.yaml` | DRA GPU claim for worker pods (GB300) |
+| `dra/compute-domain.yaml` | ComputeDomain enabling cross-node NCCL over MNNVL (GB300) |
 | `generate-report.sh` | Parses raw logs → `report.md` (auto-invoked by the runner) |
 
 ## What it auto-detects (so you don't hardcode it)
@@ -32,6 +35,11 @@ runs `all_reduce` + `alltoall` over both NVLink (single-node) and InfiniBand
 5. **Host-count cap** — requested host counts are capped to the number of
    **Ready, schedulable** nodes in the node group (Cordoned / NotReady nodes are
    excluded), so the sweep never hangs on unschedulable jobs.
+6. **GPU request mechanism** — device-plugin (`nvidia.com/gpu` limits, x86) vs
+   **DRA** (`gpu.nvidia.com` DeviceClass, GB300/Grace). On DRA there is no
+   allocatable `nvidia.com/gpu`, so the runner switches to the `-dra` MPIJob
+   template (GPU claims), reads GPUs/node from the GFD label / resourceslices, and
+   creates a ComputeDomain for cross-node NCCL. The x86 path is unchanged.
 
 Every run creates **uniquely-named, labelled resources** (`nccl-test-<pid>-<epoch>`,
 labelled `nccl-runner/run=<id>`), so two engineers can run against the same
@@ -69,17 +77,43 @@ Regenerate a report from existing logs at any time:
 > MPIJob and cascaded gracefully — the runner never force-deletes pods or touches
 > pods it doesn't own.
 
-## Configuration (top of `nccl_runner_unified.sh`)
+## GB300 / DRA clusters — automatic
+
+On DRA-native clusters (GB300/Grace) the runner needs **no code changes and no flags**
+— it detects DRA and adapts. The `IMAGE` is multi-arch, so the same tag runs on x86
+and arm64. What changes automatically:
+
+- Worker pods claim GPUs via `dra/gpu-resourceclaim-template.yaml` + the `-dra` MPIJob
+  template, instead of `nvidia.com/gpu` limits.
+- A **ComputeDomain** (`dra/compute-domain.yaml`, sized to the largest host count) is
+  created so cross-node NCCL forms one MNNVL/NVLink domain — without it NCCL's NVLS
+  setup fails with `Cuda failure 801`. It's torn down when the runner exits.
+- The report reads the **actual** transport from the NCCL logs (MNNVL vs IB).
+
+By default the cross-node collective rides **MNNVL/NVLink** (fastest on GB300). To
+soak the **InfiniBand** fabric instead, set `NCCL_TRANSPORT=ib` (disables MNNVL+NVLS):
+
+```bash
+NODE_GROUP_ID=<gb300-group> NCCL_TRANSPORT=ib ./nccl_runner_unified.sh
+```
+
+Validated on a 2-node GB300 DRA cluster: all_reduce + alltoall, 1 and 2 hosts, auto
+and `ib` transport — all passed (2-host all_reduce peak ~843 GB/s over MNNVL, 0 errors).
+
+## Configuration
+
+Top-of-script vars (several are also environment-overridable, so you don't edit the file):
 
 | Var | Default | Meaning |
 |---|---|---|
 | `NAMESPACE` | `nccl-tests` | Namespace to run in |
-| `IMAGE` | Nebius `nccl-tests` image | Must be pullable on the cluster |
-| `NODE_GROUP_ID` | — | **Set per cluster** |
+| `IMAGE` | Nebius `nccl-tests` image (multi-arch) | Must be pullable on the cluster |
+| `NODE_GROUP_ID` | (placeholder) | **Set per cluster** — env-overridable |
+| `NCCL_TRANSPORT` | `auto` | DRA/GB300 only: `auto` (MNNVL/NVLink) or `ib` (InfiniBand) |
 | `RESERVE_CPU_CORES` / `RESERVE_MEM_GI` | `4` / `50` | Headroom left for kubelet/daemonsets |
 | `MAX_LAUNCH_ATTEMPTS` | `6` | Retry budget for the transient launcher glitch |
-| `HOSTS` | `(1 2 3 4)` | Host counts to sweep. Auto-capped **down** to available Ready nodes, but never scales **up** past the values listed — on clusters larger than 4 nodes, edit this to test at full scale (e.g. `(1 2 4 8 16)` for a 16-node group). |
-| `TESTS` | `(all_reduce alltoall)` | Add `all_gather reduce_scatter reduce gather broadcast scatter` for a fuller sweep |
+| `HOSTS` (`NCCL_HOSTS`) | `1 2 3 4` | Host counts to sweep. Auto-capped **down** to available Ready nodes, but never scales **up** past the values listed — on clusters larger than 4 nodes, set higher counts to test at full scale (e.g. `NCCL_HOSTS="1 2 4 8 16"`). |
+| `TESTS` (`NCCL_TESTS`) | `all_reduce alltoall` | Add `all_gather reduce_scatter reduce gather broadcast scatter` for a fuller sweep |
 
 ## Scope & caveats
 
@@ -92,9 +126,10 @@ Regenerate a report from existing logs at any time:
     two give a clean scaling curve, and `100` measures the full cluster. Leaving
     the default `(1 2 3 4)` would test only 4 of your 100 nodes and tell you
     nothing about the fabric at scale.
-- **Supported as-is:** Nebius **x86 + InfiniBand** GPU types — H100, H200, B200, B300.
-- **Not supported as-is:** Grace-ARM types (GH200 / GB200) — aarch64, so the x86
-  image won't run and the binding math should be re-validated.
+- **Supported as-is:** Nebius **x86 + InfiniBand** GPU types (H100, H200, B200, B300)
+  and **GB300 / DRA** clusters (Grace-ARM, auto-detected — see above).
+- **Not validated:** GH200 / GB200 (aarch64) — the multi-arch image should run, but the
+  binding math and DRA path haven't been exercised there.
 - Assumes an **InfiniBand** fabric (RoCE/Ethernet clusters return no IB devices and
   the runner errors out) and the Nebius `nebius.com/node-group-id` label.
 - `busbw` (bus bandwidth) is the figure to compare against reference numbers.

--- a/k8s-training/k8s-runner-unified/dra/compute-domain.yaml
+++ b/k8s-training/k8s-runner-unified/dra/compute-domain.yaml
@@ -1,0 +1,31 @@
+# =============================================================================
+# GB300 / DRA ComputeDomain for cross-node NCCL.
+#
+# On DRA-native GB300 clusters, cross-node collectives ride MNNVL (multi-node
+# NVLink). Without a ComputeDomain the nodes aren't in a shared NVLink clique,
+# so NCCL's NVLS/MNNVL setup fails with "Cuda failure 801 'operation not
+# supported'" (transport/nvls.cc). The ComputeDomain establishes the IMEX
+# channel that lets the worker pods form one NVLink domain.
+#
+# The NVIDIA controller AUTO-CREATES the channel ResourceClaimTemplate named
+# below (nccl-channel) — do not hand-write it. Workers claim it via
+# nccl-test-template-dra.yaml. Sized to the LARGEST host count in the run so a
+# single ComputeDomain covers every 1..N-host iteration.
+#
+# Created on every DRA run regardless of NCCL_TRANSPORT: with =ib the workers
+# still claim the (now unused) channel and NCCL simply routes over InfiniBand,
+# which keeps the worker template unconditional. Harmless when unused.
+#
+# Placeholder patched by nccl_runner_unified.sh (envsubst):
+#   ${MAX_HOSTS}   largest host count in the run (= ComputeDomain size)
+# =============================================================================
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: nccl-cd
+  namespace: ${NAMESPACE}
+spec:
+  numNodes: ${MAX_HOSTS}
+  channel:
+    resourceClaimTemplate:
+      name: nccl-channel

--- a/k8s-training/k8s-runner-unified/dra/gpu-resourceclaim-template.yaml
+++ b/k8s-training/k8s-runner-unified/dra/gpu-resourceclaim-template.yaml
@@ -1,0 +1,28 @@
+# =============================================================================
+# GB300 / DRA GPU claim for the nccl-test worker pods.
+#
+# Applied ONLY on DRA clusters (Grace/GB300), which advertise GPUs via Dynamic
+# Resource Allocation instead of the nvidia.com/gpu device plugin. x86
+# device-plugin clusters never reach this file — nccl_runner_unified.sh
+# auto-detects the mode and uses nccl-test-template.yaml (limits.nvidia.com/gpu).
+#
+# Scoped to the nccl-tests namespace, so it is removed when the namespace is.
+# Only the MPIJob Worker pods claim GPUs; the Launcher runs mpirun and needs none.
+#
+# Placeholder patched by nccl_runner_unified.sh (envsubst):
+#   ${GPUS_PER_NODE}   GPUs to claim per worker (auto-detected)
+# =============================================================================
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: nccl-gpus
+  namespace: ${NAMESPACE}
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpus
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: ${GPUS_PER_NODE}

--- a/k8s-training/k8s-runner-unified/generate-report.sh
+++ b/k8s-training/k8s-runner-unified/generate-report.sh
@@ -42,7 +42,9 @@ fi
   echo ""
   echo "> \`busbw\` (bus bandwidth) is the hardware-utilization figure to compare against"
   echo "> reference numbers. Single-host runs exercise intra-node NVLink; multi-host runs"
-  echo "> cross the InfiniBand fabric. Peak is the max across the size sweep (some collectives"
+  echo "> cross the node-to-node fabric — InfiniBand on x86, or MNNVL/NVLink on GB300"
+  echo "> (unless NCCL_TRANSPORT=ib). The Transport column reports what NCCL actually used."
+  echo "> Peak is the max across the size sweep (some collectives"
   echo "> — notably alltoall — peak mid-sweep and decline, so the last row is not the peak)."
   echo ""
 
@@ -56,7 +58,15 @@ fi
     hosts="${base##*-}"
     test="${base%-*}"
     if [ "$hosts" -gt 1 ] 2>/dev/null; then scope="cross-node"; else scope="single-node"; fi
-    if grep -q "Using network IB" "$f" 2>/dev/null; then
+    # Transport = what NCCL ACTUALLY routed over, read from the channel lines, not
+    # inferred from host count. On GB300 a multi-host run rides MNNVL (multi-node
+    # NVLink) unless NCCL_TRANSPORT=ib forced it onto the IB fabric, so host count
+    # alone is misleading. Order matters: an explicit IB data path wins.
+    if grep -qE "via NET/IB" "$f" 2>/dev/null; then
+      transport="InfiniBand"
+    elif grep -qE "via P2P/MNNVL" "$f" 2>/dev/null; then
+      transport="NVLink (MNNVL)"
+    elif grep -q "Using network IB" "$f" 2>/dev/null; then
       transport=$([ "$hosts" -gt 1 ] 2>/dev/null && echo "InfiniBand" || echo "NVLink (IB init'd)")
     else
       transport="?"

--- a/k8s-training/k8s-runner-unified/nccl-test-template-dra.yaml
+++ b/k8s-training/k8s-runner-unified/nccl-test-template-dra.yaml
@@ -1,0 +1,117 @@
+# =============================================================================
+# NCCL test — MPIJob (DRA / GB300 variant)
+#
+# Identical to nccl-test-template.yaml (same unique-name + label scheme) EXCEPT
+# how the Worker pods request GPUs:
+#   - device-plugin (x86):  resources.requests/limits."nvidia.com/gpu"
+#   - DRA (this file):      pod resourceClaims + container resources.claims
+#
+# Used ONLY on DRA clusters (Grace/GB300); nccl_runner_unified.sh auto-selects it.
+# The claim templates it references are created first, in the same namespace:
+#   nccl-gpus     from dra/gpu-resourceclaim-template.yaml
+#   nccl-channel  auto-created by the NVIDIA ComputeDomain controller (dra/compute-domain.yaml)
+#
+# The Launcher only runs mpirun (no GPUs), so it matches the x86 template. Two extra
+# mpirun -x flags carry the cross-node transport choice to the ranks:
+#   NCCL_MNNVL_ENABLE / NCCL_NVLS_ENABLE  (auto -> 1/1 = NVLink; ib -> 0/0 = InfiniBand)
+# =============================================================================
+apiVersion: kubeflow.org/${MPIJOB_API_VERSION}
+kind: MPIJob
+metadata:
+  name: ${JOB_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    nccl-runner/run: "${RUN_SUFFIX}"
+    nccl-runner/owner: "${RUN_OWNER}"
+spec:
+  slotsPerWorker: ${GPUS_PER_NODE}
+  ${LAUNCHER_CREATION_POLICY_LINE}
+  runPolicy:
+    cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            nccl-runner/run: "${RUN_SUFFIX}"
+            nccl-runner/role: launcher
+        spec:
+          containers:
+            - image: ${IMAGE}
+              name: nccl-test
+              env:
+                - name: OMPI_ALLOW_RUN_AS_ROOT
+                  value: "1"
+                - name: OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
+                  value: "1"
+              command: ["/bin/bash", "-c"]
+              args:
+                - >
+                  mpirun
+                  -bind-to ${BIND_TO}
+                  --map-by ${MAP_BY_SPEC}
+                  -x NCCL_SOCKET_IFNAME=eth0
+                  -x UCX_NET_DEVICES=${UCX_NET_DEVICE}
+                  -x OMPI_MCA_coll_hcoll_enable=0
+                  -x OMPI_MCA_coll_ucc_enable=0
+                  -x NCCL_DEBUG=INFO
+                  -x NCCL_IB_HCA=${NCCL_IB_HCA}
+                  -x NCCL_MNNVL_ENABLE=${NCCL_MNNVL_ENABLE}
+                  -x NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE}
+                  -x UCX_DC_MLX5_TX_POLICY=hw_dcs
+                  /opt/nccl_tests/build/${TEST_BINARY}_perf -b 8 -e 64G -f 2 -g 1 -t 1
+              resources:
+                requests:
+                  cpu: 1
+                  memory: 128Mi
+    Worker:
+      replicas: ${WORKER_REPLICAS}
+      template:
+        metadata:
+          labels:
+            nccl-runner/run: "${RUN_SUFFIX}"
+            nccl-runner/role: worker
+        spec:
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nebius.com/node-group-id
+                        operator: In
+                        values:
+                          - ${NODE_GROUP_ID}
+          # DRA: claim GPUs (and the ComputeDomain channel for cross-node NCCL)
+          # instead of requesting nvidia.com/gpu from the device plugin.
+          resourceClaims:
+            - name: gpus
+              resourceClaimTemplateName: nccl-gpus
+            - name: compute-domain-channel
+              resourceClaimTemplateName: nccl-channel
+          containers:
+            - image: ${IMAGE}
+              name: nccl-test
+              securityContext:
+                privileged: true
+              resources:
+                claims:
+                  - name: gpus
+                  - name: compute-domain-channel
+                requests:
+                  cpu: "${WORKER_CPU}"
+                  memory: ${WORKER_MEMORY}
+                limits:
+                  cpu: "${WORKER_CPU_LIMIT}"
+                  memory: ${WORKER_MEMORY}
+              volumeMounts:
+                - mountPath: /dev/shm
+                  name: dshm
+          volumes:
+            - name: dshm
+              emptyDir:
+                medium: Memory

--- a/k8s-training/k8s-runner-unified/nccl_runner_unified.sh
+++ b/k8s-training/k8s-runner-unified/nccl_runner_unified.sh
@@ -45,6 +45,12 @@ cleanup() {
   kubectl delete mpijob "$JOB_NAME" -n "$NAMESPACE" \
     --ignore-not-found --cascade=foreground --wait=false >/dev/null 2>&1 || true
   kubectl delete pod ib-discovery -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1 || true
+  # On DRA/GB300, also tear down the ComputeDomain + GPU claim template this run
+  # created, so no cross-node NVLink domain lingers. GPU_MODE is read at exit time.
+  if [ "${GPU_MODE:-}" = "dra" ]; then
+    kubectl delete computedomain nccl-cd -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1 || true
+    kubectl delete resourceclaimtemplate nccl-gpus -n "$NAMESPACE" --ignore-not-found >/dev/null 2>&1 || true
+  fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT
@@ -52,12 +58,19 @@ trap 'exit 143' TERM
 
 # ============ CONFIGURE FOR YOUR CLUSTER ============
 NAMESPACE=nccl-tests
-TEMPLATE=nccl-test-template.yaml
+TEMPLATE=nccl-test-template.yaml          # x86/device-plugin; DRA path swaps to the -dra variant
+TEMPLATE_DRA=nccl-test-template-dra.yaml  # GB300/DRA (GPU claims instead of nvidia.com/gpu limits)
+# The image is multi-arch (amd64 + arm64/Grace), so the same tag runs on x86 and GB300.
 IMAGE="cr.eu-north1.nebius.cloud/e00b94r7bkvywphmn6/nccl-tests:v2.18.3-cudav13.2.1-ncclv2.30.4-1-hpcxv2.26"
 
-# GPU node group ID — SET THIS for your cluster. Get it via:
+# GPU node group ID — SET THIS for your cluster (env-overridable). Get it via:
 #   kubectl get nodes -o custom-columns='NAME:.metadata.name,GROUP:.metadata.labels.nebius\.com/node-group-id,GPU:.status.capacity.nvidia\.com/gpu'
-NODE_GROUP_ID="<your-node-group-id>"   # e.g. mk8snodegroup-xxxxxxxxxxxxxxxxxx
+NODE_GROUP_ID="${NODE_GROUP_ID:-<your-node-group-id>}"   # e.g. mk8snodegroup-xxxxxxxxxxxxxxxxxx
+
+# Cross-node transport on DRA/GB300 only (ignored on device-plugin/x86). On GB300 the
+# nodes fuse into one MNNVL (multi-node NVLink) domain, so cross-node NCCL defaults to
+# NVLink. Set NCCL_TRANSPORT=ib to disable MNNVL/NVLS and measure the InfiniBand fabric.
+NCCL_TRANSPORT="${NCCL_TRANSPORT:-auto}"
 
 # Worker resource sizing — auto-detected below from actual node capacity.
 # RESERVE values are headroom left for kubelet, device plugins, DaemonSets, etc.
@@ -70,12 +83,15 @@ RESERVE_MEM_GI=50
 # fast (launcher crash-loops within ~1 min), so we just relaunch a few times.
 MAX_LAUNCH_ATTEMPTS=6
 
-HOSTS=(1 2 3 4)
+# Host counts to sweep, and which collectives to run. Both overridable from the
+# environment (space-separated) for a quick single run, e.g.:
+#   NCCL_HOSTS="1 2" NCCL_TESTS="all_reduce" ./nccl_runner_unified.sh
+HOSTS=(${NCCL_HOSTS:-1 2 3 4})
 # The two tests that actually matter for validating a cluster: all_reduce
 # (canonical bus-bandwidth number) and alltoall (stresses the fabric hardest).
 # The other NCCL collectives are nice-to-haves — add them here if you want a
 # fuller sweep: all_gather reduce_scatter reduce gather broadcast scatter
-TESTS=(all_reduce alltoall)
+TESTS=(${NCCL_TESTS:-all_reduce alltoall})
 # ======================================================
 
 if [ -z "$NODE_GROUP_ID" ] || [[ "$NODE_GROUP_ID" == "<"* ]]; then
@@ -121,11 +137,41 @@ HOSTS=("${CAPPED_HOSTS[@]}")
 
 ALLOC_CPU_RAW=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.cpu}')
 ALLOC_MEM_RAW=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.memory}')
+# GPU request mechanism: device-plugin (nvidia.com/gpu) vs DRA (gpu.nvidia.com
+# DeviceClass, GB300/Grace). DRA nodes advertise NO allocatable nvidia.com/gpu, so
+# detect that and switch to claims + the DRA template. The x86 path is unchanged.
 GPUS_PER_NODE=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}')
-if [ -z "$GPUS_PER_NODE" ] || [ "$GPUS_PER_NODE" -le 0 ] 2>/dev/null; then
-  echo "ERROR: node '$NODE_NAME' reports no allocatable nvidia.com/gpu — is this a GPU node group?"
+if [ -n "$GPUS_PER_NODE" ] && [ "$GPUS_PER_NODE" -gt 0 ] 2>/dev/null; then
+  GPU_MODE="device-plugin"
+elif kubectl get deviceclass gpu.nvidia.com >/dev/null 2>&1; then
+  GPU_MODE="dra"
+  TEMPLATE="$TEMPLATE_DRA"
+  # DRA advertises no allocatable nvidia.com/gpu; take GPUs/node from the GFD
+  # label, falling back to counting this node's gpu.nvidia.com devices in the
+  # published resourceslices (portable awk, no jq / grep -P).
+  GPUS_PER_NODE=$(kubectl get node "$NODE_NAME" -o jsonpath='{.metadata.labels.nvidia\.com/gpu\.count}' 2>/dev/null)
+  if [ -z "$GPUS_PER_NODE" ] || [ "$GPUS_PER_NODE" -le 0 ] 2>/dev/null; then
+    GPUS_PER_NODE=$(kubectl get resourceslices \
+      -o jsonpath='{range .items[*]}{.spec.driver}{"\t"}{range .spec.devices[*]}{.name}{","}{end}{"\n"}{end}' 2>/dev/null \
+      | awk -F'\t' '$1=="gpu.nvidia.com" && !seen {n=gsub(/,/,",",$2); if(n>0){print n; seen=1}}')
+  fi
+else
+  echo "ERROR: node '$NODE_NAME' reports no allocatable nvidia.com/gpu and no gpu.nvidia.com"
+  echo "DeviceClass — is this a GPU node group? (device-plugin and DRA both absent)"
   exit 1
 fi
+if [ -z "$GPUS_PER_NODE" ] || [ "$GPUS_PER_NODE" -le 0 ] 2>/dev/null; then
+  echo "ERROR: could not determine GPUs/node on '$NODE_NAME' (mode=$GPU_MODE)."
+  exit 1
+fi
+
+# Transport knob only applies on DRA; map it to the NCCL env the DRA template carries.
+if [ "$GPU_MODE" = "dra" ] && [ "$NCCL_TRANSPORT" = "ib" ]; then
+  NCCL_MNNVL_ENABLE=0; NCCL_NVLS_ENABLE=0
+else
+  NCCL_MNNVL_ENABLE=1; NCCL_NVLS_ENABLE=1
+fi
+echo "GPU mode: $GPU_MODE$([ "$GPU_MODE" = dra ] && echo " (transport: $NCCL_TRANSPORT -> $([ "$NCCL_TRANSPORT" = ib ] && echo InfiniBand || echo MNNVL/NVLink))")"
 
 # CPU may be reported as whole cores ("128") or millicores ("127900m") — normalize to millicores.
 if [[ "$ALLOC_CPU_RAW" == *m ]]; then
@@ -306,6 +352,34 @@ watch_job() {
   echo TIMEOUT
 }
 
+# On DRA/GB300, create the GPU claim template and a ComputeDomain once, up front.
+# The ComputeDomain is sized to the LARGEST host count in this run so a single
+# domain covers every 1..N-host iteration; its controller auto-creates the channel
+# claim template (nccl-channel) the worker pods attach to for cross-node NCCL. Both
+# live in $NAMESPACE and are torn down by cleanup() on exit.
+if [ "$GPU_MODE" = "dra" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  MAX_HOSTS=0; for h in "${HOSTS[@]}"; do [ "$h" -gt "$MAX_HOSTS" ] && MAX_HOSTS="$h"; done
+  echo "=== DRA: applying GPU claim template + ComputeDomain (numNodes=$MAX_HOSTS) ==="
+  NAMESPACE="$NAMESPACE" GPUS_PER_NODE="$GPUS_PER_NODE" \
+    envsubst < "$SCRIPT_DIR/dra/gpu-resourceclaim-template.yaml" | kubectl apply -f - >/dev/null
+  NAMESPACE="$NAMESPACE" MAX_HOSTS="$MAX_HOSTS" \
+    envsubst < "$SCRIPT_DIR/dra/compute-domain.yaml" | kubectl apply -f - >/dev/null
+  echo "Waiting for the ComputeDomain channel template (nccl-channel)..."
+  CH_OK=0
+  for _ in $(seq 1 30); do
+    if kubectl get resourceclaimtemplate nccl-channel -n "$NAMESPACE" --request-timeout=10s >/dev/null 2>&1; then
+      CH_OK=1; break
+    fi
+    sleep 2
+  done
+  if [ "$CH_OK" -ne 1 ]; then
+    echo "ERROR: ComputeDomain channel template (nccl-channel) never appeared."
+    echo "Is the NVIDIA DRA / ComputeDomain controller running on this cluster?"
+    exit 1
+  fi
+fi
+
 OUTPUT_PATH=results/nccl-$(date +"%Y-%m-%d_%H-%M-%S")
 mkdir -p "$OUTPUT_PATH"
 
@@ -343,6 +417,8 @@ for HOST_NUM in "${HOSTS[@]}"; do
     TEST_BINARY="$TEST" \
     MPIJOB_API_VERSION="$MPIJOB_API_VERSION" \
     LAUNCHER_CREATION_POLICY_LINE="$LAUNCHER_CREATION_POLICY_LINE" \
+    NCCL_MNNVL_ENABLE="${NCCL_MNNVL_ENABLE:-1}" \
+    NCCL_NVLS_ENABLE="${NCCL_NVLS_ENABLE:-1}" \
     envsubst < "$TEMPLATE" > "$RENDERED"
 
     # Launch, retrying on the transient launcher hwloc glitch (see MAX_LAUNCH_ATTEMPTS).


### PR DESCRIPTION
Adds GB300 (Grace/ARM, DRA-native) support to the unified NCCL runner. The x86 device-plugin path is unchanged — `nccl-test-template.yaml` is untouched and all GB300 behavior is behind runtime auto-detection.

## What's new
- **Auto-detects device-plugin vs DRA** (`gpu.nvidia.com` DeviceClass). On DRA there is no allocatable `nvidia.com/gpu`, so the runner reads GPUs/node from the GFD label / resourceslices and renders the `-dra` MPIJob template (worker `resourceClaims` instead of `nvidia.com/gpu` limits).
- **ComputeDomain** (`dra/compute-domain.yaml`, sized to the largest host count) so cross-node NCCL forms one MNNVL/NVLink domain — without it NCCL's NVLS setup fails with `Cuda failure 801`. Torn down on exit.
- **`NCCL_TRANSPORT` knob** (DRA only): `auto` (MNNVL/NVLink, default) or `ib` (disable MNNVL+NVLS → InfiniBand). The image is multi-arch, so the same tag runs on x86 and arm64.
- **Report fix**: `generate-report.sh` now reads the *actual* transport from the NCCL logs (`via NET/IB` vs `via P2P/MNNVL`) instead of inferring it from host count. x86 output is preserved.
- `NODE_GROUP_ID` / `HOSTS` / `TESTS` are now environment-overridable; `results/` is gitignored (raw logs embed node names).

## Validated on 2-node GB300 (DRA)
| Test | Hosts | Transport | Peak busbw | Errors |
|---|---|---|---|---|
| all_reduce | 1 | NVLink (MNNVL) | 693.8 GB/s | none |
| all_reduce | 2 | NVLink (MNNVL) | 843.3 GB/s | none |
| alltoall | 1 | NVLink (MNNVL) | 629.1 GB/s | none |
| alltoall | 2 | NVLink (MNNVL) | 688.5 GB/s | none |
| all_reduce | 2 | InfiniBand (`NCCL_TRANSPORT=ib`) | 381.5 GB/s | none |

mpi-operator v2beta1 honors the DRA worker `resourceClaims` (verified: worker pods schedule with all 4 GB300 GPUs).
