### PR TITLE
SCHED-2175: run GPU checks only from acceptance in E2E

### DIFF
--- a/soperator/modules/slurm/locals_active_checks.tf
+++ b/soperator/modules/slurm/locals_active_checks.tf
@@ -16,6 +16,9 @@ locals {
 
     # Run what is relevant in E2E
     testing = {
+      gpu-checks = {
+        suspend = true
+      }
       ssh-check = {
         k8sJobSpec = {
           jobContainer = {

--- a/soperator/modules/slurm/locals_active_checks.tf
+++ b/soperator/modules/slurm/locals_active_checks.tf
@@ -17,7 +17,8 @@ locals {
     # Run what is relevant in E2E
     testing = {
       gpu-checks = {
-        suspend = true
+        suspend          = true
+        runAfterCreation = false
       }
       ssh-check = {
         k8sJobSpec = {


### PR DESCRIPTION
## Problem
Scheduled and post-install GPU ActiveChecks duplicate the GPU validation triggered explicitly by the E2E acceptance suite. Scheduled checks can consume workers or cancel acceptance Slurm jobs, while the initial run adds an unnecessary provisioning gate.

## Solution
For the E2E testing scope, suspend the GPU-check schedule and disable its automatic post-install run. GPU checks remain available and are triggered explicitly by the acceptance scenario; production behavior is unchanged.