### PR TITLE
Add us-north1 support to Soperator Terraform

### DIFF
--- a/soperator/modules/available_resources/platform.tf
+++ b/soperator/modules/available_resources/platform.tf
@@ -33,6 +33,7 @@ locals {
       local.regions.me-west1,
       local.regions.uk-south1,
       local.regions.us-central1,
+      local.regions.us-north1,
     ]
     (local.platforms.gpu-h100-sxm) = [
       local.regions.eu-north1,
@@ -52,6 +53,7 @@ locals {
     (local.platforms.gpu-b300-sxm) = [
       local.regions.eu-west2,
       local.regions.uk-south1,
+      local.regions.us-north1,
     ]
     (local.platforms.gpu-gb300) = [
       local.regions.eu-north1,

--- a/soperator/modules/available_resources/region.tf
+++ b/soperator/modules/available_resources/region.tf
@@ -7,5 +7,6 @@ locals {
     me-west1    = "me-west1"
     uk-south1   = "uk-south1"
     us-central1 = "us-central1"
+    us-north1   = "us-north1"
   }
 }


### PR DESCRIPTION
## Summary

- Add `us-north1` to the Soperator Terraform region allowlist.
- Enable `cpu-d3` and `gpu-b300-sxm` in `us-north1`.

## Scope

- No InfiniBand fabric mapping changes. The existing `infiniband_fabric` input remains unchanged.
- No local NVMe support changes.
- No recipe version or subversion changes.

This follows the two-file region support pattern used in #963.

## Validation

- `terraform fmt -check -recursive .`
- `make terraform-check`
- Terraform module tests: 23 passed, 0 failed
