### PR TITLE
SCHED-1858: Add login node autoscaling

### DIFF
--- a/soperator/installations/example/main.tf
+++ b/soperator/installations/example/main.tf
@@ -530,6 +530,7 @@ module "slurm" {
     worker     = [for workers in local.slurm_nodeset_workers : workers.size]
     login      = var.slurm_nodeset_login.size
   }
+  login_autoscaling = var.slurm_nodeset_login.autoscaling
 
   # Resolved tier (auto-derived from the worker count unless var.sizing_tier_override forces it).
   sizing_tier_override = module.sizing.sizing_tier

--- a/soperator/installations/example/terraform.tfvars
+++ b/soperator/installations/example/terraform.tfvars
@@ -441,6 +441,8 @@ use_preinstalled_gpu_drivers = true
 # Keep size as the desired login pod replica count. For GB300, Terraform uses
 # this value for Soperator login pods, then skips only the dedicated mk8s login
 # node group so login pods run on worker nodes instead.
+# Login pod autoscaling is disabled by default. The dedicated mk8s login node
+# group uses its independent, always-enabled infrastructure scaling limits.
 # ---
 slurm_nodeset_login = {
   size = 2

--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -1089,10 +1089,16 @@ variable "slurm_nodeset_workers" {
 }
 
 variable "slurm_nodeset_login" {
-  description = "Configuration of Slurm Login node set."
+  description = "Configuration of Slurm Login node set. Login pod autoscaling is disabled by default. When enabled, its replica bounds override size for login pods."
   type = object({
     size               = number
     node_group_enabled = optional(bool, true)
+    autoscaling = optional(object({
+      enabled                           = bool
+      min_size                          = optional(number, 1)
+      max_size                          = optional(number, 4)
+      target_cpu_utilization_percentage = optional(number, 70)
+    }))
     resource = object({
       platform = string
       preset   = string
@@ -1123,6 +1129,23 @@ variable "slurm_nodeset_login" {
   validation {
     condition     = var.slurm_nodeset_login.size >= 1
     error_message = "Login replica count (slurm_nodeset_login.size) must be at least 1."
+  }
+  validation {
+    condition = var.slurm_nodeset_login.autoscaling == null ? true : (
+      var.slurm_nodeset_login.autoscaling.min_size >= 1 &&
+      floor(var.slurm_nodeset_login.autoscaling.min_size) == var.slurm_nodeset_login.autoscaling.min_size &&
+      var.slurm_nodeset_login.autoscaling.max_size >= var.slurm_nodeset_login.autoscaling.min_size &&
+      floor(var.slurm_nodeset_login.autoscaling.max_size) == var.slurm_nodeset_login.autoscaling.max_size
+    )
+    error_message = "Login autoscaling min_size and max_size must be whole numbers, min_size must be at least 1, and max_size must be greater than or equal to min_size."
+  }
+  validation {
+    condition = var.slurm_nodeset_login.autoscaling == null ? true : (
+      var.slurm_nodeset_login.autoscaling.target_cpu_utilization_percentage >= 1 &&
+      var.slurm_nodeset_login.autoscaling.target_cpu_utilization_percentage <= 100 &&
+      floor(var.slurm_nodeset_login.autoscaling.target_cpu_utilization_percentage) == var.slurm_nodeset_login.autoscaling.target_cpu_utilization_percentage
+    )
+    error_message = "Login autoscaling target_cpu_utilization_percentage must be a whole number from 1 through 100."
   }
 }
 

--- a/soperator/modules/k8s/k8s_ng_login.tf
+++ b/soperator/modules/k8s/k8s_ng_login.tf
@@ -17,7 +17,16 @@ resource "nebius_mk8s_v1_node_group" "login" {
     module.labels.label_jail,
   )
 
-  fixed_node_count = var.node_group_login.size
+  # These are broad infrastructure guardrails, not desired node counts: one
+  # node keeps baseline login capacity available, while 100 caps runaway VM
+  # provisioning. The Kubernetes autoscaler adds nodes only when login pods
+  # are unschedulable and removes unused nodes down to the minimum.
+  autoscaling = {
+    min_node_count = 1
+    max_node_count = 100
+  }
+
+  fixed_node_count = null
 
   template = {
     metadata = {

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -257,6 +257,7 @@ resource "helm_release" "soperator_fluxcd_cm" {
 
         login = {
           size                     = var.node_count.login
+          autoscaling              = var.login_autoscaling
           k8s_node_filter_name     = var.login_on_worker_nodes ? local.node_filters.worker.name : local.node_filters.login.name
           allocation_id            = var.login_allocation_id
           sshd_config_map_ref_name = var.login_sshd_config_map_ref_name

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -690,6 +690,13 @@ resources:
                     %{~ endif ~}
               login:
                 size: ${slurm_cluster.nodes.login.size}
+                %{~ if slurm_cluster.nodes.login.autoscaling != null ~}
+                autoscaling:
+                  enabled: ${slurm_cluster.nodes.login.autoscaling.enabled}
+                  minReplicas: ${slurm_cluster.nodes.login.autoscaling.min_size}
+                  maxReplicas: ${slurm_cluster.nodes.login.autoscaling.max_size}
+                  targetCPUUtilizationPercentage: ${slurm_cluster.nodes.login.autoscaling.target_cpu_utilization_percentage}
+                %{~ endif ~}
                 k8sNodeFilterName: ${slurm_cluster.nodes.login.k8s_node_filter_name}
                 sshdServiceType: "LoadBalancer"
                 %{~ if slurm_cluster.nodes.login.allocation_id != null ~}

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -120,6 +120,18 @@ variable "node_count" {
   }
 }
 
+variable "login_autoscaling" {
+  description = "CPU-based login pod autoscaling. Its bounds override node_count.login when enabled."
+  type = object({
+    enabled                           = bool
+    min_size                          = optional(number, 1)
+    max_size                          = optional(number, 4)
+    target_cpu_utilization_percentage = optional(number, 70)
+  })
+  default  = null
+  nullable = true
+}
+
 # endregion Nodes
 
 # region Resources


### PR DESCRIPTION
## Problem

[RFC 055: Login Node Resource Fairness and Autoscaling](https://nebius.atlassian.net/wiki/spaces/SCHED/pages/2212561681/RFC+055+Login+Node+Resource+Fairness+and+Autoscaling)

The Soperator Terraform installation exposes only a fixed login pod count through `slurm_nodeset_login.size`, and the dedicated Managed Kubernetes login node group also uses a fixed node count. This prevents the Soperator login HPA and the Kubernetes cluster autoscaler from adding capacity when login CPU demand increases.

## Solution

### Login pod autoscaling configuration

Add an optional `slurm_nodeset_login.autoscaling` object:

```hcl
slurm_nodeset_login = {
  size = 2
  autoscaling = {
    enabled                           = true
    min_size                          = 2
    max_size                          = 3
    target_cpu_utilization_percentage = 70
  }

  # Existing resource and boot_disk configuration.
}
```

Terraform validates the replica bounds and target CPU utilization, passes the configuration through the Slurm module, and renders it as the Soperator `slurmNodes.login.autoscaling` Helm values.

Autoscaling remains optional and disabled by default. When it is omitted, `slurm_nodeset_login.size` continues to define the login pod replica count. When enabled, `min_size` and `max_size` define the effective login workload limits, while `size` is retained for use after autoscaling is disabled.

### Kubernetes node capacity

Replace the fixed dedicated login node-group size with the Nebius Managed Kubernetes cluster autoscaler. Its 1–100 node range is a broad infrastructure guardrail: one node preserves baseline login capacity and 100 is the Managed Kubernetes per-node-group ceiling. The actual login workload limits remain the Soperator autoscaling `min_size` and `max_size` values.

The Kubernetes cluster autoscaler adds a login node only when a login pod cannot be scheduled and removes unused nodes down to the one-node minimum.

Soperator implementation: [nebius/soperator#2917](https://github.com/nebius/soperator/pull/2917)

## Testing

Full cross-repository E2E validation passed:

- [Workflow run 33848508000](https://github.com/nebius/soperator/actions/runs/33848508000) / [MDC_B200 job](https://github.com/nebius/soperator/actions/runs/33848508000/job/100945948954)
- Soperator commit: [`b2c93638`](https://github.com/nebius/soperator/commit/b2c936380ee6b7761b142e68b10dac1e1b5d0736)
- Terraform integration commit: [`e4e0b7e1`](https://github.com/nebius/nebius-solutions-library/commit/e4e0b7e1dcdf2d00a1c44f027c20fd8edec4e43a)
- Terraform apply, the full acceptance suite, and Terraform destroy completed successfully.
- The login autoscaling scenario scaled the login workload from 2 to 3 replicas under CPU pressure, observed a new Kubernetes node, preserved the replicas after pressure was removed, and returned to the fixed size after autoscaling was disabled.

## Release Notes

Added optional CPU-based autoscaling configuration for Soperator login pods and enabled infrastructure autoscaling for their dedicated Managed Kubernetes node group. Existing configurations keep fixed login pod replicas unless login autoscaling is explicitly enabled.
