### PR TITLE
Add us-north1 support to k8s-training

### DIFF
--- a/k8s-training/locals.tf
+++ b/k8s-training/locals.tf
@@ -57,6 +57,12 @@ locals {
       gpu_nodes_platform = "gpu-b300-sxm"
       gpu_nodes_preset   = "8gpu-192vcpu-2768gb"
     }
+    us-north1 = {
+      cpu_nodes_platform = "cpu-d3"
+      cpu_nodes_preset   = "16vcpu-64gb"
+      gpu_nodes_platform = "gpu-b300-sxm"
+      gpu_nodes_preset   = "8gpu-192vcpu-2768gb"
+    }
   }
 
   current_region_defaults = local.regions_default[var.region]

--- a/k8s-training/terraform.tfvars
+++ b/k8s-training/terraform.tfvars
@@ -37,6 +37,7 @@ cpu_nodes_preset   = "4vcpu-16gb" # CPU nodes preset
 gpu_nodes_platform = "gpu-h200-sxm"        # GPU nodes platform: gpu-h100-sxm, gpu-h200-sxm, gpu-b200-sxm
 gpu_nodes_preset   = "8gpu-128vcpu-1600gb" # GPU nodes preset: 8gpu-128vcpu-1600gb, 8gpu-128vcpu-1600gb, 8gpu-160vcpu-1792gb
 # Infiniband fabrics: https://docs.nebius.com/compute/clusters/gpu#fabrics
+# New B300 region fabrics: eu-west2-a (eu-west2), us-north1-a (us-north1).
 infiniband_fabric = "" # Leave empty to disable GPU clustering for RTX6000 deployments or single-node deployments.
 
 # Node-group rollout strategy. GB300 requires max_surge to be zero and the


### PR DESCRIPTION
## Summary

- add `us-north1` defaults for CPU-D3 and B300 training nodes

## Validation

- `terraform fmt -check -recursive k8s-training`
- `terraform validate`
