### PR TITLE
SCHED-1920: Remove DCGM hpc_job job-mapping plumbing

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -458,8 +458,8 @@ module "nvidia_operator_gpu" {
   cluster_id = module.k8s.cluster_id
   parent_id  = data.nebius_iam_v1_project.this.id
 
-  enable_dcgm_exporter        = var.dcgm_job_mapping_enabled == false && var.telemetry_enabled
-  enable_dcgm_service_monitor = var.dcgm_job_mapping_enabled == false && var.telemetry_enabled
+  enable_dcgm_exporter        = var.dcgm_exporter_enabled == false && var.telemetry_enabled
+  enable_dcgm_service_monitor = var.dcgm_exporter_enabled == false && var.telemetry_enabled
   relabel_dcgm_exporter       = var.telemetry_enabled
 
 }
@@ -629,6 +629,7 @@ module "slurm" {
   rest_enabled                    = var.slurm_rest_enabled
   accounting_enabled              = var.accounting_enabled
   telemetry_enabled               = var.telemetry_enabled
+  dcgm_exporter_enabled           = var.dcgm_exporter_enabled
   public_o11y_enabled             = var.public_o11y_enabled
   soperator_notifier              = var.soperator_notifier
   nccl_inspector_profiling        = var.nccl_inspector_profiling

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -611,10 +611,11 @@ maintenance_ignore_node_groups = ["controller", "nfs"]
 # ---
 telemetry_enabled = true
 
-# Whether to enable dcgm job mapping (adds hpc_job label on DCGM_ metrics).
+# Whether to install soperator's dcgm-exporter chart.
+# When false, the NVIDIA gpu-operator's stock dcgm-exporter is used instead.
 # By default, true.
 # ---
-dcgm_job_mapping_enabled = true
+dcgm_exporter_enabled = true
 
 # Optional kube-state-metrics scrape size override in bytes.
 # By default, it is raised automatically for large clusters.

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1482,8 +1482,8 @@ variable "allow_o11y_region_migration" {
   default     = false
 }
 
-variable "dcgm_job_mapping_enabled" {
-  description = "Whether to enable HPC job mapping by installing a separate dcgm-exporter"
+variable "dcgm_exporter_enabled" {
+  description = "Whether to install soperator's dcgm-exporter chart. When false, the NVIDIA gpu-operator's stock dcgm-exporter is used instead."
   type        = bool
   default     = true
 }

--- a/soperator/modules/slurm/flux_release_nodesets.tf
+++ b/soperator/modules/slurm/flux_release_nodesets.tf
@@ -50,10 +50,6 @@ resource "local_file" "flux_release_rendered_nodesets" {
 
     gpu = {
       use_preinstalled_drivers = var.use_preinstalled_gpu_drivers
-      dcgm_job_mapping = {
-        enabled = var.dcgm_job_mapping_enabled
-        dir     = var.dcgm_job_map_dir
-      }
     }
 
     munge = {

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -78,7 +78,7 @@ resource "helm_release" "soperator_fluxcd_cm" {
     soperator_image_repo     = local.image.repository
     soperator_image_repo_nfs = var.nfs_in_k8s.use_stable_repo ? local.image.repository_stable : local.image.repository
 
-    dcgm_job_mapping_enabled       = var.dcgm_job_mapping_enabled
+    dcgm_exporter_enabled          = var.dcgm_exporter_enabled
     enroot_direct_squashfs_enabled = var.enroot_direct_squashfs_enabled
     # Cluster-wide toggle for the [program:dockerd] block in the shared jail
     # supervisord config (customConfigmaps), which is one configmap for the whole
@@ -111,7 +111,6 @@ resource "helm_release" "soperator_fluxcd_cm" {
     vmstack_version                           = var.vmstack_version
     vmstack_crds_version                      = var.vmstack_crds_version
     vmlogs_version                            = var.vmlogs_version
-    dcgm_job_map_dir                          = var.dcgm_job_map_dir
     notifier                                  = var.soperator_notifier
     nccl_inspector_profiling                  = var.nccl_inspector_profiling
 

--- a/soperator/modules/slurm/templates/helm_values/flux_release_nodesets.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/flux_release_nodesets.yaml.tftpl
@@ -202,15 +202,6 @@ nodesets:
                     defaultMode: 500
               %{~ endif ~}
 
-              %{~ if gpu.dcgm_job_mapping.enabled ~}
-              - name: hpc-jobs-dir
-                mountPath: ${gpu.dcgm_job_mapping.dir}
-                volumeSource:
-                  hostPath:
-                    path: ${gpu.dcgm_job_mapping.dir}
-                    type: DirectoryOrCreate
-              %{~ endif ~}
-
               %{~ if gpu.use_preinstalled_drivers~}
               - name: nvidia-driver-root
                 mountPath: /run/nvidia/driver

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -263,10 +263,9 @@ resources:
                   memory: ${resources.vm_logs.memory}
 
           dcgmExporter:
-            enabled: ${dcgm_job_mapping_enabled}
+            enabled: ${dcgm_exporter_enabled}
             version: ${operator_version}
             values:
-              hpcJobMapDir: ${dcgm_job_map_dir}
               # waits for nvidia toolkit when not running on preinstalled gpu drivers, so opposite of use_preinstalled_gpu_drivers
               validateToolkit: ${slurm_cluster.use_preinstalled_gpu_drivers ? "false" : "true"}
               resources:
@@ -562,13 +561,6 @@ resources:
                   path: /
                   type: ""
                 name: nvidia-driver-root
-              %{~ endif ~}
-
-              %{~ if dcgm_job_mapping_enabled ~}
-              - name: hpc-jobs-dir
-                hostPath:
-                  path: ${dcgm_job_map_dir}
-                  type: DirectoryOrCreate
               %{~ endif ~}
 
             populateJail:

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -490,8 +490,8 @@ variable "telemetry_enabled" {
   default     = true
 }
 
-variable "dcgm_job_mapping_enabled" {
-  description = "Whether to enable HPC job mapping by installing a separate dcgm-exporter"
+variable "dcgm_exporter_enabled" {
+  description = "Whether to install soperator's dcgm-exporter chart. When false, the NVIDIA gpu-operator's stock dcgm-exporter is used instead."
   type        = bool
   default     = true
 }
@@ -599,12 +599,6 @@ variable "opentelemetry_delete_jail_logs_min_age" {
     condition     = can(regex("^[0-9]+(s|m|h)$", var.opentelemetry_delete_jail_logs_min_age))
     error_message = "Must be a Go-style duration with a single unit, e.g. 90s, 30m, or 4h."
   }
-}
-
-variable "dcgm_job_map_dir" {
-  description = "Directory where HPC job mapping files are located"
-  type        = string
-  default     = "/var/run/nebius/slurm"
 }
 
 # endregion Telemetry


### PR DESCRIPTION
## Problem

nebius/soperator#2923 removes the `hpc_job` label integration from DCGM metrics. The terraform plumbing that fed it becomes dead: the `dcgm_job_map_dir` variable, the `hpcJobMapDir` helm value, and the worker `hpc-jobs-dir` hostPath mounts.

## Solution

- Remove `dcgm_job_map_dir`, `hpcJobMapDir`, and the `hpc-jobs-dir` hostPath mounts from the slurm module and its helm value templates
- Keep `dcgm_job_mapping_enabled` and redocument it: it still selects soperator's dcgm-exporter chart over the gpu-operator's stock one

Pairs with nebius/soperator#2923. Safe to land in either order: once the soperator side ships, the removed values are inert (extra Helm values are ignored and the hostPath volume was unused).

## Testing

`terraform fmt` and `terraform validate` pass.

## Release Notes

Breaking: the `dcgm_job_map_dir` variable is removed from the soperator slurm module. `dcgm_job_mapping_enabled` now only selects which dcgm-exporter chart is installed.