### PR TITLE
SCHED-2442: Fix local NVMe disks in 4.1

### DIFF
--- a/soperator/installations/example/variables.tf
+++ b/soperator/installations/example/variables.tf
@@ -833,11 +833,10 @@ variable "slurm_nodeset_workers" {
   validation {
     condition = alltrue([
       for worker in var.slurm_nodeset_workers :
-      !try(worker.local_nvme.enabled, false) || (
-        startswith(try(worker.local_nvme.mount_path, "/mnt/local-nvme"), "/")
-      )
+      !try(worker.local_nvme.enabled, false) ||
+      can(regex("^/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$", try(worker.local_nvme.mount_path, "/mnt/local-nvme")))
     ])
-    error_message = "When worker local NVMe is enabled, mount_path must be an absolute path."
+    error_message = "When worker local NVMe is enabled, mount_path must be an absolute path containing only letters, digits, '/', '.', '_', and '-'."
   }
 
   validation {

--- a/soperator/modules/k8s/templates/cloud_init.yaml.tftpl
+++ b/soperator/modules/k8s/templates/cloud_init.yaml.tftpl
@@ -16,7 +16,6 @@ users:
 package_update: true
 packages:
   - mdadm
-  - nvme-cli
 %{ if local_nvme_filesystem_type == "xfs" }
   - xfsprogs
 %{ endif }
@@ -257,9 +256,6 @@ write_files:
           fail "Unsupported filesystem type: $${FILESYSTEM_TYPE}"
           ;;
       esac
-
-      echo "Detecting NVMe disks..."
-      nvme list
 
       mapfile -t NVME_DISKS < <(
         lsblk -dnpo NAME,TYPE | awk '$2 == "disk" && $1 ~ /^\/dev\/nvme[0-9]+n[0-9]+$/ { print $1 }' | sort -V | uniq

--- a/soperator/modules/k8s/templates/cloud_init.yaml.tftpl
+++ b/soperator/modules/k8s/templates/cloud_init.yaml.tftpl
@@ -238,6 +238,12 @@ write_files:
       MOUNTPOINT="$${1:-/mnt/local-nvme}"
       FILESYSTEM_TYPE="${local_nvme_filesystem_type}"
       MD_DEV="/dev/md0"
+
+      fail() {
+        echo "ERROR: $*" >&2
+        exit 1
+      }
+
       case "$${FILESYSTEM_TYPE}" in
         ext4)
           MOUNT_OPTS="noatime,nodiratime,lazytime,commit=60"
@@ -248,8 +254,7 @@ write_files:
           MKFS_CMD=(mkfs.xfs -f)
           ;;
         *)
-          echo "Unsupported filesystem type: $${FILESYSTEM_TYPE}"
-          exit 1
+          fail "Unsupported filesystem type: $${FILESYSTEM_TYPE}"
           ;;
       esac
 
@@ -257,13 +262,12 @@ write_files:
       nvme list
 
       mapfile -t NVME_DISKS < <(
-        nvme list | awk 'NR>2 && $1 ~ /^\/dev\/nvme[0-9]+n[0-9]+$/ { print $1 }' | sort -V | uniq
+        lsblk -dnpo NAME,TYPE | awk '$2 == "disk" && $1 ~ /^\/dev\/nvme[0-9]+n[0-9]+$/ { print $1 }' | sort -V | uniq
       )
 
       ROOT_SOURCE="$(findmnt -n -o SOURCE / || true)"
-      ROOT_PKNAME="$(lsblk -no PKNAME "$${ROOT_SOURCE}" 2>/dev/null || true)"
-      if [[ -n "$${ROOT_PKNAME}" ]]; then
-        ROOT_DISK="/dev/$${ROOT_PKNAME}"
+      ROOT_DISK="$(lsblk -snpo NAME,TYPE "$${ROOT_SOURCE}" 2>/dev/null | awk '$2 == "disk" { print $1; exit }')"
+      if [[ -n "$${ROOT_DISK}" ]]; then
         FILTERED=()
         for d in "$${NVME_DISKS[@]}"; do
           if [[ "$${d}" != "$${ROOT_DISK}" ]]; then
@@ -275,12 +279,11 @@ write_files:
 
       DISK_COUNT="$${#NVME_DISKS[@]}"
       if (( DISK_COUNT < 2 || DISK_COUNT > 8 )); then
-        echo "Expected 2..8 NVMe disks for RAID0, found $${DISK_COUNT}: $${NVME_DISKS[*]}"
-        exit 1
+        fail "Expected 2..8 NVMe disks for RAID0, found $${DISK_COUNT}: $${NVME_DISKS[*]}"
       fi
 
       for d in "$${NVME_DISKS[@]}"; do
-        [[ -b "$${d}" ]] || { echo "Block device not found: $${d}"; exit 1; }
+        [[ -b "$${d}" ]] || fail "Block device not found: $${d}"
       done
 
       echo "Using $${DISK_COUNT} NVMe disk(s): $${NVME_DISKS[*]}"
@@ -295,34 +298,62 @@ write_files:
         fi
       done
 
-      if [[ -e "$${MD_DEV}" ]]; then
-        mdadm --stop "$${MD_DEV}" || true
+      mkdir -p "$${MOUNTPOINT}"
+      if mountpoint -q "$${MOUNTPOINT}"; then
+        umount "$${MOUNTPOINT}"
       fi
+
+      # Remove entries written by older versions. This service owns the mount,
+      # so persisting a filesystem UUID would only delay boot after replacement.
+      FSTAB_TMP="$(mktemp /etc/fstab.soperator-local-nvme.XXXXXX)"
+      trap '[[ -z "$${FSTAB_TMP:-}" ]] || rm -f "$${FSTAB_TMP}"' EXIT
+      awk -v mountpoint="$${MOUNTPOINT}" '$2 != mountpoint' /etc/fstab > "$${FSTAB_TMP}"
+      chmod --reference=/etc/fstab "$${FSTAB_TMP}"
+      chown --reference=/etc/fstab "$${FSTAB_TMP}"
+      mv "$${FSTAB_TMP}" /etc/fstab
+      FSTAB_TMP=""
+
+      # The array may have been auto-assembled under any /dev/md* name. Stop
+      # every MD array holding one of the ephemeral disks before recreating it.
+      mapfile -t ACTIVE_ARRAYS < <(
+        lsblk -nrpo NAME,TYPE "$${NVME_DISKS[@]}" | awk '$2 ~ /^raid/ { print $1 }' | sort -u
+      )
+      for array in "$${ACTIVE_ARRAYS[@]}"; do
+        mdadm --stop "$${array}"
+      done
 
       mdadm --create "$${MD_DEV}" \
         --level=0 \
         --raid-devices="$${DISK_COUNT}" \
         --force \
+        --run \
         "$${NVME_DISKS[@]}"
 
       udevadm settle
-
       "$${MKFS_CMD[@]}" "$${MD_DEV}"
-
-      mkdir -p "$${MOUNTPOINT}"
       mount -o "$${MOUNT_OPTS}" "$${MD_DEV}" "$${MOUNTPOINT}"
-
-      UUID="$(blkid -s UUID -o value "$${MD_DEV}")"
-      grep -q "$${UUID}" /etc/fstab || echo "UUID=$${UUID} $${MOUNTPOINT} $${FILESYSTEM_TYPE} $${MOUNT_OPTS},nofail 0 2" >> /etc/fstab
-
-      if [[ -d /etc/mdadm ]]; then
-        mdadm --detail --scan > /etc/mdadm/mdadm.conf
-      fi
 
       echo "Done."
       echo "RAID device: $${MD_DEV}"
       echo "Mounted at : $${MOUNTPOINT}"
       df -h "$${MOUNTPOINT}"
+  - path: /etc/systemd/system/prepare-local-nvme.service
+    owner: root:root
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Prepare local NVMe storage
+      After=local-fs.target
+      Before=containerd.service kubelet.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/usr/local/sbin/prepare-disks.sh ${local_nvme_mount_path}
+
+      [Install]
+      WantedBy=multi-user.target
+      RequiredBy=containerd.service kubelet.service
 %{ endif }
 %{ endif }
 
@@ -332,6 +363,8 @@ runcmd:
   - [ bash, -lc, "/usr/local/bin/nvidia-config-check.sh >> /var/log/nvidia-config-check.log 2>&1" ]
 %{ endif }
 %{ if local_nvme_enabled }
-  - [ bash, -lc, "/usr/local/sbin/prepare-disks.sh ${local_nvme_mount_path} > /var/log/prepare-disks.log 2>&1" ]
+  - [ systemctl, daemon-reload ]
+  - [ systemctl, enable, prepare-local-nvme.service ]
+  - [ systemctl, start, prepare-local-nvme.service ]
 %{ endif }
 %{ endif }

--- a/soperator/modules/k8s/templates/cloud_init.yaml.tftpl
+++ b/soperator/modules/k8s/templates/cloud_init.yaml.tftpl
@@ -345,7 +345,7 @@ write_files:
       [Service]
       Type=oneshot
       RemainAfterExit=yes
-      ExecStart=/usr/local/sbin/prepare-disks.sh ${local_nvme_mount_path}
+      ExecStart=/usr/local/sbin/prepare-disks.sh "${local_nvme_mount_path}"
 
       [Install]
       WantedBy=multi-user.target

--- a/soperator/modules/slurm/main.tf
+++ b/soperator/modules/slurm/main.tf
@@ -102,9 +102,13 @@ resource "helm_release" "soperator_fluxcd_cm" {
     region                  = var.region
     public_o11y_enabled     = var.public_o11y_enabled
     tsa_token_writer_source = local.public_o11y_tsa_token_writer_source
-    has_local_nvme          = anytrue([for nodeset in var.worker_nodesets : try(nodeset.local_nvme.enabled, false)])
-    metrics_collector       = local.metrics_collector
-    create_pvcs             = var.create_pvcs
+    has_local_nvme          = anytrue([for nodeset in var.worker_nodesets : nodeset.local_nvme.enabled])
+    local_nvme_mount_path = one(distinct([
+      for nodeset in var.worker_nodesets : nodeset.local_nvme.mount_path
+      if nodeset.local_nvme.enabled
+    ]))
+    metrics_collector = local.metrics_collector
+    create_pvcs       = var.create_pvcs
 
     slurm_cluster_storage = {
       scheduling = local.node_filters

--- a/soperator/modules/slurm/templates/helm_values/flux_release_nodesets.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/flux_release_nodesets.yaml.tftpl
@@ -265,7 +265,23 @@ nodesets:
           - name: ensure-node-local-jail-submount-local-nvme-${try(nodeset.local_nvme.filesystem_type, "ext4")}
             image: cr.eu-north1.nebius.cloud/soperator/busybox
             volumeMounts: [{ name: 'local-nvme', mountPath: /volume-mount }]
-            command: ["grep", ' /volume-mount ${try(nodeset.local_nvme.filesystem_type, "ext4")} ', "/proc/mounts"]
+            command:
+              - sh
+              - -ec
+              - |
+                mount_source="$(awk '$2 == "/volume-mount" && $3 == "${try(nodeset.local_nvme.filesystem_type, "ext4")}" { print $1; exit }' /proc/mounts)"
+                case "$${mount_source}" in
+                  /dev/md[0-9]*) ;;
+                  *)
+                    echo "ERROR: /volume-mount is not backed by an MD RAID device (source=$${mount_source:-missing})" >&2
+                    exit 1
+                    ;;
+                esac
+                raid_device="$${mount_source#/dev/}"
+                test -d "/sys/class/block/$${raid_device}/md" || {
+                  echo "ERROR: $${mount_source} is not an MD RAID device" >&2
+                  exit 1
+                }
           %{~ endif ~}
 
           %{~ if nodeset.node_local_image_storage.enabled ~}

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -249,6 +249,24 @@ resources:
               builtIn:
                 nvme_raid_health.sh:
                   enabled: true
+                  customConfig: |
+                    {
+                      "name": "nvme_raid_health",
+                      "command": ${jsonencode(format("NVME_RAID_MOUNT_POINT=%s ./nvme_raid_health.sh", local_nvme_mount_path))},
+                      "platforms": ["8xB300", "4xGB300"],
+                      "skip_for_cpu_jobs": false,
+                      "skip_for_partial_gpu_jobs": false,
+                      "skip_for_reservation_prefixes": [],
+                      "contexts": ["hc_program"],
+                      "node_states": ["any"],
+                      "on_fail": "drain",
+                      "on_ok": "undrain",
+                      "reason_base": "$name",
+                      "reason_append_details": true,
+                      "run_in_jail": true,
+                      "log": "slurm_scripts/$worker.$name.$context.out",
+                      "need_env": []
+                    }
             %{~ endif ~}
 
             partitionConfiguration:

--- a/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
+++ b/soperator/modules/slurm/templates/helm_values/terraform_fluxcd_values.yaml.tftpl
@@ -252,7 +252,7 @@ resources:
                   customConfig: |
                     {
                       "name": "nvme_raid_health",
-                      "command": ${jsonencode(format("NVME_RAID_MOUNT_POINT=%s ./nvme_raid_health.sh", local_nvme_mount_path))},
+                      "command": ${jsonencode(format("NVME_RAID_MOUNT_POINT='%s' ./nvme_raid_health.sh", local_nvme_mount_path))},
                       "platforms": ["8xB300", "4xGB300"],
                       "skip_for_cpu_jobs": false,
                       "skip_for_partial_gpu_jobs": false,

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -808,6 +808,14 @@ variable "worker_nodesets" {
     ])
     error_message = "When worker persistent_volume_claim_retention_policy is set, when_deleted and when_scaled must be `Retain` or `Delete`."
   }
+
+  validation {
+    condition = length(distinct([
+      for worker in var.worker_nodesets : worker.local_nvme.mount_path
+      if worker.local_nvme.enabled
+    ])) <= 1
+    error_message = "All worker nodesets with local NVMe enabled must use the same local_nvme.mount_path because nvme_raid_health has one cluster-wide mount path."
+  }
 }
 
 variable "slurm_nodesets_partitions" {


### PR DESCRIPTION
## Problem

On Soperator 4.1, local NVMe RAID storage is not reliably restored after a worker VM stop/start.

## Solution

- Prepare and mount the local NVMe RAID through a systemd service before containerd and kubelet start.
- Remove stale fstab entries and stop auto-assembled arrays before recreating RAID0.
- Verify that the worker mount is backed by an MD RAID device.
- Pass the configured mount path to the NVMe health check and require one shared path across NVMe-enabled nodesets.

## Testing

- Soperator Terraform checks pass.

## Release Notes

Fix: Restore local NVMe RAID storage after worker VM stop/start. Local NVMe remains ephemeral and is recreated during boot.