### PR TITLE
SCHED-1687, SCHED-2426: make envrc Nebius operations retry-safe

### DIFF
--- a/soperator/installations/example/.envrc
+++ b/soperator/installations/example/.envrc
@@ -1,3 +1,11 @@
+set -o pipefail
+
+retry_script="$(dirname "${BASH_SOURCE[0]}")/../../modules/scripts/retry.sh"
+
+retry_nebius() {
+  "$retry_script" -- nebius "$@"
+}
+
 NEBIUS_TENANT_ID="$NEBIUS_TENANT_ID" # ='tenant-...'
 NEBIUS_PROJECT_ID="$NEBIUS_PROJECT_ID" # ='project-...'
 NEBIUS_REGION="${NEBIUS_REGION:-eu-north1}"
@@ -19,9 +27,8 @@ fi
 # region IAM token
 
 unset NEBIUS_IAM_TOKEN
-nebius iam whoami > /dev/null
-nebius iam get-access-token > /dev/null
-NEBIUS_IAM_TOKEN=$(nebius iam get-access-token)
+retry_nebius iam whoami > /dev/null
+NEBIUS_IAM_TOKEN=$(retry_nebius iam get-access-token)
 export NEBIUS_IAM_TOKEN
 
 if [ -f "$HOME/.nebius/credentials.yaml" ]; then
@@ -39,7 +46,7 @@ fi
 
 # region VPC subnet
 
-NEBIUS_VPC_SUBNET_ID=$(nebius vpc subnet list \
+NEBIUS_VPC_SUBNET_ID=$(retry_nebius vpc subnet list \
   --parent-id "${NEBIUS_PROJECT_ID}" \
   --format json \
   | jq -r '.items[0].metadata.id')
@@ -51,7 +58,7 @@ export NEBIUS_VPC_SUBNET_ID
 
 # region Service account
 
-NEBIUS_SA_TERRAFORM_ID=$(nebius iam service-account list \
+NEBIUS_SA_TERRAFORM_ID=$(retry_nebius iam service-account list \
   --page-size 999 \
   --parent-id "${NEBIUS_PROJECT_ID}" \
   --format json \
@@ -73,13 +80,13 @@ fi
 
 # region `editors` group
 
-NEBIUS_GROUP_EDITORS_ID=$(nebius iam group get-by-name \
+NEBIUS_GROUP_EDITORS_ID=$(retry_nebius iam group get-by-name \
   --parent-id "${NEBIUS_TENANT_ID}" \
   --name 'editors' \
   --format json \
   | jq -r '.metadata.id')
 
-IS_MEMBER=$(nebius iam group-membership list-members \
+IS_MEMBER=$(retry_nebius iam group-membership list-members \
   --parent-id "${NEBIUS_GROUP_EDITORS_ID}" \
   --page-size 1000 \
   --format json \
@@ -101,7 +108,7 @@ fi
 # region Access key
 
 echo 'Cleaning up expired access keys for service account'
-EXPIRED_KEYS=$(nebius iam v2 access-key list-by-account \
+EXPIRED_KEYS=$(retry_nebius iam v2 access-key list-by-account \
   --account-service-account-id "${NEBIUS_SA_TERRAFORM_ID}" \
   --format json \
   --page-size 100 \
@@ -139,17 +146,17 @@ echo "Created new access key: ${NEBIUS_SA_ACCESS_KEY_ID}"
 
 # region AWS access key
 
-AWS_ACCESS_KEY_ID=$(nebius iam v2 access-key get \
+NEBIUS_SA_ACCESS_KEY=$(retry_nebius iam v2 access-key get \
   --id "${NEBIUS_SA_ACCESS_KEY_ID}" \
-  --format json | jq -r '.status.aws_access_key_id')
+  --format json)
+
+AWS_ACCESS_KEY_ID=$(jq -r '.status.aws_access_key_id' <<< "${NEBIUS_SA_ACCESS_KEY}")
 export AWS_ACCESS_KEY_ID
 
 echo "Generating new AWS_SECRET_ACCESS_KEY"
-AWS_SECRET_ACCESS_KEY="$(nebius iam v2 access-key get \
-  --id "${NEBIUS_SA_ACCESS_KEY_ID}" \
-  --format json \
-  | jq -r '.status.secret')"
+AWS_SECRET_ACCESS_KEY=$(jq -r '.status.secret' <<< "${NEBIUS_SA_ACCESS_KEY}")
 export AWS_SECRET_ACCESS_KEY
+unset NEBIUS_SA_ACCESS_KEY
 
 AWS_REGION=$NEBIUS_REGION
 export AWS_REGION
@@ -164,7 +171,7 @@ export AWS_ENDPOINT_URL
 NEBIUS_BUCKET_NAME="tfstate-slurm-k8s-$(echo -n "${NEBIUS_TENANT_ID}-${NEBIUS_PROJECT_ID}" | md5sum | awk '$0=$1')"
 export NEBIUS_BUCKET_NAME
 # Check if bucket exists
-EXISTING_BUCKET=$(nebius storage bucket list \
+EXISTING_BUCKET=$(retry_nebius storage bucket list \
   --parent-id "${NEBIUS_PROJECT_ID}" \
   --format json \
   | jq -r --arg BUCKET "${NEBIUS_BUCKET_NAME}" '.items[]? | select(.metadata.name == $BUCKET) | .metadata.name')

--- a/soperator/modules/scripts/retry.sh
+++ b/soperator/modules/scripts/retry.sh
@@ -23,7 +23,7 @@ for i in $(seq 1 "$retries"); do
         exit 0
     fi
     if [[ $i -lt $retries ]]; then
-        echo "($i/$retries) Command failed, retrying in ${interval}s..."
+        echo "($i/$retries) Command failed, retrying in ${interval}s..." >&2
         sleep "$interval"
     fi
 done


### PR DESCRIPTION
## Problem
The example installation's `.envrc` can hide transient Nebius CLI failures behind successful `jq` processes, allowing empty IDs or credentials to reach later commands. Its IAM bootstrap also has no outer retry for transient errors that the CLI does not retry internally.

## Solution
Reuse the existing retry helper for IAM and read-only Nebius operations, make retry diagnostics safe for captured output, enable pipeline failure propagation, and remove duplicate API calls. State-changing operations remain single-shot and fail immediately rather than risking duplicate resources.