### PR TITLE
Use IMDS token endpoint in bastion cloud-init

### DIFF
--- a/modules/cloud-init/bastion-cloud-init.tftpl
+++ b/modules/cloud-init/bastion-cloud-init.tftpl
@@ -88,7 +88,7 @@ runcmd:
   - su - ${ssh_user_name} -c 'source "/home/${ssh_user_name}/.bashrc"' >> /tmp/csa-install.log 2>&1
   
   - echo "### Nebius CLI profile create" >> /tmp/csa-install.log 2>&1
-  - su - ${ssh_user_name} -c '/home/${ssh_user_name}/.nebius/bin/nebius profile create --endpoint api.eu.nebius.cloud --token-file /mnt/cloud-metadata/token --profile default --parent-id ${parent_id}' >> /tmp/csa-install.log 2>&1
+  - su - ${ssh_user_name} -c '/home/${ssh_user_name}/.nebius/bin/nebius profile create --endpoint api.eu.nebius.cloud --token-endpoint http://metadata.nebius.internal/v1/iam/sa/token --profile default --parent-id ${parent_id}' >> /tmp/csa-install.log 2>&1
 
   - echo "### Install kubectl" >> /tmp/csa-install.log 2>&1
   - curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" >> /tmp/csa-install.log 2>&1


### PR DESCRIPTION
## Summary

- replace the deprecated /mnt/cloud-metadata/token file with the HTTP IMDS token endpoint
- let the Nebius CLI retrieve refreshed service-account tokens from IMDS

## Release Notes (Mandatory Description)

Use the HTTP IMDS token endpoint when configuring the Nebius CLI on bastion hosts.