### PR TITLE
Fix CI by updating the Allure report action

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -282,7 +282,7 @@ jobs:
         path: gh-pages
 
     - name: Build test report
-      uses: simple-elf/allure-report-action@v1.13
+      uses: simple-elf/allure-report-action@v1.15
       if: always()
       with:
         gh_pages: gh-pages


### PR DESCRIPTION
## Release Notes (Mandatory Description)

All CI jobs are currently failing because the Allure report step exits with an error. Since this is a required step, each job fails even when its Terraform tests pass, blocking CI.

This started without any change in this repository. Although the workflow uses `simple-elf/allure-report-action@v1.13`, that Docker-based action builds from the floating `amazoncorretto:8` image. Amazon moved that image from Amazon Linux 2 to Amazon Linux 2023, which no longer included `findutils` and its `xargs` command.

The Allure action requires `xargs`, so it could no longer generate reports. Upstream fixed this by explicitly installing `findutils`, and released the fix in `v1.15`:

- Upstream issue: https://github.com/simple-elf/allure-report-action/issues/77
- Upstream fix: https://github.com/simple-elf/allure-report-action/pull/78
- Fixed release: https://github.com/simple-elf/allure-report-action/releases/tag/v1.15

This updates the action from `v1.13` to `v1.15`, applying the upstream fix and restoring CI.
