### PR TITLE
SCHED-2322: reserve NFS CPU for per-node DaemonSets

### DIFF
--- a/soperator/modules/sizing_tier/main.tf
+++ b/soperator/modules/sizing_tier/main.tf
@@ -255,29 +255,27 @@ locals {
   # system nodes. Kruise is excluded because it is restricted to worker and controller
   # nodes. Keep this derived from the effective preset so component overrides are
   # reflected in capacity reserved from pods that otherwise fill a node.
-  # Normalize the result to Kubernetes' millicore precision so decimal conversions
-  # cannot leak fractional millicores into the rendered NFS request.
-  nfs_system_daemonset_cpu_cores = floor((
-    local.preset.node_configurator.requests.cpu
+  nfs_system_daemonset_cpu_millicores = (
+    local.preset.node_configurator.requests.cpu * 1000
     + (
       endswith(local.preset.logs_collector.cpu, "m")
-      ? tonumber(trimsuffix(local.preset.logs_collector.cpu, "m")) / 1000
-      : tonumber(local.preset.logs_collector.cpu)
+      ? tonumber(trimsuffix(local.preset.logs_collector.cpu, "m"))
+      : tonumber(local.preset.logs_collector.cpu) * 1000
     )
     + (
       endswith(local.preset.spo_daemon.cpu, "m")
-      ? tonumber(trimsuffix(local.preset.spo_daemon.cpu, "m")) / 1000
-      : tonumber(local.preset.spo_daemon.cpu)
+      ? tonumber(trimsuffix(local.preset.spo_daemon.cpu, "m"))
+      : tonumber(local.preset.spo_daemon.cpu) * 1000
     )
-  ) * 1000 + 0.5) / 1000
+  )
 
   # Capacity checks cover every built-in tier and therefore use the default component
   # values rather than an override supplied for one resolved installation.
-  default_nfs_system_daemonset_cpu_cores = floor((
-    local.constant_presets.node_configurator.requests.cpu
-    + tonumber(trimsuffix(local.constant_presets.logs_collector.cpu, "m")) / 1000
-    + tonumber(trimsuffix(local.constant_presets.spo_daemon.cpu, "m")) / 1000
-  ) * 1000 + 0.5) / 1000
+  default_nfs_system_daemonset_cpu_millicores = (
+    local.constant_presets.node_configurator.requests.cpu * 1000
+    + tonumber(trimsuffix(local.constant_presets.logs_collector.cpu, "m"))
+    + tonumber(trimsuffix(local.constant_presets.spo_daemon.cpu, "m"))
+  )
 
   # Node VM preset per CPU nodeset for the resolved tier
   # (overridden per nodeset by the caller via the nodeset's own `preset` field).
@@ -378,7 +376,7 @@ locals {
   # placed there; memory retains the existing node-configurator-only accounting until
   # the other agents' memory is included in the sizing model.
   daemonset_requests = {
-    cpu    = local.default_nfs_system_daemonset_cpu_cores
+    cpu    = local.default_nfs_system_daemonset_cpu_millicores / 1000
     memory = local.constant_presets.node_configurator.requests.memory
   }
 

--- a/soperator/modules/sizing_tier/main.tf
+++ b/soperator/modules/sizing_tier/main.tf
@@ -211,8 +211,7 @@ locals {
     # The per-node log agent only processes logs written on its own node (its k8s metadata
     # watch is node-scoped); the size-correlated part of the pipeline is the central
     # vm_logs sink, which is tier-scaled above.
-    # Keep the CPU reservation small enough to share the dedicated NFS node's remaining
-    # 100m with the 50m Kruise daemon. The collector has no CPU limit and can burst.
+    # The collector has no CPU limit, so it can burst above this request when needed.
     logs_collector = { memory = "200Mi", cpu = "50m" }
     # Per-worker DaemonSet reading Slurm workload outputs from its own node's boot disk;
     # its load is bounded by one node's log volume, not by the cluster size. Runs on worker
@@ -252,12 +251,14 @@ locals {
     nccl_profiles_collector     = coalesce(var.component_overrides.nccl_profiles_collector, local.component_presets.nccl_profiles_collector[local.sizing_tier])
   }
 
-  # Effective CPU requested on every node by the standard DaemonSet agents.
-  # Keep this derived from the effective preset so component overrides are reflected
-  # in capacity reserved from pods that otherwise fill a node, such as the NFS server.
-  per_node_daemonset_cpu_cores = (
+  # Effective CPU requested by the standard DaemonSet agents that run on NFS and
+  # system nodes. Kruise is excluded because it is restricted to worker and controller
+  # nodes. Keep this derived from the effective preset so component overrides are
+  # reflected in capacity reserved from pods that otherwise fill a node.
+  # Normalize the result to Kubernetes' millicore precision so decimal conversions
+  # cannot leak fractional millicores into the rendered NFS request.
+  nfs_system_daemonset_cpu_cores = floor((
     local.preset.node_configurator.requests.cpu
-    + local.preset.kruise_daemon.cpu
     + (
       endswith(local.preset.logs_collector.cpu, "m")
       ? tonumber(trimsuffix(local.preset.logs_collector.cpu, "m")) / 1000
@@ -268,16 +269,15 @@ locals {
       ? tonumber(trimsuffix(local.preset.spo_daemon.cpu, "m")) / 1000
       : tonumber(local.preset.spo_daemon.cpu)
     )
-  )
+  ) * 1000 + 0.5) / 1000
 
   # Capacity checks cover every built-in tier and therefore use the default component
   # values rather than an override supplied for one resolved installation.
-  default_per_node_daemonset_cpu_cores = (
+  default_nfs_system_daemonset_cpu_cores = floor((
     local.constant_presets.node_configurator.requests.cpu
-    + local.constant_presets.kruise_daemon.cpu
     + tonumber(trimsuffix(local.constant_presets.logs_collector.cpu, "m")) / 1000
     + tonumber(trimsuffix(local.constant_presets.spo_daemon.cpu, "m")) / 1000
-  )
+  ) * 1000 + 0.5) / 1000
 
   # Node VM preset per CPU nodeset for the resolved tier
   # (overridden per nodeset by the caller via the nodeset's own `preset` field).
@@ -374,11 +374,11 @@ locals {
     }
   }
 
-  # Per-node DaemonSet agents: they occupy every node, including each system node.
-  # CPU accounts for all standard agents. Memory retains the existing node-configurator-only
-  # accounting until the other agents' memory is included in the sizing model.
+  # DaemonSet agents scheduled on system nodes. CPU accounts for all standard agents
+  # placed there; memory retains the existing node-configurator-only accounting until
+  # the other agents' memory is included in the sizing model.
   daemonset_requests = {
-    cpu    = local.default_per_node_daemonset_cpu_cores
+    cpu    = local.default_nfs_system_daemonset_cpu_cores
     memory = local.constant_presets.node_configurator.requests.memory
   }
 

--- a/soperator/modules/sizing_tier/main.tf
+++ b/soperator/modules/sizing_tier/main.tf
@@ -250,6 +250,33 @@ locals {
     nccl_profiles_collector     = coalesce(var.component_overrides.nccl_profiles_collector, local.component_presets.nccl_profiles_collector[local.sizing_tier])
   }
 
+  # Effective CPU requested on every node by the standard DaemonSet agents.
+  # Keep this derived from the effective preset so component overrides are reflected
+  # in capacity reserved from pods that otherwise fill a node, such as the NFS server.
+  per_node_daemonset_cpu_cores = (
+    local.preset.node_configurator.requests.cpu
+    + local.preset.kruise_daemon.cpu
+    + (
+      endswith(local.preset.logs_collector.cpu, "m")
+      ? tonumber(trimsuffix(local.preset.logs_collector.cpu, "m")) / 1000
+      : tonumber(local.preset.logs_collector.cpu)
+    )
+    + (
+      endswith(local.preset.spo_daemon.cpu, "m")
+      ? tonumber(trimsuffix(local.preset.spo_daemon.cpu, "m")) / 1000
+      : tonumber(local.preset.spo_daemon.cpu)
+    )
+  )
+
+  # Capacity checks cover every built-in tier and therefore use the default component
+  # values rather than an override supplied for one resolved installation.
+  default_per_node_daemonset_cpu_cores = (
+    local.constant_presets.node_configurator.requests.cpu
+    + local.constant_presets.kruise_daemon.cpu
+    + tonumber(trimsuffix(local.constant_presets.logs_collector.cpu, "m")) / 1000
+    + tonumber(trimsuffix(local.constant_presets.spo_daemon.cpu, "m")) / 1000
+  )
+
   # Node VM preset per CPU nodeset for the resolved tier
   # (overridden per nodeset by the caller via the nodeset's own `preset` field).
   node_preset = {
@@ -346,10 +373,10 @@ locals {
   }
 
   # Per-node DaemonSet agents: they occupy every node, including each system node.
-  # Only node_configurator is modeled; the smaller constant agents (kruise daemon,
-  # logs agent, spo daemon) are not.
+  # CPU accounts for all standard agents. Memory retains the existing node-configurator-only
+  # accounting until the other agents' memory is included in the sizing model.
   daemonset_requests = {
-    cpu    = local.constant_presets.node_configurator.requests.cpu
+    cpu    = local.default_per_node_daemonset_cpu_cores
     memory = local.constant_presets.node_configurator.requests.memory
   }
 

--- a/soperator/modules/sizing_tier/outputs.tf
+++ b/soperator/modules/sizing_tier/outputs.tf
@@ -8,6 +8,11 @@ output "preset" {
   value       = local.preset
 }
 
+output "per_node_daemonset_cpu_cores" {
+  description = "Effective CPU requests, in cores, of the standard DaemonSet agents that run on every node."
+  value       = local.per_node_daemonset_cpu_cores
+}
+
 output "node_preset" {
   description = "Node VM preset per CPU nodeset for the resolved tier (controller/accounting/nfs/system -> preset string)."
   value       = local.node_preset

--- a/soperator/modules/sizing_tier/outputs.tf
+++ b/soperator/modules/sizing_tier/outputs.tf
@@ -8,9 +8,9 @@ output "preset" {
   value       = local.preset
 }
 
-output "per_node_daemonset_cpu_cores" {
-  description = "Effective CPU requests, in cores, of the standard DaemonSet agents that run on every node."
-  value       = local.per_node_daemonset_cpu_cores
+output "nfs_system_daemonset_cpu_cores" {
+  description = "Effective CPU requests, in cores, of the standard DaemonSet agents that run on NFS and system nodes."
+  value       = local.nfs_system_daemonset_cpu_cores
 }
 
 output "node_preset" {

--- a/soperator/modules/sizing_tier/outputs.tf
+++ b/soperator/modules/sizing_tier/outputs.tf
@@ -8,9 +8,9 @@ output "preset" {
   value       = local.preset
 }
 
-output "nfs_system_daemonset_cpu_cores" {
-  description = "Effective CPU requests, in cores, of the standard DaemonSet agents that run on NFS and system nodes."
-  value       = local.nfs_system_daemonset_cpu_cores
+output "nfs_system_daemonset_cpu_millicores" {
+  description = "Effective CPU requests, in millicores, of the standard DaemonSet agents that run on NFS and system nodes."
+  value       = local.nfs_system_daemonset_cpu_millicores
 }
 
 output "node_preset" {

--- a/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
+++ b/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
@@ -195,8 +195,8 @@ run "component_override_wins_over_tier" {
     error_message = "soperator_main_controller without an override must keep its tier (XS) value"
   }
   assert {
-    condition     = output.per_node_daemonset_cpu_cores == 1.15
-    error_message = "the per-node DaemonSet CPU total must reflect the logs_collector override, got ${output.per_node_daemonset_cpu_cores}"
+    condition     = output.nfs_system_daemonset_cpu_cores == 1.1
+    error_message = "the NFS/system DaemonSet CPU total must reflect the logs_collector override, got ${output.nfs_system_daemonset_cpu_cores}"
   }
 }
 
@@ -235,8 +235,8 @@ run "constants_do_not_scale_with_tier" {
     error_message = "node_configurator must stay constant at XL"
   }
   assert {
-    condition     = output.per_node_daemonset_cpu_cores == 0.85
-    error_message = "the standard per-node DaemonSet CPU total must stay at 0.85 cores, got ${output.per_node_daemonset_cpu_cores}"
+    condition     = output.nfs_system_daemonset_cpu_cores == 0.65
+    error_message = "the standard NFS/system DaemonSet CPU total must stay at 0.65 cores, got ${output.nfs_system_daemonset_cpu_cores}"
   }
 }
 

--- a/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
+++ b/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
@@ -194,6 +194,10 @@ run "component_override_wins_over_tier" {
     condition     = output.preset.soperator_main_controller.limits.memory == 1
     error_message = "soperator_main_controller without an override must keep its tier (XS) value"
   }
+  assert {
+    condition     = output.per_node_daemonset_cpu_cores == 1.15
+    error_message = "the per-node DaemonSet CPU total must reflect the logs_collector override, got ${output.per_node_daemonset_cpu_cores}"
+  }
 }
 
 run "vm_single_size_override_must_be_io_m3_multiple" {
@@ -229,6 +233,10 @@ run "constants_do_not_scale_with_tier" {
   assert {
     condition     = output.preset.node_configurator.requests.cpu == 0.5 && output.preset.node_configurator.requests.memory == 0.25 && output.preset.node_configurator.limits.memory == 0.25
     error_message = "node_configurator must stay constant at XL"
+  }
+  assert {
+    condition     = output.per_node_daemonset_cpu_cores == 0.85
+    error_message = "the standard per-node DaemonSet CPU total must stay at 0.85 cores, got ${output.per_node_daemonset_cpu_cores}"
   }
 }
 

--- a/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
+++ b/soperator/modules/sizing_tier/tests/dispatch.tftest.hcl
@@ -195,8 +195,8 @@ run "component_override_wins_over_tier" {
     error_message = "soperator_main_controller without an override must keep its tier (XS) value"
   }
   assert {
-    condition     = output.nfs_system_daemonset_cpu_cores == 1.1
-    error_message = "the NFS/system DaemonSet CPU total must reflect the logs_collector override, got ${output.nfs_system_daemonset_cpu_cores}"
+    condition     = output.nfs_system_daemonset_cpu_millicores == 1100
+    error_message = "the NFS/system DaemonSet CPU total must reflect the logs_collector override, got ${output.nfs_system_daemonset_cpu_millicores}m"
   }
 }
 
@@ -235,8 +235,8 @@ run "constants_do_not_scale_with_tier" {
     error_message = "node_configurator must stay constant at XL"
   }
   assert {
-    condition     = output.nfs_system_daemonset_cpu_cores == 0.65
-    error_message = "the standard NFS/system DaemonSet CPU total must stay at 0.65 cores, got ${output.nfs_system_daemonset_cpu_cores}"
+    condition     = output.nfs_system_daemonset_cpu_millicores == 650
+    error_message = "the standard NFS/system DaemonSet CPU total must stay at 650m, got ${output.nfs_system_daemonset_cpu_millicores}m"
   }
 }
 

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -130,15 +130,17 @@ locals {
       daemon     = local.selected_preset.spo_daemon
       controller = local.selected_preset.spo_controller
     }
-    # The NFS server pod fills its dedicated node, so when an NFS nodeset exists
-    # its node capacity (var.node_capacity.nfs) wins over the tier value.
+    # The NFS server pod fills its dedicated node after reserving CPU for the
+    # standard DaemonSet agents that must also schedule there.
     nfs_server = {
       limits = {
         memory = var.node_capacity.nfs != null ? var.node_capacity.nfs.memory_gibibytes : local.selected_preset.nfs_server.memory
       }
       requests = {
         memory = var.node_capacity.nfs != null ? var.node_capacity.nfs.memory_gibibytes : local.selected_preset.nfs_server.memory
-        cpu    = var.node_capacity.nfs != null ? var.node_capacity.nfs.cpu_cores : local.selected_preset.nfs_server.cpu
+        cpu = var.node_capacity.nfs != null ? (
+          var.node_capacity.nfs.cpu_cores - module.sizing.per_node_daemonset_cpu_cores
+        ) : local.selected_preset.nfs_server.cpu
       }
     }
   }

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -139,7 +139,7 @@ locals {
       requests = {
         memory = var.node_capacity.nfs != null ? var.node_capacity.nfs.memory_gibibytes : local.selected_preset.nfs_server.memory
         cpu = var.node_capacity.nfs != null ? (
-          var.node_capacity.nfs.cpu_cores - module.sizing.per_node_daemonset_cpu_cores
+          var.node_capacity.nfs.cpu_cores - module.sizing.nfs_system_daemonset_cpu_cores
         ) : local.selected_preset.nfs_server.cpu
       }
     }

--- a/soperator/modules/slurm/locals.tf
+++ b/soperator/modules/slurm/locals.tf
@@ -139,7 +139,7 @@ locals {
       requests = {
         memory = var.node_capacity.nfs != null ? var.node_capacity.nfs.memory_gibibytes : local.selected_preset.nfs_server.memory
         cpu = var.node_capacity.nfs != null ? (
-          var.node_capacity.nfs.cpu_cores - module.sizing.nfs_system_daemonset_cpu_cores
+          var.node_capacity.nfs.cpu_cores - module.sizing.nfs_system_daemonset_cpu_millicores / 1000
         ) : local.selected_preset.nfs_server.cpu
       }
     }

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -222,9 +222,9 @@ resource "terraform_data" "check_worker_nodesets" {
   lifecycle {
     precondition {
       condition = var.node_capacity.nfs == null ? true : (
-        var.node_capacity.nfs.cpu_cores > module.sizing.nfs_system_daemonset_cpu_cores
+        var.node_capacity.nfs.cpu_cores * 1000 > module.sizing.nfs_system_daemonset_cpu_millicores
       )
-      error_message = "Dedicated NFS node usable CPU (${try(var.node_capacity.nfs.cpu_cores, 0)} cores) must be greater than the NFS/system DaemonSet reservation (${module.sizing.nfs_system_daemonset_cpu_cores} cores)."
+      error_message = "Dedicated NFS node usable CPU (${try(var.node_capacity.nfs.cpu_cores, 0) * 1000}m) must be greater than the NFS/system DaemonSet reservation (${module.sizing.nfs_system_daemonset_cpu_millicores}m)."
     }
 
     precondition {

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -222,9 +222,9 @@ resource "terraform_data" "check_worker_nodesets" {
   lifecycle {
     precondition {
       condition = var.node_capacity.nfs == null ? true : (
-        var.node_capacity.nfs.cpu_cores > module.sizing.per_node_daemonset_cpu_cores
+        var.node_capacity.nfs.cpu_cores > module.sizing.nfs_system_daemonset_cpu_cores
       )
-      error_message = "Dedicated NFS node usable CPU (${try(var.node_capacity.nfs.cpu_cores, 0)} cores) must be greater than the per-node DaemonSet reservation (${module.sizing.per_node_daemonset_cpu_cores} cores)."
+      error_message = "Dedicated NFS node usable CPU (${try(var.node_capacity.nfs.cpu_cores, 0)} cores) must be greater than the NFS/system DaemonSet reservation (${module.sizing.nfs_system_daemonset_cpu_cores} cores)."
     }
 
     precondition {

--- a/soperator/modules/slurm/variables.tf
+++ b/soperator/modules/slurm/variables.tf
@@ -221,6 +221,13 @@ variable "node_capacity" {
 resource "terraform_data" "check_worker_nodesets" {
   lifecycle {
     precondition {
+      condition = var.node_capacity.nfs == null ? true : (
+        var.node_capacity.nfs.cpu_cores > module.sizing.per_node_daemonset_cpu_cores
+      )
+      error_message = "Dedicated NFS node usable CPU (${try(var.node_capacity.nfs.cpu_cores, 0)} cores) must be greater than the per-node DaemonSet reservation (${module.sizing.per_node_daemonset_cpu_cores} cores)."
+    }
+
+    precondition {
       condition     = length(var.node_count.worker) == length(var.node_capacity.worker)
       error_message = "Worker node set resources must accord to the worker node count."
     }


### PR DESCRIPTION
## Problem
<!-- ❗ Required: Describe the user-visible problem this PR addresses.
Explain the pain or limitation. Keep it concrete. -->

The dedicated in-cluster NFS server consumes all Terraform-modeled CPU capacity from its node. Even after reducing the logs collector request and restricting Kruise to worker and controller nodes, an SPO webhook can consume the remaining incidental headroom and leave no scheduling margin. Component overrides or another tolerating workload can therefore make required DaemonSets pending and block E2E provisioning or acceptance.

## Solution
<!-- ❗ Required: What did you change to solve the problem?
Focus on what and why; avoid deep implementation detail. -->

Calculate the effective CPU requested by the standard DaemonSets that still run on NFS and system nodes: NodeConfigurator, the logs collector, and the SPO daemon. Calculate the total directly in Kubernetes millicores and reserve it when sizing a dedicated NFS server. Reuse the default total in system-node capacity checks, honor component overrides, exclude Kruise because it is now restricted to worker and controller nodes, and preserve the existing general node reserve and NFS burst capacity.