### PR TITLE
SCHED-1685: wait for backup service account visibility

### DIFF
--- a/soperator/modules/backups/main.tf
+++ b/soperator/modules/backups/main.tf
@@ -15,7 +15,7 @@ resource "terraform_data" "backups_service_account_ready" {
     }
     command = <<-EOT
       "${path.module}/../scripts/retry.sh" -n 30 -i 5 -- \
-        nebius iam v2 service-account get --id "$SERVICE_ACCOUNT_ID" >/dev/null
+        nebius iam service-account get --id "$SERVICE_ACCOUNT_ID" >/dev/null
     EOT
   }
 }

--- a/soperator/modules/backups/main.tf
+++ b/soperator/modules/backups/main.tf
@@ -3,6 +3,23 @@ resource "nebius_iam_v1_service_account" "backups_service_account" {
   name      = "${var.instance_name}-backup-sa"
 }
 
+resource "terraform_data" "backups_service_account_ready" {
+  triggers_replace = {
+    service_account_id = nebius_iam_v1_service_account.backups_service_account.id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      SERVICE_ACCOUNT_ID = self.triggers_replace.service_account_id
+    }
+    command = <<-EOT
+      "${path.module}/../scripts/retry.sh" -n 30 -i 5 -- \
+        nebius iam v2 service-account get --id "$SERVICE_ACCOUNT_ID" >/dev/null
+    EOT
+  }
+}
+
 # TODO: replace it with more granular access binding as it becomes available
 data "nebius_iam_v1_group" "editors" {
   name      = "editors"
@@ -10,12 +27,15 @@ data "nebius_iam_v1_group" "editors" {
 }
 
 resource "nebius_iam_v1_group_membership" "backups_service_account_group" {
+  depends_on = [terraform_data.backups_service_account_ready]
+
   parent_id = data.nebius_iam_v1_group.editors.id
   member_id = nebius_iam_v1_service_account.backups_service_account.id
 }
 
 # TODO: replace this mess with proper nebius provider resources as they become available
 resource "terraform_data" "k8s_backups_bucket_access_secret" {
+  depends_on = [terraform_data.backups_service_account_ready]
 
   triggers_replace = {
     namespace           = var.soperator_namespace

--- a/soperator/modules/backups/scripts/destroy.sh
+++ b/soperator/modules/backups/scripts/destroy.sh
@@ -14,7 +14,7 @@ fi
 
 # Delete all IAM access keys for the service account.
 # Skip the IAM block if the SA was already removed out-of-band (e.g. by force-cleanup).
-if "$retry_script" -- nebius iam v2 service-account get --id "$SERVICE_ACCOUNT_ID" >/dev/null 2>&1; then
+if "$retry_script" -- nebius iam service-account get --id "$SERVICE_ACCOUNT_ID" >/dev/null 2>&1; then
   for AKID in $("$retry_script" -- nebius iam v2 access-key list-by-account \
     --account-service-account-id "$SERVICE_ACCOUNT_ID" \
     --format json | jq -r '.items[].metadata.id'); do


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

Terraform starts consuming a newly created backups service account as soon as IAM returns its ID. During the IAM propagation window, group-membership creation can still receive EntityNotFound, aborting Terraform Apply before acceptance tests start.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

Add a bounded service-account visibility check using the existing retry helper before creating its group membership or access key.

Keep both resources managed through their existing Terraform lifecycle while allowing IAM replication enough time to complete.