### PR TITLE
SCHED-2241: Clarify opentelemetry_batch does not affect Cloud Logging

### DIFF
--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -606,7 +606,10 @@ dcgm_job_mapping_enabled = true
 # ---
 # kube_state_metrics_max_scrape_size = 268435456
 
-# Optional OpenTelemetry sending_queue batch overrides for logs, jail logs, events, and nccl-profiles collectors.
+# Optional OpenTelemetry sending_queue batch overrides for the in-cluster (VictoriaLogs/VictoriaMetrics)
+# exporters of the logs, jail logs, events, and nccl-profiles collectors.
+# The public Cloud Logging exporter is not affected: its batching is managed by the chart
+# (observability.opentelemetry.publicBatch) and capped at 1000 records per request.
 # By default, chart values are used.
 # ---
 # opentelemetry_batch = {

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1484,7 +1484,7 @@ variable "kube_state_metrics_max_scrape_size" {
 }
 
 variable "opentelemetry_batch" {
-  description = "OpenTelemetry sending_queue batch overrides for logs, jail logs, events, and nccl-profiles collectors. Leave null to use chart defaults."
+  description = "OpenTelemetry sending_queue batch overrides for the in-cluster (VictoriaLogs/VictoriaMetrics) exporters of the logs, jail logs, events, and nccl-profiles collectors. Does not affect the public Cloud Logging exporter, whose batching is managed by the chart (publicBatch, capped at 1000 records per request). Leave null to use chart defaults."
   type = object({
     timeout             = optional(string)
     send_batch_size     = optional(number)

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -495,7 +495,7 @@ variable "kube_state_metrics_max_scrape_size" {
 }
 
 variable "opentelemetry_batch" {
-  description = "OpenTelemetry sending_queue batch overrides for logs, jail logs, events, and nccl-profiles collectors. Leave null to use chart defaults."
+  description = "OpenTelemetry sending_queue batch overrides for the in-cluster (VictoriaLogs/VictoriaMetrics) exporters of the logs, jail logs, events, and nccl-profiles collectors. Does not affect the public Cloud Logging exporter, whose batching is managed by the chart (publicBatch, capped at 1000 records per request). Leave null to use chart defaults."
   type = object({
     timeout             = optional(string)
     send_batch_size     = optional(number)


### PR DESCRIPTION
## Problem

The `opentelemetry_batch` description implies it tunes batching for all exporters of the logs, jail logs, events, and nccl-profiles collectors. It only applies to the in-cluster VictoriaLogs/VictoriaMetrics exporters; the public Cloud Logging exporter batches separately.

## Solution

- Updated `opentelemetry_batch` descriptions in `soperator/installations/example/variables.tf` and `soperator/modules/slurm/variables.tf` to state the in-cluster scope
- Noted that Cloud Logging batching is managed by the chart (`observability.opentelemetry.publicBatch`) and capped at 1000 records per request
- Same clarification in the example `terraform.tfvars` comment

## Testing

Docs-only change (descriptions and comments), no resources affected.

## Release Notes

None