### PR TITLE
NOTIC: Support extra labels for mk8s nodes

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -130,6 +130,7 @@ locals {
       preemptible            = nodeset.preemptible
       reservation_policy     = nodeset.reservation_policy
       nvlink                 = nodeset.nvlink
+      extra_labels           = nodeset.extra_labels
       placement_policy_nodes = nodeset.placement_policy_nodes
       max_pods               = nodeset.max_pods
       local_nvme = {

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -341,6 +341,9 @@ slurm_nodeset_workers = [
     #   enabled = true
     #   type    = "GB300"
     # }
+    # Additional labels applied to every mk8s node in this worker nodeset.
+    # Built-in Soperator labels take precedence when keys overlap.
+    # extra_labels = {}
     # Optional mk8s placement policy node list for this nodeset. Non-production only.
     # placement_policy_nodes = []
     # Provide a list of strings to set Slurm Node features

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -794,6 +794,8 @@ variable "slurm_nodeset_workers" {
       enabled = optional(bool, false)
       type    = optional(string, "GB300")
     }), {})
+    # Additional labels applied to every mk8s node in this worker nodeset.
+    extra_labels                   = optional(map(string), {})
     placement_policy_nodes         = optional(list(string))
     features                       = optional(list(string))
     create_partition               = optional(bool)

--- a/soperator/modules/k8s/k8s_ng_workers_v2.tf
+++ b/soperator/modules/k8s/k8s_ng_workers_v2.tf
@@ -151,6 +151,7 @@ resource "nebius_mk8s_v1_node_group" "worker_v2" {
   template = {
     metadata = {
       labels = merge(
+        var.node_group_workers_v2[count.index].extra_labels,
         module.labels.label_jail,
         module.labels.label_nodeset_worker,
         tomap({

--- a/soperator/modules/k8s/variables.tf
+++ b/soperator/modules/k8s/variables.tf
@@ -158,6 +158,8 @@ variable "node_group_workers_v2" {
       reservation_ids = optional(list(string))
     }))
     nvl_instance_group_id  = optional(string)
+    # Additional labels applied to the mk8s worker node template.
+    extra_labels           = optional(map(string), {})
     max_pods               = optional(number, 32)
     placement_policy_nodes = optional(list(string))
     local_nvme = optional(object({

--- a/soperator/modules/k8s/variables.tf
+++ b/soperator/modules/k8s/variables.tf
@@ -157,7 +157,7 @@ variable "node_group_workers_v2" {
       policy          = optional(string)
       reservation_ids = optional(list(string))
     }))
-    nvl_instance_group_id  = optional(string)
+    nvl_instance_group_id = optional(string)
     # Additional labels applied to the mk8s worker node template.
     extra_labels           = optional(map(string), {})
     max_pods               = optional(number, 32)


### PR DESCRIPTION
## Release Notes (Mandatory Description)
This is extra helpful while developing when we need to mimic some feature by setting well-known labels.