### PR TITLE
Fix k8s-training validation when node group strategy is unset

### DIFF
--- a/k8s-training/variables.tf
+++ b/k8s-training/variables.tf
@@ -126,8 +126,8 @@ variable "node_group_strategy" {
   validation {
     condition = var.node_group_strategy == null || alltrue([
       for setting in [
-        var.node_group_strategy.max_surge,
-        var.node_group_strategy.max_unavailable,
+        try(var.node_group_strategy.max_surge, null),
+        try(var.node_group_strategy.max_unavailable, null),
       ] :
       setting == null || !(try(setting.count, null) != null && try(setting.percent, null) != null)
     ])


### PR DESCRIPTION
## Release Notes (Mandatory Description)

The `k8s-training` tests fail during Terraform validation when `node_group_strategy` uses its default `null` value.

[PR #1110](https://github.com/nebius/nebius-solutions-library/pull/1110) added validation that reads `max_surge` and `max_unavailable` behind a logical `||`. CI uses Terraform 1.11.4, which still evaluates those attribute accesses and raises a null-reference error before the tests can run.

This change makes those optional attribute reads null-safe with `try()`.
